### PR TITLE
Sidebar fix for massive performance improvements

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		04540D5F27DD08C300E91B77 /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043DF9C127DD045800CA0FC3 /* EditorView.swift */; };
 		04540D6127DD08C300E91B77 /* CodeFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348313FB27DC8C070016D42C /* CodeFile.swift */; };
 		04540D6327DD08C300E91B77 /* CodeEditorAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* CodeEditorAppDelegate.swift */; };
+		287776E727E3413200D46668 /* SideBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776E627E3413200D46668 /* SideBar.swift */; };
+		287776E927E34BC700D46668 /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776E827E34BC700D46668 /* TabBar.swift */; };
+		287776ED27E350D800D46668 /* SideBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776EC27E350D800D46668 /* SideBarItem.swift */; };
+		287776EF27E3515300D46668 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776EE27E3515300D46668 /* TabBarItem.swift */; };
 		345F667527DF6C180069BD69 /* FileTabRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345F667427DF6C180069BD69 /* FileTabRow.swift */; };
 		34EE19BE27E0469C00F152CE /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EE19BD27E0469C00F152CE /* BlurView.swift */; };
 		5C403B8F27E20F8000788241 /* WorkspaceClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5C403B8E27E20F8000788241 /* WorkspaceClient */; };
@@ -47,6 +51,10 @@
 		0468438427DC76E200F8E88E /* CodeEditorAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorAppDelegate.swift; sourceTree = "<group>"; };
 		04F2BF0E27DBB28E0024EAB1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		04F2BF1127DBB3C10024EAB1 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
+		287776E627E3413200D46668 /* SideBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBar.swift; sourceTree = "<group>"; };
+		287776E827E34BC700D46668 /* TabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBar.swift; sourceTree = "<group>"; };
+		287776EC27E350D800D46668 /* SideBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarItem.swift; sourceTree = "<group>"; };
+		287776EE27E3515300D46668 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
 		345F667427DF6C180069BD69 /* FileTabRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTabRow.swift; sourceTree = "<group>"; };
 		348313FB27DC8C070016D42C /* CodeFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeFile.swift; sourceTree = "<group>"; };
 		34EE19BD27E0469C00F152CE /* BlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurView.swift; sourceTree = "<group>"; };
@@ -107,6 +115,24 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		287776EA27E350A100D46668 /* SideBar */ = {
+			isa = PBXGroup;
+			children = (
+				287776E627E3413200D46668 /* SideBar.swift */,
+				287776EC27E350D800D46668 /* SideBarItem.swift */,
+			);
+			path = SideBar;
+			sourceTree = "<group>";
+		};
+		287776EB27E350BA00D46668 /* TabBar */ = {
+			isa = PBXGroup;
+			children = (
+				287776E827E34BC700D46668 /* TabBar.swift */,
+				287776EE27E3515300D46668 /* TabBarItem.swift */,
+			);
+			path = TabBar;
+			sourceTree = "<group>";
+		};
 		345F667327DF6BCC0069BD69 /* Rows */ = {
 			isa = PBXGroup;
 			children = (
@@ -163,6 +189,8 @@
 				0468438427DC76E200F8E88E /* CodeEditorAppDelegate.swift */,
 				B658FB2F27DA9E0F00EA4DBD /* CodeEditApp.swift */,
 				B658FB3127DA9E0F00EA4DBD /* ContentView.swift */,
+				287776EA27E350A100D46668 /* SideBar */,
+				287776EB27E350BA00D46668 /* TabBar */,
 				345F667327DF6BCC0069BD69 /* Rows */,
 				0439FEF327DD100800528317 /* Editor */,
 				04F2BF1027DBB3AF0024EAB1 /* Settings */,
@@ -335,9 +363,13 @@
 				04540D5F27DD08C300E91B77 /* EditorView.swift in Sources */,
 				34EE19BE27E0469C00F152CE /* BlurView.swift in Sources */,
 				D7211D4327E066CE008F2ED7 /* Localized+Ex.swift in Sources */,
+				287776ED27E350D800D46668 /* SideBarItem.swift in Sources */,
 				04540D6127DD08C300E91B77 /* CodeFile.swift in Sources */,
 				345F667527DF6C180069BD69 /* FileTabRow.swift in Sources */,
+				287776E927E34BC700D46668 /* TabBar.swift in Sources */,
 				04540D6327DD08C300E91B77 /* CodeEditorAppDelegate.swift in Sources */,
+				287776EF27E3515300D46668 /* TabBarItem.swift in Sources */,
+				287776E727E3413200D46668 /* SideBar.swift in Sources */,
 				0439FEF527DD104500528317 /* WorkspaceEditorView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CodeEdit/SideBar/SideBar.swift
+++ b/CodeEdit/SideBar/SideBar.swift
@@ -1,0 +1,31 @@
+//
+//  SideBar.swift
+//  CodeEdit
+//
+//  Created by Lukas Pistrol on 17.03.22.
+//
+
+import SwiftUI
+import WorkspaceClient
+
+struct SideBar: View {
+
+	var directoryURL: URL
+	var workspaceClient: WorkspaceClient
+	@Binding var openFileItems: [WorkspaceClient.FileItem]
+	@Binding var selectedId: UUID?
+
+    var body: some View {
+		List {
+			Section(header: Text(directoryURL.lastPathComponent)) {
+				ForEach(workspaceClient.getFiles()) { item in // Instead of OutlineGroup
+					SideBarItem(item: item,
+								directoryURL: directoryURL,
+								workspaceClient: workspaceClient,
+								openFileItems: $openFileItems,
+								selectedId: $selectedId)
+				}
+			}
+		}
+    }
+}

--- a/CodeEdit/SideBar/SideBarItem.swift
+++ b/CodeEdit/SideBar/SideBarItem.swift
@@ -1,0 +1,70 @@
+//
+//  SideBarItem.swift
+//  CodeEdit
+//
+//  Created by Lukas Pistrol on 17.03.22.
+//
+
+import SwiftUI
+import WorkspaceClient
+
+struct SideBarItem: View {
+
+	var item: WorkspaceClient.FileItem
+
+	var directoryURL: URL
+	var workspaceClient: WorkspaceClient
+	@Binding var openFileItems: [WorkspaceClient.FileItem]
+	@Binding var selectedId: UUID?
+	@State var isExpanded: Bool = false
+
+	var body: some View {
+		if item.children == nil {
+			// TODO: Add selection indicator
+			sidebarFileItem(item)
+				.id(item.id)
+		} else {
+			sidebarFolderItem(item)
+				.id(item.id)
+		}
+	}
+
+	func sidebarFileItem(_ item: WorkspaceClient.FileItem) -> some View {
+		NavigationLink(tag: item.id, selection: $selectedId) {
+			WorkspaceEditorView(item: item)
+				.overlay(alignment: .top) {
+					TabBar(openFileItems: $openFileItems, selectedId: $selectedId)
+				}
+				.onAppear { selectItem(item) }
+		} label: {
+			Label(item.url.lastPathComponent, systemImage: item.systemImage)
+				.foregroundColor(.secondary)
+				.font(.callout)
+		}
+	}
+
+	func sidebarFolderItem(_ item: WorkspaceClient.FileItem) -> some View {
+		DisclosureGroup(isExpanded: $isExpanded) {
+			if isExpanded { // Only load when expanded -> Improves performance massively
+				ForEach(item.children!) { child in
+					SideBarItem(item: child,
+								directoryURL: directoryURL,
+								workspaceClient: workspaceClient,
+								openFileItems: $openFileItems,
+								selectedId: $selectedId)
+				}
+			}
+		} label: {
+			Label(item.url.lastPathComponent, systemImage: item.systemImage)
+				.accentColor(.secondary)
+				.font(.callout)
+		}
+	}
+
+	func selectItem(_ item: WorkspaceClient.FileItem) {
+		withAnimation {
+			if !openFileItems.contains(item) { openFileItems.append(item) }
+		}
+		selectedId = item.id
+	}
+}

--- a/CodeEdit/SideBar/SideBarItem.swift
+++ b/CodeEdit/SideBar/SideBarItem.swift
@@ -20,7 +20,6 @@ struct SideBarItem: View {
 
 	var body: some View {
 		if item.children == nil {
-			// TODO: Add selection indicator
 			sidebarFileItem(item)
 				.id(item.id)
 		} else {

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -1,0 +1,45 @@
+//
+//  TabBar.swift
+//  CodeEdit
+//
+//  Created by Lukas Pistrol on 17.03.22.
+//
+
+import SwiftUI
+import WorkspaceClient
+
+struct TabBar: View {
+
+	@Binding var openFileItems: [WorkspaceClient.FileItem]
+	@Binding var selectedId: UUID?
+
+	var tabBarHeight = 28.0
+
+    var body: some View {
+		VStack(spacing: 0.0) {
+			Divider()
+			ScrollView(.horizontal, showsIndicators: false) {
+				HStack(alignment: .center, spacing: 0.0) {
+					Divider()
+						.foregroundColor(.primary.opacity(0.25))
+					ForEach(openFileItems, id: \.id) { item in
+						TabBarItem(item: item,
+								   selectedId: $selectedId,
+								   openFileItems: $openFileItems,
+								   tabBarHeight: tabBarHeight)
+					}
+					Spacer()
+				}
+			}
+			Divider()
+				.foregroundColor(.black)
+				.frame(height: 1.0)
+		}
+		.frame(maxHeight: tabBarHeight)
+		.background {
+			BlurView(material: .titlebar, blendingMode: .withinWindow)
+		}
+    }
+
+	
+}

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -1,0 +1,58 @@
+//
+//  TabBarItem.swift
+//  CodeEdit
+//
+//  Created by Lukas Pistrol on 17.03.22.
+//
+
+import SwiftUI
+import WorkspaceClient
+
+struct TabBarItem: View {
+	var item: WorkspaceClient.FileItem
+
+	@Binding var selectedId: UUID?
+	@Binding var openFileItems: [WorkspaceClient.FileItem]
+
+	var tabBarHeight: Double
+
+    var body: some View {
+		let isActive = selectedId == item.id
+		HStack(spacing: 0.0) {
+			Button {
+				selectedId = item.id
+			} label: {
+				FileTabRow(fileItem: item, isSelected: isActive, closeAction: {
+					withAnimation {
+						closeFileTab(item: item)
+					}
+				})
+				.frame(height: tabBarHeight)
+				.foregroundColor(.primary.opacity(isActive ? 0.9 : 0.55))
+			}
+			.buttonStyle(.plain)
+			.background {
+				(isActive ? Color(red: 0.219, green: 0.219, blue: 0.219) : Color(red: 0.113, green: 0.113, blue: 0.113))
+					.opacity(0.85)
+			}
+
+			Divider()
+				.foregroundColor(.primary.opacity(0.25))
+		}
+		.animation(.easeOut(duration: 0.2), value: openFileItems)
+    }
+
+	func closeFileTab(item: WorkspaceClient.FileItem) {
+		guard let idx = openFileItems.firstIndex(of: item) else { return }
+		let closedFileItem = openFileItems.remove(at: idx)
+		guard closedFileItem.id == selectedId else { return }
+
+		if openFileItems.isEmpty {
+			selectedId = nil
+		} else if idx == 0 {
+			selectedId = openFileItems.first?.id
+		} else {
+			selectedId = openFileItems[idx - 1].id
+		}
+	}
+}


### PR DESCRIPTION
While debugging the slow behavior of opening files and folders I found out that the reason was `OutlineGroup` reloading all its children every time a file was selected. 

By implementing a custom `List` interface using `DisclosureGroup(isExpanded: )` I was able to prevent loading files that currently aren't on display.

This improves performance immensely:
* Loading a folder on startup is now instant (even for large projects)
* Selecting a file in the `SideBar` opens it in the editor instantly (as expected)
* Switching between files also works instantly now using the `TabBar`
* The `SideBar` displays selected files in a native way. (background is taking the available width, blue when in focus, grayed out when not)

Corresponding Issue: #20 

Thanks to @MarcoCarnevali for helping!

And finally here's a short screen capture

https://user-images.githubusercontent.com/9460130/158801554-9661480e-8c47-4a45-86e8-a5992dc9ca65.mov

