### PR TITLE
Welcome Screen Style Fixes

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -79,18 +79,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         
         switch behavior {
         case .welcome:
-            let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 780, height: 500), styleMask: [.borderless], backing: .buffered, defer: false)
+            let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 800, height: 460), styleMask: [.titled, .fullSizeContentView], backing: .buffered, defer: false)
             let windowController = NSWindowController(window: window)
             window.center()
-            let contentView = WelcomeWindowView(windowController: windowController)
+            let contentView = WelcomeWindowView(windowController: windowController).edgesIgnoringSafeArea(.top)
+            window.titlebarAppearsTransparent = true
             window.isMovableByWindowBackground = true
             window.contentView = NSHostingView(rootView: contentView)
-            window.isOpaque = false
-            window.backgroundColor = .clear
-            window.contentView?.wantsLayer = true
-            window.contentView?.layer?.masksToBounds = true
-            window.contentView?.layer?.cornerRadius = 10
-            window.hasShadow = true
             window.makeKeyAndOrderFront(self)
         case .openPanel:
             CodeEditDocumentController.shared.openDocument(self)

--- a/CodeEdit/CustomViews/BlurView.swift
+++ b/CodeEdit/CustomViews/BlurView.swift
@@ -9,17 +9,21 @@ import Foundation
 import SwiftUI
 
 struct BlurView: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
     
-    var material: NSVisualEffectView.Material
-    var blendingMode: NSVisualEffectView.BlendingMode
-    
-    func makeNSView(context: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-        view.material = material
-        view.blendingMode = blendingMode
-        return view
+    func makeNSView(context: Context) -> NSVisualEffectView
+    {
+        let visualEffectView = NSVisualEffectView()
+        visualEffectView.material = material
+        visualEffectView.blendingMode = blendingMode
+        visualEffectView.state = NSVisualEffectView.State.active
+        return visualEffectView
     }
-    
-    func updateNSView(_ nsView: NSVisualEffectView, context: Context) { }
-    
+
+    func updateNSView(_ visualEffectView: NSVisualEffectView, context: Context)
+    {
+        visualEffectView.material = material
+        visualEffectView.blendingMode = blendingMode
+    }
 }

