### PR TITLE
Added global settings for color/monochrome style on file icons

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -13,8 +13,6 @@
 		04540D5B27DD08C300E91B77 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F2BF0E27DBB28E0024EAB1 /* SettingsView.swift */; };
 		04540D5C27DD08C300E91B77 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F2BF1127DBB3C10024EAB1 /* GeneralSettingsView.swift */; };
 		04540D5E27DD08C300E91B77 /* WorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */; };
-		04540D5F27DD08C300E91B77 /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043DF9C127DD045800CA0FC3 /* EditorView.swift */; };
-		04540D6127DD08C300E91B77 /* CodeFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348313FB27DC8C070016D42C /* CodeFile.swift */; };
 		04660F6427E3ACAF00477777 /* Appearances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6327E3ACAF00477777 /* Appearances.swift */; };
 		04660F6627E3ACEF00477777 /* ReopenBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6527E3ACEF00477777 /* ReopenBehavior.swift */; };
 		286620A527E4AB6900E18C2B /* BreadcrumbsComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286620A427E4AB6900E18C2B /* BreadcrumbsComponent.swift */; };
@@ -23,6 +21,7 @@
 		287776E927E34BC700D46668 /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776E827E34BC700D46668 /* TabBar.swift */; };
 		287776ED27E350D800D46668 /* SideBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776EC27E350D800D46668 /* SideBarItem.swift */; };
 		287776EF27E3515300D46668 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776EE27E3515300D46668 /* TabBarItem.swift */; };
+		289978ED27E4E97E00BB0357 /* FileIconStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289978EC27E4E97E00BB0357 /* FileIconStyle.swift */; };
 		28B0A19827E385C300B73177 /* SideBarToolbarTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B0A19727E385C300B73177 /* SideBarToolbarTop.swift */; };
 		28FFE1BF27E3A441001939DB /* SideBarToolbarBottom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FFE1BE27E3A441001939DB /* SideBarToolbarBottom.swift */; };
 		2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* AppDelegate.swift */; };
@@ -69,6 +68,7 @@
 		287776E827E34BC700D46668 /* TabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBar.swift; sourceTree = "<group>"; };
 		287776EC27E350D800D46668 /* SideBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarItem.swift; sourceTree = "<group>"; };
 		287776EE27E3515300D46668 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
+		289978EC27E4E97E00BB0357 /* FileIconStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIconStyle.swift; sourceTree = "<group>"; };
 		28B0A19727E385C300B73177 /* SideBarToolbarTop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarToolbarTop.swift; sourceTree = "<group>"; };
 		28FFE1BE27E3A441001939DB /* SideBarToolbarBottom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarToolbarBottom.swift; sourceTree = "<group>"; };
 		345F667427DF6C180069BD69 /* FileTabRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTabRow.swift; sourceTree = "<group>"; };
@@ -126,6 +126,7 @@
 			children = (
 				04660F6327E3ACAF00477777 /* Appearances.swift */,
 				04660F6527E3ACEF00477777 /* ReopenBehavior.swift */,
+				289978EC27E4E97E00BB0357 /* FileIconStyle.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -401,12 +402,11 @@
 				287776EF27E3515300D46668 /* TabBarItem.swift in Sources */,
 				287776E727E3413200D46668 /* SideBar.swift in Sources */,
 				287776ED27E350D800D46668 /* SideBarItem.swift in Sources */,
+				289978ED27E4E97E00BB0357 /* FileIconStyle.swift in Sources */,
 				04660F6627E3ACEF00477777 /* ReopenBehavior.swift in Sources */,
 				043C321627E3201F006AE443 /* WorkspaceDocument.swift in Sources */,
 				28B0A19827E385C300B73177 /* SideBarToolbarTop.swift in Sources */,
 				345F667527DF6C180069BD69 /* FileTabRow.swift in Sources */,
