### PR TITLE
Fixed reopen behavior on first launch

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -75,7 +75,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
     
     func handleOpen() {
-        let behavior = ReopenBehavior(rawValue: UserDefaults.standard.string(forKey: ReopenBehavior.storageKey) ?? ReopenBehavior.openPanel.rawValue) ?? ReopenBehavior.openPanel
+        let behavior = ReopenBehavior(rawValue: UserDefaults.standard.string(forKey: ReopenBehavior.storageKey) ?? ReopenBehavior.default.rawValue) ?? ReopenBehavior.default
         
         switch behavior {
         case .welcome:


### PR DESCRIPTION
On the first launch, panel opens instead of welcome screen, but reopen behavior is 'Welcome Screen' in preference window as default.

Fixed to use `ReopenBehavior.default` as default unwrapped value.