### PR TITLE
File saving

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		04540D5E27DD08C300E91B77 /* WorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */; };
 		04660F6427E3ACAF00477777 /* Appearances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6327E3ACAF00477777 /* Appearances.swift */; };
 		04660F6627E3ACEF00477777 /* ReopenBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6527E3ACEF00477777 /* ReopenBehavior.swift */; };
+		04660F6A27E51E5C00477777 /* CodeEditWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6927E51E5C00477777 /* CodeEditWindowController.swift */; };
 		286620A527E4AB6900E18C2B /* BreadcrumbsComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286620A427E4AB6900E18C2B /* BreadcrumbsComponent.swift */; };
 		2875A46D27E3BE5B007805F8 /* BreadcrumbsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2875A46C27E3BE5B007805F8 /* BreadcrumbsView.swift */; };
 		287776E727E3413200D46668 /* SideBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776E627E3413200D46668 /* SideBar.swift */; };
@@ -63,6 +64,7 @@
 		04660F6027E3A68A00477777 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		04660F6327E3ACAF00477777 /* Appearances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Appearances.swift; sourceTree = "<group>"; };
 		04660F6527E3ACEF00477777 /* ReopenBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReopenBehavior.swift; sourceTree = "<group>"; };
+		04660F6927E51E5C00477777 /* CodeEditWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditWindowController.swift; sourceTree = "<group>"; };
 		0468438427DC76E200F8E88E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		04F2BF0E27DBB28E0024EAB1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		04F2BF1127DBB3C10024EAB1 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 			children = (
 				043C321327E31FF6006AE443 /* CodeEditDocumentController.swift */,
 				043C321527E3201F006AE443 /* WorkspaceDocument.swift */,
+				04660F6927E51E5C00477777 /* CodeEditWindowController.swift */,
 			);
 			path = Documents;
 			sourceTree = "<group>";
@@ -422,6 +425,7 @@
 				286620A527E4AB6900E18C2B /* BreadcrumbsComponent.swift in Sources */,
 				287776EF27E3515300D46668 /* TabBarItem.swift in Sources */,
 				D72E1A8727E4242900EB11B9 /* RecentProjectsView.swift in Sources */,
+				04660F6A27E51E5C00477777 /* CodeEditWindowController.swift in Sources */,
 				287776E727E3413200D46668 /* SideBar.swift in Sources */,
 				287776ED27E350D800D46668 /* SideBarItem.swift in Sources */,
 				289978ED27E4E97E00BB0357 /* FileIconStyle.swift in Sources */,

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -98,4 +98,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             CodeEditDocumentController.shared.newDocument(self)
         }
     }
+    
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        CodeEditDocumentController.shared.documents.flatMap { doc in
+            return doc.windowControllers
+        }.forEach { (wc : NSWindowController) in
+            if let wc = wc as? CodeEditWindowController {
+                wc.workspace?.close()
+            }
+        }
+        return .terminateNow
+    }
 }

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -1,0 +1,29 @@
+//
+//  CodeEditWindowController.swift
+//  CodeEdit
+//
+//  Created by Pavel Kasila on 18.03.22.
+//
+
+import Cocoa
+
+class CodeEditWindowController: NSWindowController {
+    
+    var workspace: WorkspaceDocument?
+
+    override func windowDidLoad() {
+        super.windowDidLoad()
+    
+        // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
+    }
+    
+    @IBAction func saveDocument(_ sender: Any) {
+        guard let id = workspace?.selectedId else { return }
+        guard let item = workspace?.openFileItems.first(where: { item in
+            return item.id == id
+        }) else { return }
+        guard let file = workspace?.openedCodeFiles[item] else { return }
+        file.save(sender)
+    }
+
+}

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -6,6 +6,7 @@
 //
 
 import Cocoa
+import CodeFile
 
 class CodeEditWindowController: NSWindowController {
     
@@ -17,13 +18,16 @@ class CodeEditWindowController: NSWindowController {
         // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
     }
     
-    @IBAction func saveDocument(_ sender: Any) {
-        guard let id = workspace?.selectedId else { return }
+    private func getSelectedCodeFile() -> CodeFileDocument? {
+        guard let id = workspace?.selectedId else { return nil }
         guard let item = workspace?.openFileItems.first(where: { item in
             return item.id == id
-        }) else { return }
-        guard let file = workspace?.openedCodeFiles[item] else { return }
-        file.save(sender)
+        }) else { return nil }
+        guard let file = workspace?.openedCodeFiles[item] else { return nil }
+        return file
     }
-
+    
+    @IBAction func saveDocument(_ sender: Any) {
+        getSelectedCodeFile()?.save(sender)
+    }
 }

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -133,4 +133,12 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     }
     
     override func write(to url: URL, ofType typeName: String) throws {}
+    
+    override func close() {
+        selectedId = nil
+        openFileItems.forEach { item in
+            openedCodeFiles[item]?.save(self)
+        }
+        super.close()
+    }
 }

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -137,7 +137,9 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     override func close() {
         selectedId = nil
         openFileItems.forEach { item in
-            openedCodeFiles[item]?.save(self)
+            do {
+                try openedCodeFiles[item]?.write(to: item.url, ofType: "public.source-code")
+            } catch {}
         }
         super.close()
     }

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -31,7 +31,8 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     
     func closeFileTab(item: WorkspaceClient.FileItem) {
         defer {
-            openedCodeFiles.removeValue(forKey: item)
+            let file = openedCodeFiles.removeValue(forKey: item)
+            file?.save(self)
         }
         
         guard let idx = openFileItems.firstIndex(of: item) else { return }
@@ -40,6 +41,7 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         
         if openFileItems.isEmpty {
             selectedId = nil
+            self.windowControllers.first?.document = self
         } else if idx == 0 {
             selectedId = openFileItems.first?.id
         } else {
@@ -69,7 +71,11 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     ]
     
     override class var autosavesInPlace: Bool {
-        return true
+        return false
+    }
+    
+    override var isDocumentEdited: Bool {
+        return false
     }
         
     override func makeWindowControllers() {
@@ -85,7 +91,8 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         
         window.toolbar?.displayMode = .iconOnly
         window.toolbar?.insertItem(withItemIdentifier: .toggleSidebar, at: 0)
-        let windowController = NSWindowController(window: window)
+        let windowController = CodeEditWindowController(window: window)
+        windowController.workspace = self
         let contentView = WorkspaceView(windowController: windowController, workspace: self)
         window.contentView = NSHostingView(rootView: contentView)
         self.addWindowController(windowController)

--- a/CodeEdit/MainMenu.xib
+++ b/CodeEdit/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
@@ -93,7 +93,7 @@
                             </menuItem>
                             <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
                                 <connections>
-                                    <action selector="saveDocument:" target="-1" id="4cD-US-9JR"/>
+                                    <action selector="saveDocument:" target="-1" id="kkG-H8-VoM"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">

--- a/CodeEdit/MainMenu.xib
+++ b/CodeEdit/MainMenu.xib
@@ -96,16 +96,6 @@
                                     <action selector="saveDocument:" target="-1" id="kkG-H8-VoM"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
-                                <connections>
-                                    <action selector="saveDocumentAs:" target="-1" id="mDf-zr-I0C"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
-                                <connections>
-                                    <action selector="revertDocumentToSaved:" target="-1" id="iJ3-Pv-kwq"/>
-                                </connections>
-                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
                             <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
                                 <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>


### PR DESCRIPTION
Fixes #39
Fixes #40

* `CodeEditorWindowController.saveDocument` (Cmd-S, MainMenu's File -> Save) action calls `save` on the selected `CodeFile`
* on tab close `save` is called