-				043C321827E32246006AE443 /* CodeFileEditor.swift in Sources */,
-				0439FEF527DD104500528317 /* WorkspaceEditorView.swift in Sources */,
 				28FFE1BF27E3A441001939DB /* SideBarToolbarBottom.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CodeEdit/Breadcrumbs/BreadcrumbsComponent.swift
+++ b/CodeEdit/Breadcrumbs/BreadcrumbsComponent.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct BreadcrumbsComponent: View {
+
+	@AppStorage(FileIconStyle.storageKey) var iconStyle: FileIconStyle = .default
 	
 	private let title: String
 	private let image: String
@@ -25,7 +27,7 @@ struct BreadcrumbsComponent: View {
 				.resizable()
 				.aspectRatio(contentMode: .fit)
 				.frame(width: 12)
-				.foregroundStyle(color)
+				.foregroundStyle(iconStyle == .color ? color : .secondary)
 			Text(title)
 				.foregroundStyle(.primary)
 				.font(.system(size: 11))

--- a/CodeEdit/Settings/GeneralSettingsView.swift
+++ b/CodeEdit/Settings/GeneralSettingsView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct GeneralSettingsView: View {
     @AppStorage(Appearances.storageKey) var appearance: Appearances = Appearances.default
     @AppStorage(ReopenBehavior.storageKey) var reopenBehavior: ReopenBehavior = ReopenBehavior.default
+	@AppStorage(FileIconStyle.storageKey) var fileIconStyle: FileIconStyle = FileIconStyle.default
     
     var body: some View {
         Form {
@@ -27,6 +28,13 @@ struct GeneralSettingsView: View {
             .onChange(of: appearance) { tag in
                 tag.applyAppearance()
             }
+
+			Picker("File Icon Style", selection: $fileIconStyle) {
+				Text("Color")
+					.tag(FileIconStyle.color)
+				Text("Monochrome")
+					.tag(FileIconStyle.monochrome)
+			}
             
             Picker("Reopen Behavior", selection: $reopenBehavior) {
                 Text("Open Panel")

--- a/CodeEdit/Settings/Models/FileIconStyle.swift
+++ b/CodeEdit/Settings/Models/FileIconStyle.swift
@@ -1,0 +1,16 @@
+//
+//  FileIconStyle.swift
+//  CodeEdit
+//
+//  Created by Lukas Pistrol on 18.03.22.
+//
+
+import Foundation
+
+enum FileIconStyle: String, CaseIterable, Hashable {
+	case color
+	case monochrome
+
+	static let `default` = FileIconStyle.color
+	static let storageKey = "fileIconStyle"
+}

--- a/CodeEdit/SideBar/SideBarItem.swift
+++ b/CodeEdit/SideBar/SideBarItem.swift
@@ -11,6 +11,8 @@ import CodeFile
 
 struct SideBarItem: View {
 
+	@AppStorage(FileIconStyle.storageKey) var iconStyle: FileIconStyle = .default
+
 	var item: WorkspaceClient.FileItem
     @ObservedObject var workspace: WorkspaceDocument
     var windowController: NSWindowController
@@ -44,7 +46,7 @@ struct SideBarItem: View {
             .onAppear { workspace.openFile(item: item) }
         } label: {
 			Label(item.url.lastPathComponent, systemImage: item.systemImage)
-				.accentColor(item.iconColor)
+				.accentColor(iconStyle == .color ? item.iconColor : .secondary)
 				.font(.callout)
 		}
 	}


### PR DESCRIPTION
<img width="562" alt="Screen Shot 2022-03-18 at 17 39 20" src="https://user-images.githubusercontent.com/9460130/159045314-6802fbd5-6b2e-4c71-876d-133ce7b0c786.png">
<img width="912" alt="Screen Shot 2022-03-18 at 17 39 37" src="https://user-images.githubusercontent.com/9460130/159045325-e5f0955d-5fce-43d0-ad2f-9c38454a03f9.png">
<img width="912" alt="Screen Shot 2022-03-18 at 17 39 52" src="https://user-images.githubusercontent.com/9460130/159045331-e9b1361f-f8c8-4ffb-8a36-7507f2b9692b.png">
