### PR TITLE
Small design changes

### DIFF
--- a/CodeEdit/ContentView.swift
+++ b/CodeEdit/ContentView.swift
@@ -63,9 +63,7 @@ struct ContentView: View {
                         VStack {
                             tabBar
                                 .frame(maxHeight: tabBarHeight)
-                                .background {
-                                    BlurView(material: .titlebar, blendingMode: .withinWindow)
-                                }
+                                .background(Material.bar)
                             
                             Spacer()
                         }
@@ -132,34 +130,25 @@ struct ContentView: View {
     
     var tabBar: some View {
         VStack(spacing: 0.0) {
-            Divider()
-            
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(alignment: .center, spacing: 0.0) {
-                    Divider()
-                        .foregroundColor(.primary.opacity(0.25))
-                    
                     ForEach(openFileItems, id: \.id) { item in
                         let isActive = selectedId == item.id
                         
                         HStack(spacing: 0.0) {
                             Button(action: { selectedId = item.id }) {
-                                FileTabRow(fileItem: item, isSelected: isActive, closeAction: {
+                                FileTabRow(fileItem: item, isSelected: isActive) {
                                     withAnimation {
                                         closeFileTab(item: item)
                                     }
-                                })
+                                }
                                 .frame(height: tabBarHeight)
-                                .foregroundColor(.primary.opacity(isActive ? 0.9 : 0.55))
+                                .foregroundColor(isActive ? .primary : .gray)
                             }
                             .buttonStyle(.plain)
-                            .background {
-                                (isActive ? Color(red: 0.219, green: 0.219, blue: 0.219) : Color(red: 0.113, green: 0.113, blue: 0.113))
-                                    .opacity(0.85)
-                            }
+                            .background(isActive ? Material.regular : Material.bar)
                             
                             Divider()
-                                .foregroundColor(.primary.opacity(0.25))
                         }
                         .animation(.easeOut(duration: 0.2), value: openFileItems)
                     }
@@ -169,7 +158,7 @@ struct ContentView: View {
             }
             
             Divider()
-                .foregroundColor(.black)
+                .foregroundColor(.gray)
                 .frame(height: 1.0)
         }
     }

--- a/CodeEdit/Editor/EditorView.swift
+++ b/CodeEdit/Editor/EditorView.swift
@@ -11,13 +11,9 @@ struct EditorView: View {
     @Binding var text: String
     
     var body: some View {
-        ScrollView {
-            TextEditor(text: $text)
-                .disableAutocorrection(true)
-                .font(.callout.monospaced())
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.top, 31.0)
-        }
+        TextEditor(text: $text)
+            .disableAutocorrection(true)
+            .font(.callout.monospaced())
     }
 }
 

--- a/CodeEdit/Editor/WorkspaceEditorView.swift
+++ b/CodeEdit/Editor/WorkspaceEditorView.swift
@@ -22,7 +22,16 @@ struct WorkspaceEditorView: View {
     }
     
     var body: some View {
-        EditorView(text: $text)
+        GeometryReader { proxy in
+            ScrollView {
+                EditorView(text: $text)
+                    .frame(minHeight: proxy.size.height + 30.0)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 30.0)
+                    .padding(.bottom, 200.0)
+                    .background(Color(nsColor: NSColor.textBackgroundColor))
+            }
+        }
             .navigationTitle(item.url.lastPathComponent)
             .onAppear { initText(item: self.item) }
             .onChange(of: item) { newItem in

--- a/CodeEdit/Rows/FileTabRow.swift
+++ b/CodeEdit/Rows/FileTabRow.swift
@@ -23,7 +23,7 @@ struct FileTabRow: View {
                     Image(systemName: showingCloseButton ? "xmark.square.fill" : fileItem.systemImage)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(width: showingCloseButton ? 12.0 : 16.0)
+                        .frame(width: 12.0)
                 }
                 .offset(x: showingCloseButton ? 10.0 : 8.0)
                 .buttonStyle(.plain)


### PR DESCRIPTION
## Changes
* Fixed light appearance
* Use SwiftUI's `Material`s in the tab bar
* Small changes in tab bar UI
* Move `ScrollView`-workaround for `TextEditor` to `WorkspaceEditorView` (`EditorView` is also used by single file editor)
* Add padding at the bottom of `EditorView` in the `WorkspaceEditorView`, so if the user adds a new line, then everything is shown correctly, instead of the new line appearing off screen
* Keep `FileTabRow`'s close button and file icon the same size