### PR TITLE
feat: added SidebarItem and selected state

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		345F667527DF6C180069BD69 /* FileTabRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345F667427DF6C180069BD69 /* FileTabRow.swift */; };
 		34EE19BE27E0469C00F152CE /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EE19BD27E0469C00F152CE /* BlurView.swift */; };
 		5C403B8F27E20F8000788241 /* WorkspaceClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5C403B8E27E20F8000788241 /* WorkspaceClient */; };
+		5C403B9827E2712B00788241 /* SidebarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C403B9727E2712B00788241 /* SidebarItem.swift */; };
 		B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3327DA9E1000EA4DBD /* Assets.xcassets */; };
 		B658FB3727DA9E1000EA4DBD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3627DA9E1000EA4DBD /* Preview Assets.xcassets */; };
 		D7211D4327E066CE008F2ED7 /* Localized+Ex.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7211D4227E066CE008F2ED7 /* Localized+Ex.swift */; };
@@ -50,6 +51,7 @@
 		345F667427DF6C180069BD69 /* FileTabRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTabRow.swift; sourceTree = "<group>"; };
 		348313FB27DC8C070016D42C /* CodeFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeFile.swift; sourceTree = "<group>"; };
 		34EE19BD27E0469C00F152CE /* BlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurView.swift; sourceTree = "<group>"; };
+		5C403B9727E2712B00788241 /* SidebarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarItem.swift; sourceTree = "<group>"; };
 		B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodeEdit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B658FB2F27DA9E0F00EA4DBD /* CodeEditApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditApp.swift; sourceTree = "<group>"; };
 		B658FB3127DA9E0F00EA4DBD /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -138,6 +140,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		5C403B9627E2712100788241 /* Sidebar */ = {
+			isa = PBXGroup;
+			children = (
+				5C403B9727E2712B00788241 /* SidebarItem.swift */,
+			);
+			path = Sidebar;
+			sourceTree = "<group>";
+		};
 		B658FB2327DA9E0F00EA4DBD = {
 			isa = PBXGroup;
 			children = (
@@ -163,6 +173,7 @@
 				0468438427DC76E200F8E88E /* CodeEditorAppDelegate.swift */,
 				B658FB2F27DA9E0F00EA4DBD /* CodeEditApp.swift */,
 				B658FB3127DA9E0F00EA4DBD /* ContentView.swift */,
+				5C403B9627E2712100788241 /* Sidebar */,
 				345F667327DF6BCC0069BD69 /* Rows */,
 				0439FEF327DD100800528317 /* Editor */,
 				04F2BF1027DBB3AF0024EAB1 /* Settings */,
@@ -337,6 +348,7 @@
 				D7211D4327E066CE008F2ED7 /* Localized+Ex.swift in Sources */,
 				04540D6127DD08C300E91B77 /* CodeFile.swift in Sources */,
 				345F667527DF6C180069BD69 /* FileTabRow.swift in Sources */,
+				5C403B9827E2712B00788241 /* SidebarItem.swift in Sources */,
 				04540D6327DD08C300E91B77 /* CodeEditorAppDelegate.swift in Sources */,
 				0439FEF527DD104500528317 /* WorkspaceEditorView.swift in Sources */,
 			);

--- a/CodeEdit/ContentView.swift
+++ b/CodeEdit/ContentView.swift
@@ -200,18 +200,12 @@ struct ContentView: View {
             Section(header: Text(directoryURL.lastPathComponent)) {
                 OutlineGroup(workspaceClient.getFiles(), children: \.children) { item in
                     if item.children == nil {
-                        // TODO: Add selection indicator
-                        Button(action: {
+                        SidebarItem(item: item, selectedId: $selectedId) { item in
                             withAnimation {
                                 if !openFileItems.contains(item) { openFileItems.append(item) }
                             }
                             selectedId = item.id
-                        }) {
-                            Label(item.url.lastPathComponent, systemImage: item.systemImage)
-                                .accentColor(.secondary)
-                                .font(.callout)
                         }
-                        .buttonStyle(.plain)
                     } else {
                         Label(item.url.lastPathComponent, systemImage: item.systemImage)
                             .accentColor(.secondary)

--- a/CodeEdit/Sidebar/SidebarItem.swift
+++ b/CodeEdit/Sidebar/SidebarItem.swift
@@ -1,0 +1,42 @@
+//
+//  SidebarItem.swift
+//  CodeEdit
+//
+//  Created by Marco Carnevali on 16/03/22.
+//
+
+import Foundation
+import SwiftUI
+import WorkspaceClient
+
+struct SidebarItem: View {
+    let item: WorkspaceClient.FileItem
+    @Binding var selectedId: UUID?
+    let action: (WorkspaceClient.FileItem) -> Void
+
+    var body: some View {
+        Button(action: {
+            action(item)
+        }) {
+            Label(item.url.lastPathComponent, systemImage: item.systemImage)
+                .accentColor(.secondary)
+                .font(.callout)
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, 3)
+        .padding(.horizontal, 5)
+        .background(
+            selectedId == item.id ? Color.blue : Color.clear
+        )
+        .cornerRadius(5)
+    }
+
+    func generateBackground(selected: Bool) -> AnyView {
+        guard !selected else { return AnyView(Color.clear) }
+        return AnyView(
+            Color.red
+                .padding()
+                .cornerRadius(10)
+        )
+    }
+}


### PR DESCRIPTION
This PR adds a new `SidebarItem` file inside the main target that should help isolate the view for the sidebar single file item. It now also has a knowledge of _if the item is selected or not_. This let us implement a different UI based on if the file is selected or not. 
<img width="1411" alt="Screenshot 2022-03-16 at 21 41 32" src="https://user-images.githubusercontent.com/9656572/158687568-c671ad6a-687c-41cb-b87e-36d12507712b.png">
