### PR TITLE
feat: observe directory changes with publisher

### DIFF
--- a/CodeEdit/ContentView.swift
+++ b/CodeEdit/ContentView.swift
@@ -11,11 +11,10 @@ import WorkspaceClient
 struct WorkspaceView: View {
     @State private var directoryURL: URL?
     @State private var workspaceClient: WorkspaceClient?
-
 	// TODO: Create a ViewModel to hold selectedId, openFileItems, ... to pass it to subviews as an EnvironmentObject (less boilerplate parameters)
-    @State var selectedId: UUID?
-    @State var openFileItems: [WorkspaceClient.FileItem] = []
-    @State var urlInit = false
+    @State private var selectedId: WorkspaceClient.FileId?
+    @State private var openFileItems: [WorkspaceClient.FileItem] = []
+    @State private var urlInit = false
     
     @State private var showingAlert = false
     @State private var alertTitle = ""
@@ -52,7 +51,6 @@ struct WorkspaceView: View {
                             .help("Show/Hide Sidebar")
                         }
                     }
-                
                 if openFileItems.isEmpty {
                     Text("Open file from sidebar")
                 } else {

--- a/CodeEdit/SideBar/SideBar.swift
+++ b/CodeEdit/SideBar/SideBar.swift
@@ -9,25 +9,25 @@ import SwiftUI
 import WorkspaceClient
 
 struct SideBar: View {
-
     @ObservedObject var workspace: WorkspaceDocument
     var windowController: NSWindowController
-
 	@State private var selection: Int = 0
-
+    
 	var body: some View {
 		List {
-			switch selection {
-			case 0:
-				Section(header: Text(workspace.fileURL?.lastPathComponent ?? "Unknown")) {
-					ForEach(files.sortItems(foldersOnTop: workspace.sortFoldersOnTop)) { item in // Instead of OutlineGroup
-						SideBarItem(item: item,
-									workspace: workspace,
-									windowController: windowController)
-					}
-				}
-			default: EmptyView()
-			}
+            switch selection {
+            case 0:
+                Section(header: Text(workspace.fileURL?.lastPathComponent ?? "Unknown")) {
+                    ForEach(workspace.fileItems.sortItems(foldersOnTop: workspace.sortFoldersOnTop)) { item in // Instead of OutlineGroup
+                        SideBarItem(
+                            item: item,
+                            workspace: workspace,
+                            windowController: windowController
+                        )
+                    }
+                }
+            default: EmptyView()
+            }
 		}
 		.safeAreaInset(edge: .top) {
 			SideBarToolbarTop(selection: $selection)
@@ -36,9 +36,5 @@ struct SideBar: View {
 		.safeAreaInset(edge: .bottom) {
 			SideBarToolbarBottom(workspace: workspace)
 		}
-	}
-
-	private var files: [WorkspaceClient.FileItem] {
-		workspace.workspaceClient?.getFiles() ?? []
 	}
 }

--- a/CodeEdit/SideBar/SideBarItem.swift
+++ b/CodeEdit/SideBar/SideBarItem.swift
@@ -11,7 +11,6 @@ import WorkspaceClient
 struct SideBarItem: View {
 
 	var item: WorkspaceClient.FileItem
-
     @ObservedObject var workspace: WorkspaceDocument
     var windowController: NSWindowController
 	@State var isExpanded: Bool = false

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -10,7 +10,6 @@ import WorkspaceClient
 
 struct TabBarItem: View {
 	var item: WorkspaceClient.FileItem
-
     var windowController: NSWindowController
     @ObservedObject var workspace: WorkspaceDocument
 

--- a/CodeEditModules/Modules/WorkspaceClient/Tests/UnitTests.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/Tests/UnitTests.swift
@@ -1,24 +1,26 @@
 //
-//  File.swift
-//  
+//  UnitTests.swift
+//  CodeEdit
 //
 //  Created by Marco Carnevali on 16/03/22.
 //
-@testable import WorkspaceClient
+import Combine
 import Foundation
+@testable import WorkspaceClient
 import XCTest
 
 final class WorkspaceClientUnitTests: XCTestCase {
-    
     let typeOfExtensions = ["json", "txt", "swift", "js", "py", "md"]
-    
+
     func testListFile() throws {
         let directory = try FileManager.default.url(for: .developerApplicationDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
             .appendingPathComponent("CodeEdit", isDirectory: true)
             .appendingPathComponent("WorkspaceClientTests", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        
-        let randomCount = Int.random(in: 1 ... 2)
+
+        var cancellable: AnyCancellable?
+        let expectation = expectation(description: "wait for files")
+        let randomCount = Int.random(in: 1 ... 100)
         let files = generateRandomFiles(amount: randomCount)
         try files.forEach {
             let fakeData = "fake string".data(using: .utf8)
@@ -31,11 +33,73 @@ final class WorkspaceClientUnitTests: XCTestCase {
             folderURL: directory,
             ignoredFilesAndFolders: []
         )
-        print("file: ",files.count, " 2: ", client.getFiles().count)
-        XCTAssertEqual(files, client.getFiles().map(\.url.lastPathComponent))
+
+        var newFiles: [WorkspaceClient.FileItem] = []
+
+        cancellable = client
+            .getFiles
+            .sink { files in
+                newFiles = files
+                expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: 0.5)
+
+        XCTAssertEqual(files.count, newFiles.count)
         try FileManager.default.removeItem(at: directory)
+        cancellable?.cancel()
     }
-    
+
+    func testDirectoryChanges() throws {
+        let directory = try FileManager.default.url(for: .developerApplicationDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+            .appendingPathComponent("CodeEdit", isDirectory: true)
+            .appendingPathComponent("WorkspaceClientTests", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        var cancellable: AnyCancellable?
+        let expectation = expectation(description: "wait for files")
+        expectation.expectedFulfillmentCount = 2
+
+        let randomCount = Int.random(in: 1 ... 100)
+        var files = generateRandomFiles(amount: randomCount)
+        try files.forEach {
+            let fakeData = "fake string".data(using: .utf8)
+            let fileUrl = directory
+                .appendingPathComponent($0)
+            try fakeData!.write(to: fileUrl)
+        }
+
+        let client: WorkspaceClient = try .default(
+            fileManager: .default,
+            folderURL: directory,
+            ignoredFilesAndFolders: []
+        )
+
+        var newFiles: [WorkspaceClient.FileItem] = []
+
+        cancellable = client
+            .getFiles
+            .sink { files in
+                newFiles = files
+                expectation.fulfill()
+            }
+
+        let nextBatchOfFiles = generateRandomFiles(amount: 1)
+        files.append(contentsOf: nextBatchOfFiles)
+        try files.forEach {
+            let fakeData = "fake string".data(using: .utf8)
+            let fileUrl = directory
+                .appendingPathComponent($0)
+            try fakeData!.write(to: fileUrl)
+        }
+
+        waitForExpectations(timeout: 1.5)
+
+        XCTAssertEqual(files.count, newFiles.count)
+        try FileManager.default.removeItem(at: directory)
+        cancellable?.cancel()
+    }
+
     func generateRandomFiles(amount: Int) -> [String] {
         [String](repeating: "", count: amount)
             .map { _ in
@@ -44,9 +108,9 @@ final class WorkspaceClientUnitTests: XCTestCase {
                 return "\(fileName).\(fileExtension)"
             }
     }
-    
+
     func randomString(length: Int) -> String {
         let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        return String((0..<length).map{ _ in letters.randomElement()! })
+        return String((0 ..< length).map { _ in letters.randomElement()! })
     }
 }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Interface.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Interface.swift
@@ -4,22 +4,23 @@
 //
 //  Created by Marco Carnevali on 16/03/22.
 //
+
+import Combine
 import Foundation
 
 public struct WorkspaceClient {
-    
-    public var getFiles: () -> [FileItem]
-    
-    public var getFileItem: (_ id: UUID) throws -> FileItem
-    
+    public var getFiles: AnyPublisher<[FileItem], Never>
+
+    public var getFileItem: (_ id: String) throws -> FileItem
+
     public init(
-        getFiles: @escaping () -> [FileItem],
-        getFileItem: @escaping (_ id: UUID) throws -> FileItem
+        getFiles: AnyPublisher<[FileItem], Never>,
+        getFileItem: @escaping (_ id: String) throws -> FileItem
     ) {
         self.getFiles = getFiles
         self.getFileItem = getFileItem
     }
-    
+
     enum WorkspaceClientError: Error {
         case fileNotExist
     }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
@@ -5,6 +5,7 @@
 //  Created by Marco Carnevali on 16/03/22.
 //
 
+import Combine
 import Foundation
 
 public extension WorkspaceClient {
@@ -13,41 +14,82 @@ public extension WorkspaceClient {
         folderURL: URL,
         ignoredFilesAndFolders: [String]
     ) throws -> Self {
-        var fileItems: [FileItem] = []
-        var flattenedFileItems: [UUID: FileItem] = [:]
-        
+        var flattenedFileItems: [String: FileItem] = [:]
+
         func loadFiles(fromURL url: URL) throws -> [FileItem] {
             let directoryContents = try fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
             var items: [FileItem] = []
-            
+
             for itemURL in directoryContents {
                 // Skip file if it is in ignore list
                 guard !ignoredFilesAndFolders.contains(itemURL.lastPathComponent) else { continue }
-                
+
                 var isDir: ObjCBool = false
-                
+
                 if fileManager.fileExists(atPath: itemURL.path, isDirectory: &isDir) {
-                    var subItems: [FileItem]? = nil
-                    
+                    var subItems: [FileItem]?
+
                     if isDir.boolValue {
                         // TODO: Possibly optimize to loading avoid cache dirs and/or large folders
                         // Recursively fetch subdirectories and files if the path points to a directory
                         subItems = try loadFiles(fromURL: itemURL)
                     }
-                    
+
                     let newFileItem = FileItem(url: itemURL, children: subItems)
                     items.append(newFileItem)
                     flattenedFileItems[newFileItem.id] = newFileItem
                 }
             }
-            
             return items
         }
-        
-        fileItems = try loadFiles(fromURL: folderURL)
-        
+        // initial load
+        let fileItems = try loadFiles(fromURL: folderURL)
+        // By using `CurrentValueSubject` we can define a starting value.
+        // The value passed during init it's going to be send as soon as the
+        // consumer subscribes to the publisher.
+        let subject = CurrentValueSubject<[FileItem], Never>(fileItems)
+
+        var source: DispatchSourceFileSystemObject?
+
+        func startListeningToDirectory() {
+            // open the folder to listen for changes
+            let descriptor = open(folderURL.path, O_EVTONLY)
+
+            source = DispatchSource.makeFileSystemObjectSource(
+                fileDescriptor: descriptor,
+                eventMask: .write,
+                queue: DispatchQueue.global()
+            )
+
+            source?.setEventHandler {
+                // Something has changed inside the directory
+                // We should reload the files.
+                if let fileItems = try? loadFiles(fromURL: folderURL) {
+                    subject.send(fileItems)
+                }
+            }
+
+            source?.setCancelHandler {
+                close(descriptor)
+            }
+
+            source?.resume()
+        }
+
+        func stopListeningToDirectory() {
+            source?.cancel()
+            source = nil
+        }
+
         return Self(
-            getFiles: { fileItems },
+            getFiles: subject
+                .handleEvents(receiveSubscription: { _ in
+                    startListeningToDirectory()
+                }, receiveCancel: {
+                    stopListeningToDirectory()
+                })
+                .receive(on: RunLoop.main)
+                .eraseToAnyPublisher(),
             getFileItem: { id in
                 guard let item = flattenedFileItems[id] else {
                     throw WorkspaceClientError.fileNotExist

--- a/CodeEditModules/Modules/WorkspaceClient/src/Mocks.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Mocks.swift
@@ -1,15 +1,16 @@
 //
-//  File.swift
-//  
+//  Mocks.swift
+//  CodeEdit
 //
 //  Created by Marco Carnevali on 16/03/22.
 //
 
+import Combine
 import Foundation
 
 public extension WorkspaceClient {
     static var empty = Self(
-        getFiles: { [] },
+        getFiles: CurrentValueSubject<[FileItem], Never>([]).eraseToAnyPublisher(),
         getFileItem: { _ in throw WorkspaceClientError.fileNotExist }
     )
 }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -8,15 +8,16 @@
 import Foundation
 
 public extension WorkspaceClient {
-    struct FileItem: Hashable, Identifiable {
-        public var id: UUID = UUID()
+    struct FileItem: Hashable, Identifiable, Comparable {
+        // TODO: use a phantom type instead of a String
+        public var id: String
         public var url: URL
-        public var children: [FileItem]? = nil
+        public var children: [FileItem]?
         public var systemImage: String {
             switch children {
             case nil:
                 return fileIcon
-            case .some(let children):
+            case let .some(children):
                 return children.isEmpty ? "folder" : "folder.fill"
             }
         }
@@ -56,17 +57,33 @@ public extension WorkspaceClient {
                 return "doc"
             }
         }
-        
+
         private var fileType: String {
             url.lastPathComponent.components(separatedBy: ".").last ?? ""
         }
-        
+
         public init(
             url: URL,
             children: [FileItem]? = nil
         ) {
             self.url = url
             self.children = children
+            self.id = url.relativePath
         }
+        
+        public static func ==(lhs: FileItem, rhs: FileItem) -> Bool {
+            return lhs.id == rhs.id
+        }
+        public static func <(lhs: FileItem, rhs: FileItem) -> Bool {
+            return lhs.url.lastPathComponent < rhs.url.lastPathComponent
+        }
+    }
+}
+
+public extension Array where Element: Hashable {
+    func difference(from other: [Element]) -> [Element] {
+        let thisSet = Set(self)
+        let otherSet = Set(other)
+        return Array(thisSet.symmetricDifference(otherSet))
     }
 }

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(
             name: "WorkspaceClient",
             targets: ["WorkspaceClient"]
-        )
+        ),
     ],
     dependencies: [],
     targets: [


### PR DESCRIPTION
This PR changes the response of the `WorkspaceClient` `getFiles()` API. Instead of returning an array of files it now returns a _Combine_ `Publisher` which publish the list of files anytime there is a change on the directory. This is useful so that the sidebar is always up-to-date with the selected directory. 

https://user-images.githubusercontent.com/9656572/158763124-55e46792-53ab-43e4-9a94-e1b75106101f.mov

