### PR TITLE
Fixed Xcode warnings

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		04540D5E27DD08C300E91B77 /* WorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */; };
 		04540D5F27DD08C300E91B77 /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043DF9C127DD045800CA0FC3 /* EditorView.swift */; };
 		04540D6127DD08C300E91B77 /* CodeFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348313FB27DC8C070016D42C /* CodeFile.swift */; };
-		04540D6327DD08C300E91B77 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* AppDelegate.swift */; };
 		04660F6427E3ACAF00477777 /* Appearances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6327E3ACAF00477777 /* Appearances.swift */; };
 		04660F6627E3ACEF00477777 /* ReopenBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6527E3ACEF00477777 /* ReopenBehavior.swift */; };
 		287776E727E3413200D46668 /* SideBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776E627E3413200D46668 /* SideBar.swift */; };
@@ -397,7 +396,6 @@
 				34EE19BE27E0469C00F152CE /* BlurView.swift in Sources */,
 				D7211D4327E066CE008F2ED7 /* Localized+Ex.swift in Sources */,
 				287776E927E34BC700D46668 /* TabBar.swift in Sources */,
-				04540D6327DD08C300E91B77 /* AppDelegate.swift in Sources */,
 				287776EF27E3515300D46668 /* TabBarItem.swift in Sources */,
 				287776E727E3413200D46668 /* SideBar.swift in Sources */,
 				287776ED27E350D800D46668 /* SideBarItem.swift in Sources */,
@@ -407,7 +405,6 @@
 				28B0A19827E385C300B73177 /* SideBarToolbarTop.swift in Sources */,
 				345F667527DF6C180069BD69 /* FileTabRow.swift in Sources */,
 				043C321827E32246006AE443 /* CodeFileEditor.swift in Sources */,
-				04540D6327DD08C300E91B77 /* AppDelegate.swift in Sources */,
 				0439FEF527DD104500528317 /* WorkspaceEditorView.swift in Sources */,
 				28FFE1BF27E3A441001939DB /* SideBarToolbarBottom.swift in Sources */,
 			);

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		287776EF27E3515300D46668 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776EE27E3515300D46668 /* TabBarItem.swift */; };
 		28B0A19827E385C300B73177 /* SideBarToolbarTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B0A19727E385C300B73177 /* SideBarToolbarTop.swift */; };
 		28FFE1BF27E3A441001939DB /* SideBarToolbarBottom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FFE1BE27E3A441001939DB /* SideBarToolbarBottom.swift */; };
+		2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* AppDelegate.swift */; };
 		345F667527DF6C180069BD69 /* FileTabRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345F667427DF6C180069BD69 /* FileTabRow.swift */; };
 		34EE19BE27E0469C00F152CE /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EE19BD27E0469C00F152CE /* BlurView.swift */; };
 		5C403B8F27E20F8000788241 /* WorkspaceClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5C403B8E27E20F8000788241 /* WorkspaceClient */; };
@@ -387,6 +388,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */,
 				04540D5B27DD08C300E91B77 /* SettingsView.swift in Sources */,
 				04540D5C27DD08C300E91B77 /* GeneralSettingsView.swift in Sources */,
 				043C321427E31FF6006AE443 /* CodeEditDocumentController.swift in Sources */,

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -18,15 +18,14 @@
 		04540D5F27DD08C300E91B77 /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043DF9C127DD045800CA0FC3 /* EditorView.swift */; };
 		04540D6127DD08C300E91B77 /* CodeFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348313FB27DC8C070016D42C /* CodeFile.swift */; };
 		04540D6327DD08C300E91B77 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* AppDelegate.swift */; };
-		04660F6127E3A68A00477777 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 04660F6027E3A68A00477777 /* Info.plist */; };
 		04660F6427E3ACAF00477777 /* Appearances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6327E3ACAF00477777 /* Appearances.swift */; };
 		04660F6627E3ACEF00477777 /* ReopenBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6527E3ACEF00477777 /* ReopenBehavior.swift */; };
 		287776E727E3413200D46668 /* SideBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776E627E3413200D46668 /* SideBar.swift */; };
 		287776E927E34BC700D46668 /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776E827E34BC700D46668 /* TabBar.swift */; };
 		287776ED27E350D800D46668 /* SideBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776EC27E350D800D46668 /* SideBarItem.swift */; };
 		287776EF27E3515300D46668 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776EE27E3515300D46668 /* TabBarItem.swift */; };
