### PR TITLE
Fix Preferences going fullscreen, not allow creation of multiple Preferences windows

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -47,9 +47,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     @IBAction func openPreferences(_ sender: Any) {
+        if let window = NSApp.windows.filter({ window in
+            return (window.contentView as? NSHostingView<SettingsView>) != nil
+        }).first {
+            window.makeKeyAndOrderFront(self)
+            return
+        }
+
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 400),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            styleMask: [.titled, .closable],
             backing: .buffered, defer: false)
         window.center()
         window.toolbar = NSToolbar()


### PR DESCRIPTION
* Fixes #93
* Now multiple Preferences windows won't be created on <kbd>Cmd</kbd> + <kbd>,</kbd>

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/17158860/159126569-aa3b17f8-bf4e-460a-9487-48c2024ed239.png">