--- a/CodeEdit/Welcome/RecentProjectsView.swift
+++ b/CodeEdit/Welcome/RecentProjectsView.swift
@@ -10,7 +10,7 @@ import WelcomeModule
 
 struct RecentProjectsView: View {
     @State var recentProjectPaths: [String] = UserDefaults.standard.array(forKey: "recentProjectPaths") as? [String] ?? []
-    @State var selectedProjectPath = ""
+    @State var selectedProjectPath: String = ""
     let dismissWindow: () -> Void
     
     private var emptyView: some View {
@@ -50,7 +50,7 @@ struct RecentProjectsView: View {
         }
         .frame(width: 300)
         .padding(10)
-        .background(Color(nsColor: .windowBackgroundColor))
+        .background(BlurView(material: NSVisualEffectView.Material.underWindowBackground, blendingMode: NSVisualEffectView.BlendingMode.behindWindow))
         .onAppear {
             recentProjectPaths = UserDefaults.standard.array(forKey: "recentProjectPaths") as? [String] ?? []
         }

--- a/CodeEdit/Welcome/WelcomeView.swift
+++ b/CodeEdit/Welcome/WelcomeView.swift
@@ -12,16 +12,28 @@ import WelcomeModule
 
 struct WelcomeView: View {
     @State var isHovering: Bool = false
+    @State var isHoveringClose: Bool = false
+
     @AppStorage(ReopenBehavior.storageKey) var behavior: ReopenBehavior = .welcome
-    
+
     var dismissWindow: () -> Void
     
     private var dismissButton: some View {
-        Image(systemName: "xmark")
-            .frame(width: 16, height: 16)
-            .onTapGesture {
-                dismissWindow()
-            }
+        Button(action: dismissWindow, label: {
+            Circle()
+                .fill(isHoveringClose ? .secondary : Color(.clear))
+                .frame(width: 13, height: 13)
+                .overlay(
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8.5, weight: .heavy, design: .rounded))
+                        .foregroundColor(isHoveringClose ? Color(nsColor: .windowBackgroundColor) : .secondary)
+                )
+        })
+        .buttonStyle(PlainButtonStyle())
+        .accessibilityLabel(Text("Close"))
+        .onHover { hover in
+            isHoveringClose = hover
+        }
     }
     
     private var appVersion: String {
@@ -33,73 +45,76 @@ struct WelcomeView: View {
     }
     
     var body: some View {
-        VStack(spacing: 8) {
-            HStack(alignment: .center) {
-                if (isHovering) {
-                    dismissButton
-                }
-                Spacer()
-            }.frame(height: 20)
-            Image(nsImage: NSApp.applicationIconImage)
-                .resizable()
-                .frame(width: 128, height: 128)
-            Text("Welcome to CodeEdit")
-                .bold()
-                .font(.system(size: 28))
-            Text("Version \(appVersion)(\(appBuild))")
-                .foregroundColor(.gray)
-                .font(.system(size: 16))
-            Spacer().frame(height: 20)
-            HStack {
-                VStack(alignment: .leading, spacing: 15) {
-                    WelcomeActionView(
-                        iconName: "plus.square",
-                        title: "Create a new file",
-                        subtitle: "Create a new file"
-                    )
-                        .onTapGesture {
-                            CodeEditDocumentController.shared.newDocument(nil)
-                            dismissWindow()
-                        }
-                    WelcomeActionView(
-                        iconName: "plus.square.on.square",
-                        title: "Clone an exisiting project",
-                        subtitle: "Start working on something from a Git repository"
-                    )
-                        .onTapGesture {
-                            // TODO: clone a Git repository
-                        }
-                    WelcomeActionView(
-                        iconName: "folder",
-                        title: "Open a project or file",
-                        subtitle: "Open an existing project or file on your Mac"
-                    )
-                        .onTapGesture {
-                            CodeEditDocumentController.shared.openDocument { _, _ in
+        ZStack(alignment: .topLeading) {
+            VStack(spacing: 8) {
+                Spacer().frame(height: 12)
+                Image(nsImage: NSApp.applicationIconImage)
+                    .resizable()
+                    .frame(width: 128, height: 128)
+                Text("Welcome to CodeEdit")
+                    .font(.system(size: 38))
+                Text("Version \(appVersion)(\(appBuild))")
+                    .foregroundColor(.secondary)
+                    .font(.system(size: 13))
+                Spacer().frame(height: 20)
+                HStack {
+                    VStack(alignment: .leading, spacing: 15) {
+                        WelcomeActionView(
+                            iconName: "plus.square",
+                            title: "Create a new file",
+                            subtitle: "Create a new file"
+                        )
+                            .onTapGesture {
+                                CodeEditDocumentController.shared.newDocument(nil)
                                 dismissWindow()
                             }
-                        }
+                        WelcomeActionView(
+                            iconName: "plus.square.on.square",
+                            title: "Clone an exisiting project",
+                            subtitle: "Start working on something from a Git repository"
+                        )
+                            .onTapGesture {
+                                // TODO: clone a Git repository
+                            }
+                        WelcomeActionView(
+                            iconName: "folder",
+                            title: "Open a project or file",
+                            subtitle: "Open an existing project or file on your Mac"
+                        )
+                            .onTapGesture {
+                                CodeEditDocumentController.shared.openDocument { _, _ in
+                                    dismissWindow()
+                                }
+                            }
+                    }
+                }
+                Spacer()
+                if (isHovering) {
+                    HStack {
+                        Toggle("Show this window when CodeEdit launches", isOn: .init(get: {
+                            return self.behavior == .welcome
+                        }, set: { new in
+                            self.behavior = new ? .welcome : .openPanel
+                        }))
+                            .toggleStyle(.checkbox)
+                    }.transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.25)))
                 }
             }
-            Spacer()
+            .frame(width: 384)
+            .padding(.top, 20)
+            .padding(.horizontal, 56)
+            .padding(.bottom, 16)
+            .background(Color(nsColor: .windowBackgroundColor))
+            .onHover { isHovering in
+                self.isHovering = isHovering
+            }
             if (isHovering) {
-                HStack {
-                    Toggle("Show this window when CodeEdit launches", isOn: .init(get: {
-                        return self.behavior == .welcome
-                    }, set: { new in
-                        self.behavior = new ? .welcome : .openPanel
-                    }))
-                        .toggleStyle(.checkbox)
+                HStack(alignment: .center) {
+                    dismissButton
                     Spacer()
-                }
+                }.padding(13).transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.25)))
             }
-        }
-        .frame(width: 480)
-        .padding(.vertical, 24)
-        .padding(.horizontal, 32)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .onHover { isHovering in
-            self.isHovering = isHovering
+            
         }
     }
 }
@@ -109,6 +124,6 @@ struct WelcomeView_Previews: PreviewProvider {
         WelcomeView() {
             
         }
-        .frame(width: 780, height: 600)
+        .frame(width: 800, height: 460)
     }
 }

--- a/CodeEditModules/Modules/WelcomeModule/src/WelcomeActionView.swift
+++ b/CodeEditModules/Modules/WelcomeModule/src/WelcomeActionView.swift
@@ -19,18 +19,18 @@ public struct WelcomeActionView: View {
     }
     
     public var body: some View {
-        HStack(spacing: 15) {
+        HStack(spacing: 16) {
             Image(systemName: iconName)
                 .aspectRatio(contentMode: .fit)
                 .foregroundColor(.accentColor)
-                .font(.system(size: 24, weight: .light))
+                .font(.system(size: 30, weight: .light))
                 .frame(width: 24)
             VStack(alignment: .leading) {
                 Text(title)
                     .bold()
-                    .font(.system(size: 16))
+                    .font(.system(size: 13))
                 Text(subtitle)
-                    .font(.system(size: 14))
+                    .font(.system(size: 12))
             }
             Spacer()
         }


### PR DESCRIPTION
Per #35, to be more consistent with Xcode on the Welcome Screen fixed typography, added hover state to close button, added transition, added vibrancy to recent files list.

Before
<img width="910" alt="image" src="https://user-images.githubusercontent.com/806104/159116719-10fbecf2-1a7e-4917-b113-3e1d73bd84cb.png">

After
<img width="928" alt="Screen Shot 2022-03-19 at 5 01 47 AM" src="https://user-images.githubusercontent.com/806104/159116653-8151d9a7-2729-4dbb-83bd-90d1ac397eea.png">

Xcode
<img width="914" alt="image" src="https://user-images.githubusercontent.com/806104/158868651-4969929f-eac2-4192-b75f-a168434f2b90.png">
