### PR TITLE
Bump `CodeEditModules` platform version to `.v12`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: Testing CodeEdit
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: Testing CodeEdit
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "CodeEditModules",
     defaultLocalization: "en",
     platforms: [
-        .macOS(.v11)
+        .macOS(.v12)
     ],
     products: [
         .library(


### PR DESCRIPTION
Bumping to `.v12` to enable new SwiftUI features in Modules 