### PR TITLE
Filetype specific icon colors

### DIFF
--- a/CodeEdit/Breadcrumbs/BreadcrumbsView.swift
+++ b/CodeEdit/Breadcrumbs/BreadcrumbsView.swift
@@ -34,7 +34,7 @@ struct BreadcrumbsView: View {
 					BreadcrumbsComponent(folder, systemImage: "folder.fill")
 					chevron
 				}
-				BreadcrumbsComponent(fileName, systemImage: fileImage, color: .accentColor)
+				BreadcrumbsComponent(fileName, systemImage: fileImage, color: file.iconColor)
 			}
 			.padding(.leading, 12)
 		}

--- a/CodeEdit/SideBar/SideBarItem.swift
+++ b/CodeEdit/SideBar/SideBarItem.swift
@@ -36,7 +36,7 @@ struct SideBarItem: View {
 				}
 		} label: {
 			Label(item.url.lastPathComponent, systemImage: item.systemImage)
-				.tint(.accentColor)
+				.accentColor(item.iconColor)
 				.font(.callout)
 		}
 	}

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 public extension WorkspaceClient {
     struct FileItem: Hashable, Identifiable, Comparable {
@@ -45,7 +46,9 @@ public extension WorkspaceClient {
                 return "square.fill.on.circle.fill"
             case "entitlements":
                 return "checkmark.seal"
-            case "md", "txt", "rtf", "plist":
+			case "plist":
+				return "tablecells"
+            case "md", "txt", "rtf":
                 return "doc.plaintext"
             case "html", "py", "sh":
                 return "chevron.left.forwardslash.chevron.right"
@@ -57,6 +60,23 @@ public extension WorkspaceClient {
                 return "doc"
             }
         }
+
+		public var iconColor: Color {
+			switch fileType {
+			case "swift", "html":
+				return .orange
+			case "java":
+				return .red
+			case "js", "entitlements", "json", "LICENSE":
+				return .yellow
+			case "css", "ts", "jsx", "md", "py":
+				return .blue
+			case "sh":
+				return .green
+			default:
+				return .blue
+			}
+		}
 
         private var fileType: String {
             url.lastPathComponent.components(separatedBy: ".").last ?? ""


### PR DESCRIPTION
<img width="912" alt="Screen Shot 2022-03-18 at 15 40 41" src="https://user-images.githubusercontent.com/9460130/159023933-a9eaf84f-74db-4939-ac02-b162819874fa.png">

I just pulled colors from VSCode. But we can discuss about colors below.