### PR TITLE
Quick fix: Welcome screen

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -33,19 +33,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         if let appearanceString = UserDefaults.standard.string(forKey: Appearances.storageKey) {
             Appearances(rawValue: appearanceString)?.applyAppearance()
         }
-        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 780, height: 500), styleMask: [.borderless], backing: .buffered, defer: false)
-        let windowController = NSWindowController(window: window)
-        window.center()
-        let contentView = WelcomeWindowView(windowController: windowController)
-        window.isMovableByWindowBackground = true
-        window.contentView = NSHostingView(rootView: contentView)
-        window.isOpaque = false
-        window.backgroundColor = .clear
-        window.contentView?.wantsLayer = true
-        window.contentView?.layer?.masksToBounds = true
-        window.contentView?.layer?.cornerRadius = 10
-        window.hasShadow = true
-        window.makeKeyAndOrderFront(self)
+        
+        handleOpen()
     }
     
     func applicationWillTerminate(_ aNotification: Notification) {
@@ -76,19 +65,37 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             return false
         }
         
-        let behavior = ReopenBehavior(rawValue: UserDefaults.standard.string(forKey: ReopenBehavior.storageKey) ?? ReopenBehavior.openPanel.rawValue) ?? ReopenBehavior.openPanel
-        
-        switch behavior {
-        case .openPanel:
-            CodeEditDocumentController.shared.openDocument(self)
-        case .newDocument:
-            CodeEditDocumentController.shared.newDocument(self)
-        }
+        handleOpen()
         
         return false
     }
     
     func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {
         return false
+    }
+    
+    func handleOpen() {
+        let behavior = ReopenBehavior(rawValue: UserDefaults.standard.string(forKey: ReopenBehavior.storageKey) ?? ReopenBehavior.openPanel.rawValue) ?? ReopenBehavior.openPanel
+        
+        switch behavior {
+        case .welcome:
+            let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 780, height: 500), styleMask: [.borderless], backing: .buffered, defer: false)
+            let windowController = NSWindowController(window: window)
+            window.center()
+            let contentView = WelcomeWindowView(windowController: windowController)
+            window.isMovableByWindowBackground = true
+            window.contentView = NSHostingView(rootView: contentView)
+            window.isOpaque = false
+            window.backgroundColor = .clear
+            window.contentView?.wantsLayer = true
+            window.contentView?.layer?.masksToBounds = true
+            window.contentView?.layer?.cornerRadius = 10
+            window.hasShadow = true
+            window.makeKeyAndOrderFront(self)
+        case .openPanel:
+            CodeEditDocumentController.shared.openDocument(self)
+        case .newDocument:
+            CodeEditDocumentController.shared.newDocument(self)
+        }
     }
 }

--- a/CodeEdit/Localization/en.lproj/Localizable.strings
+++ b/CodeEdit/Localization/en.lproj/Localizable.strings
@@ -16,5 +16,6 @@
 
 // Settings Reopen Behavior
 "Reopen Behavior"="Reopen Behavior";
+"Welcome Screen"="Welcome Screen";
 "Open Panel"="Open Panel";
 "New Document"="New Document";

--- a/CodeEdit/Settings/GeneralSettingsView.swift
+++ b/CodeEdit/Settings/GeneralSettingsView.swift
@@ -37,6 +37,9 @@ struct GeneralSettingsView: View {
 			}
             
 			Picker("Reopen Behavior".localized(), selection: $reopenBehavior) {
+                Text("Welcome Screen".localized())
+                    .tag(ReopenBehavior.welcome)
+                Divider()
 				Text("Open Panel".localized())
                     .tag(ReopenBehavior.openPanel)
 				Text("New Document".localized())

--- a/CodeEdit/Settings/Models/ReopenBehavior.swift
+++ b/CodeEdit/Settings/Models/ReopenBehavior.swift
@@ -8,9 +8,10 @@
 import Foundation
 
 enum ReopenBehavior: String, CaseIterable, Hashable {
+    case welcome
     case openPanel
     case newDocument
     
-    static let `default` = ReopenBehavior.openPanel
+    static let `default` = ReopenBehavior.welcome
     static let storageKey = "behavior"
 }

--- a/CodeEdit/Welcome/WelcomeView.swift
+++ b/CodeEdit/Welcome/WelcomeView.swift
@@ -12,7 +12,7 @@ import WelcomeModule
 
 struct WelcomeView: View {
     @State var isHovering: Bool = false
-    @AppStorage("showWelcomeWindowWhenLaunch") var showWelcomeWindowWhenLaunch: Bool = true
+    @AppStorage(ReopenBehavior.storageKey) var behavior: ReopenBehavior = .welcome
     
     var dismissWindow: () -> Void
     
@@ -58,7 +58,8 @@ struct WelcomeView: View {
                         subtitle: "Create a new file"
                     )
                         .onTapGesture {
-                            // TODO: open a new empty editor
+                            CodeEditDocumentController.shared.newDocument(nil)
+                            dismissWindow()
                         }
                     WelcomeActionView(
                         iconName: "plus.square.on.square",
@@ -83,7 +84,11 @@ struct WelcomeView: View {
             Spacer()
             if (isHovering) {
                 HStack {
-                    Toggle("Show this window when CodeEdit launches", isOn: $showWelcomeWindowWhenLaunch)
+                    Toggle("Show this window when CodeEdit launches", isOn: .init(get: {
+                        return self.behavior == .welcome
+                    }, set: { new in
+                        self.behavior = new ? .welcome : .openPanel
+                    }))
                         .toggleStyle(.checkbox)
                     Spacer()
                 }


### PR DESCRIPTION
Add `.welcome` option to reopen behaviors, handle reopen behavior on `applicationDidFinishLaunching` and `applicationShouldHandleReopen`.

By default, the behavior is set to `.welcome`. But if you had the app installed before, then you may need to manually select it in Preferences because the state is stored in `AppStorage` and won't be changed by the app automatically.

Add open new document/file behavior to `WelcomeView`