### PR TITLE
Fix: Scroll to the selected item in the TabBar

### DIFF
--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -39,10 +39,8 @@ struct TabBar: View {
                             )
                         }
                     }
-                    .onChange(of: workspace.selectedId) { newValue in
-                        withAnimation {
-                            value.scrollTo(newValue)
-                        }
+                    .onAppear {
+                        value.scrollTo(self.workspace.selectedId)
                     }
                 }
             }


### PR DESCRIPTION
When the user selects a file, then it will automatically scroll to it in the tab bar.

It was implemented earlier but now it works again correctly because it was moved to the `onAppear`-modifier due to use of `NavigationLink` to switch between files.