-        28B0A19827E385C300B73177 /* SideBarToolbarTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B0A19727E385C300B73177 /* SideBarToolbarTop.swift */; };
-        28FFE1BF27E3A441001939DB /* SideBarToolbarBottom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FFE1BE27E3A441001939DB /* SideBarToolbarBottom.swift */; };
+		28B0A19827E385C300B73177 /* SideBarToolbarTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B0A19727E385C300B73177 /* SideBarToolbarTop.swift */; };
+		28FFE1BF27E3A441001939DB /* SideBarToolbarBottom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FFE1BE27E3A441001939DB /* SideBarToolbarBottom.swift */; };
 		345F667527DF6C180069BD69 /* FileTabRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345F667427DF6C180069BD69 /* FileTabRow.swift */; };
 		34EE19BE27E0469C00F152CE /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EE19BD27E0469C00F152CE /* BlurView.swift */; };
 		5C403B8F27E20F8000788241 /* WorkspaceClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5C403B8E27E20F8000788241 /* WorkspaceClient */; };
@@ -364,7 +363,6 @@
 				B658FB3727DA9E1000EA4DBD /* Preview Assets.xcassets in Resources */,
 				D7211D4727E06BFE008F2ED7 /* Localizable.strings in Resources */,
 				B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */,
-				04660F6127E3A68A00477777 /* Info.plist in Resources */,
 				043C321A27E32295006AE443 /* MainMenu.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -406,7 +404,7 @@
 				04540D6127DD08C300E91B77 /* CodeFile.swift in Sources */,
 				04660F6627E3ACEF00477777 /* ReopenBehavior.swift in Sources */,
 				043C321627E3201F006AE443 /* WorkspaceDocument.swift in Sources */,
-                28B0A19827E385C300B73177 /* SideBarToolbarTop.swift in Sources */,
+				28B0A19827E385C300B73177 /* SideBarToolbarTop.swift in Sources */,
 				345F667527DF6C180069BD69 /* FileTabRow.swift in Sources */,
 				043C321827E32246006AE443 /* CodeFileEditor.swift in Sources */,
 				04540D6327DD08C300E91B77 /* AppDelegate.swift in Sources */,

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -51,7 +51,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         window.toolbar = NSToolbar()
         window.title = "Settings"
         window.toolbarStyle = .unifiedCompact
-        let windowController = NSWindowController(window: window)
         let contentView = SettingsView()
         window.contentView = NSHostingView(rootView: contentView)
         

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -51,6 +51,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         window.toolbar = NSToolbar()
         window.title = "Settings"
         window.toolbarStyle = .unifiedCompact
+        let _ = NSWindowController(window: window)
         let contentView = SettingsView()
         window.contentView = NSHostingView(rootView: contentView)
         

--- a/CodeEdit/Documents/CodeEditDocumentController.swift
+++ b/CodeEdit/Documents/CodeEditDocumentController.swift
@@ -21,10 +21,20 @@ class CodeEditDocumentController: NSDocumentController {
 
         dialog.begin { result in
             if result ==  NSApplication.ModalResponse.OK, let url = dialog.url {
-                self.openDocument(withContentsOf: url, display: true) { document, documentWasAlreadyOpen, err in
+                self.openDocument(withContentsOf: url, display: true) { document, documentWasAlreadyOpen, error in
                     // TODO: handle errors
+                    if let error = error {
+                        print("Error: \(error.localizedDescription)")
+                        return
+                    }
+
+                    guard let document = document else {
+                        print("Error: Failed to get document")
+                        return
+                    }
                     
-                    print(document, documentWasAlreadyOpen, err)
+                    print("Document:", document)
+                    print("Was already open?", documentWasAlreadyOpen)
                 }
             }
         }

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -117,7 +117,7 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
                 // it.
                 let diff = files.difference(from: self.fileItems)
                 diff.forEach { newFile in
-                    if let index = self.fileItems.firstIndex(of: newFile) {
+                    if let index = self.fileItems.firstIndex(of: newFile) {
                         self.fileItems.remove(at: index)
                     } else {
                         self.fileItems.append(newFile)


### PR DESCRIPTION
Changes:

- Replaced a non-breaking space for a normal space
- `let window = WindowController()` to `let _ = WindowController()`, to remove warning (removing the line let the editor crash on closing the window)
- `guard let` some statements to remove warnings
- Removed `Info.plist` from Copy Bundle Resources (Xcode warning)
- Removed a duplicate `AppDelegate.swift` in Compile Sources Build Phase