### PR TITLE
Added Editor Theme Switcher to settings

### DIFF
--- a/CodeEdit/Settings/GeneralSettingsView.swift
+++ b/CodeEdit/Settings/GeneralSettingsView.swift
@@ -6,13 +6,16 @@
 //
 
 import SwiftUI
+import CodeFile
+import CodeEditor
 
 // MARK: - View
 
 struct GeneralSettingsView: View {
-    @AppStorage(Appearances.storageKey) var appearance: Appearances = Appearances.default
-    @AppStorage(ReopenBehavior.storageKey) var reopenBehavior: ReopenBehavior = ReopenBehavior.default
-	@AppStorage(FileIconStyle.storageKey) var fileIconStyle: FileIconStyle = FileIconStyle.default
+    @AppStorage(Appearances.storageKey) var appearance: Appearances = .default
+    @AppStorage(ReopenBehavior.storageKey) var reopenBehavior: ReopenBehavior = .default
+	@AppStorage(FileIconStyle.storageKey) var fileIconStyle: FileIconStyle = .default
+	@AppStorage(CodeEditorTheme.storageKey) var editorTheme: CodeEditor.ThemeName = .atelierSavannaAuto
     
     var body: some View {
         Form {
@@ -42,6 +45,22 @@ struct GeneralSettingsView: View {
 				Text("New Document".localized())
                     .tag(ReopenBehavior.newDocument)
             }
+
+			Picker("Editor Theme".localized(), selection: $editorTheme) {
+				Text("Atelier Savanna (Auto)")
+					.tag(CodeEditor.ThemeName.atelierSavannaAuto)
+				Text("Atelier Savanna Dark")
+					.tag(CodeEditor.ThemeName.atelierSavannaDark)
+				Text("Atelier Savanna Light")
+					.tag(CodeEditor.ThemeName.atelierSavannaLight)
+				// TODO: Pojoaque does not seem to work (does not change from previous selection)
+//				Text("Pojoaque")
+//					.tag(CodeEditor.ThemeName.pojoaque)
+				Text("Agate")
+					.tag(CodeEditor.ThemeName.agate)
+				Text("Ocean")
+					.tag(CodeEditor.ThemeName.ocean)
+			}
         }
         .padding()
         

--- a/CodeEditModules/Modules/CodeFile/src/CodeEditor+AppStorage.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeEditor+AppStorage.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  
+//
+//  Created by Lukas Pistrol on 18.03.22.
+//
+
+import Foundation
+import CodeEditor
+
+public extension CodeEditor.ThemeName {
+	static var atelierSavannaAuto = CodeEditor.ThemeName(rawValue: "atelier-savanna-auto")
+}
+
+public enum CodeEditorTheme {
+	public static let storageKey = "codeEditorTheme"
+}

--- a/CodeEditModules/Modules/CodeFile/src/CodeFileView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFileView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 public struct CodeFileView: View {
     @ObservedObject public var codeFile: CodeFileDocument
     @Environment(\.colorScheme) private var colorScheme
+	@AppStorage(CodeEditorTheme.storageKey) var theme: CodeEditor.ThemeName = .atelierSavannaAuto
     
     public init(codeFile: CodeFileDocument) {
         self.codeFile = codeFile
@@ -22,8 +23,15 @@ public struct CodeFileView: View {
         CodeEditor(
             source: $codeFile.content,
             language: codeFile.fileLanguage(),
-            theme: colorScheme == .light ? .atelierSavannaLight : .atelierSavannaDark,
+            theme: getTheme(),
             indentStyle: .system
         )
     }
+
+	private func getTheme() -> CodeEditor.ThemeName {
+		if theme == .atelierSavannaAuto {
+			return colorScheme == .light ? .atelierSavannaLight : .atelierSavannaDark
+		}
+		return theme
+	}
 }


### PR DESCRIPTION
<img width="481" alt="Screen Shot 2022-03-18 at 19 25 02" src="https://user-images.githubusercontent.com/9460130/159061692-cb5991dd-e9d9-4202-b9d9-b0e548a6e2ab.png">

> Note: The theme `pojoaque` does not work apparently. It just stays on the theme that was selected before. It therefore is currently commented out.