### PR TITLE
fix: code-editor dark mode

### DIFF
--- a/CodeEditModules/Modules/CodeFile/src/CodeFileView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFileView.swift
@@ -12,7 +12,8 @@ import SwiftUI
 /// CodeFileView is just a wrapper of the `CodeEditor` dependency
 public struct CodeFileView: View {
     @ObservedObject public var codeFile: CodeFileDocument
-
+    @Environment(\.colorScheme) private var colorScheme
+    
     public init(codeFile: CodeFileDocument) {
         self.codeFile = codeFile
     }
@@ -21,7 +22,7 @@ public struct CodeFileView: View {
         CodeEditor(
             source: $codeFile.content,
             language: codeFile.fileLanguage(),
-            theme: .atelierSavannaLight,
+            theme: colorScheme == .light ? .atelierSavannaLight : .atelierSavannaDark,
             indentStyle: .system
         )
     }


### PR DESCRIPTION
This PR should add support of dark-mode to the CodeEditor!
<img width="1917" alt="Screenshot 2022-03-18 at 17 15 33" src="https://user-images.githubusercontent.com/9656572/159041442-6b5de759-6c4c-4186-bbe6-fda0c334455d.png">
