### PR TITLE
Improvement: file icons depending on file extension

### DIFF
--- a/CodeEdit/Models/FileItem.swift
+++ b/CodeEdit/Models/FileItem.swift
@@ -14,9 +14,39 @@ struct FileItem: Hashable, Identifiable {
     var systemImage: String {
         switch children {
         case nil:
-            return "doc.plaintext"
+            return fileImage
         case .some(let children):
             return children.isEmpty ? "folder" : "folder.fill"
         }
     }
+
+	var fileImage: String {
+		switch fileType {
+		case "json":
+			return "curlybraces"
+		case "css":
+			return "number"
+		case "js":
+			return "atom"
+		case "swift":
+			return "swift"
+		case "env":
+			return "gearshape.fill"
+		case "gitignore":
+			return "arrow.triangle.branch"
+		case "png", "jpg", "jpeg", "ico":
+			return "photo"
+		case "svg":
+			return "square.fill.on.circle.fill"
+		default:
+			return "doc.plaintext"
+		}
+	}
+
+	private var fileType: String {
+		if let comp = url.lastPathComponent.components(separatedBy: ".").last {
+			return comp
+		}
+		return ""
+	}
 }

--- a/CodeEdit/Models/FileItem.swift
+++ b/CodeEdit/Models/FileItem.swift
@@ -14,13 +14,13 @@ struct FileItem: Hashable, Identifiable {
     var systemImage: String {
         switch children {
         case nil:
-            return fileImage
+            return fileIcon
         case .some(let children):
             return children.isEmpty ? "folder" : "folder.fill"
         }
     }
 
-	var fileImage: String {
+	var fileIcon: String {
 		switch fileType {
 		case "json":
 			return "curlybraces"


### PR DESCRIPTION
* Added some logic to the `FileItem` struct to return specific system images depending on the file extension.
<img width="245" alt="Sidebar with file icons" src="https://user-images.githubusercontent.com/9460130/158645693-cd49c4f1-08b8-401f-a564-721482c681ab.png">

