### PR TITLE
[Fix] Quick open panel init every time keyboard shortcut fires

### DIFF
--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -36,14 +36,13 @@ class CodeEditWindowController: NSWindowController {
 
     @IBAction func openQuickly(_ sender: Any) {
         if let workspace = workspace, let state = workspace.quickOpenState {
-            if let window = window?.childWindows?.filter({ window in
-                return (window.contentView as? NSHostingView<QuickOpenView>) != nil
-            }).first {
-                window.close()
-                return
-            }
             if let quickOpenPanel = quickOpenPanel {
-                quickOpenPanel.makeKeyAndOrderFront(self)
+                if quickOpenPanel.isKeyWindow {
+                    quickOpenPanel.close()
+                    return
+                } else {
+                    quickOpenPanel.makeKeyAndOrderFront(self)
+                }
             } else {
                 let panel = OverlayPanel()
                 self.quickOpenPanel = panel

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -13,7 +13,7 @@ import Overlays
 class CodeEditWindowController: NSWindowController {
 
     var workspace: WorkspaceDocument?
-
+    var quickOpenPanel: OverlayPanel?
     override func windowDidLoad() {
         super.windowDidLoad()
 
@@ -42,14 +42,18 @@ class CodeEditWindowController: NSWindowController {
                 window.close()
                 return
             }
-
-            let panel = OverlayPanel()
-            let contentView = QuickOpenView(state: state) {
-                panel.close()
-            }
-            panel.contentView = NSHostingView(rootView: contentView)
-            window?.addChildWindow(panel, ordered: .above)
-            panel.makeKeyAndOrderFront(self)
+            if let quickOpenPanel = quickOpenPanel {
+                quickOpenPanel.makeKeyAndOrderFront(self)
+            } else {
+                let panel = OverlayPanel()
+                self.quickOpenPanel = panel
+                let contentView = QuickOpenView(state: state) {
+                    panel.close()
+                }
+                panel.contentView = NSHostingView(rootView: contentView)
+                window?.addChildWindow(panel, ordered: .above)
+                panel.makeKeyAndOrderFront(self)
+            }  
         }
     }
 }

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -53,7 +53,7 @@ class CodeEditWindowController: NSWindowController {
                 panel.contentView = NSHostingView(rootView: contentView)
                 window?.addChildWindow(panel, ordered: .above)
                 panel.makeKeyAndOrderFront(self)
-            }  
+            }
         }
     }
 }


### PR DESCRIPTION
Fix quick open panel init every time keyboard shortcut fires, may produce multi quick open view instance if you open Quick Open multi time.

**How to reproduce this problem?**
cmd + shit + O multi times or "File -> Open Quickly" multi times, see the debug view hierarchy

### Solution
See file change in CodeEditViewController.swift

Before:
![image](https://user-images.githubusercontent.com/19910304/159202499-970e56e1-fa72-44bb-b372-89a372c9bbbd.png)

After:
![image](https://user-images.githubusercontent.com/19910304/159202428-43aa555f-798b-496d-8ebd-2be106693445.png)


