### PR TITLE
Quick Open panel add esc keyboard shortcut to close

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		04ADA0CA27E5D41F00BF00B2 /* be */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = be; path = be.lproj/Localizable.strings; sourceTree = "<group>"; };
 		04F2BF0E27DBB28E0024EAB1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		04F2BF1127DBB3C10024EAB1 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
+		12F71F7127E833A000095416 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		20F8067027E65A5200EB7827 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2805D9E827E5ED180032BC56 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		286620A427E4AB6900E18C2B /* BreadcrumbsComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbsComponent.swift; sourceTree = "<group>"; };
@@ -406,6 +407,7 @@
 				de,
 				af,
 				fr,
+				ja,
 			);
 			mainGroup = B658FB2327DA9E0F00EA4DBD;
 			packageReferences = (
@@ -565,6 +567,7 @@
 				2805D9E827E5ED180032BC56 /* de */,
 				20F8067027E65A5200EB7827 /* af */,
 				5E3C6A3427E72AE000A7CA0D /* fr */,
+				12F71F7127E833A000095416 /* ja */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/CodeEdit/Localization/ja.lproj/Localizable.strings
+++ b/CodeEdit/Localization/ja.lproj/Localizable.strings
@@ -1,0 +1,44 @@
+"Hello, world!"="こんにちは";
+
+// Settings - General Tab
+"General"="一般";
+
+// Settings - File Icon Style
+"File Icon Style"="ファイルアイコンのスタイル";
+"Color"="カラー";
+"Monochrome"="モノクロ";
+
+// Settings - Appearance
+"Appearance"="外観";
+"System"="システム";
+"Light"="ライト";
+"Dark"="ダーク";
+
+// Settings - Reopen Behavior
+"Reopen Behavior"="再開時の扱い";
+"Welcome Screen"="ウェルカムスクリーン";
+"Open Panel"="オープンパネル";
+"New Document"="新しいドキュメント";
+
+// Settings - Editor Theme
+"Editor Theme"="エディタのテーマ";
+
+// Welcome Screen
+"Welcome to CodeEdit"="Welcome to CodeEdit";
+"Version %@ (%@)"="バージョン %@ (%@)";
+"No Recent Projects"="最近のプロジェクトはありません";
+
+// Welcome Screen - New File
+"Create a new file"="新しいファイルを作る";
+"Clone an exisiting project"="既存プロジェクトをクローン";
+
+// Welcome Screen - SCM
+"Start working on something from a Git repository"="Gitリポジトリから作業を開始する";
+"Open a project or file"="プロジェクトまたはファイルを開く";
+
+// Welcome Screen - Workspaces
+"Open an existing project or file on your Mac"="Macで既存のプロジェクトまたはファイルを開く";
+"Show this window when CodeEdit launches"="CodeEditの起動時にこのウィンドウを表示する";
+
+//Editor Screen
+"CodeEdit cannot open this file because its file type is not supported." = "CodeEditはこのファイルを開くことができません。";

--- a/CodeEdit/Quick Open/QuickOpenView.swift
+++ b/CodeEdit/Quick Open/QuickOpenView.swift
@@ -16,25 +16,34 @@ struct QuickOpenView: View {
     var body: some View {
         VStack(spacing: 0.0) {
             VStack {
-                HStack(alignment: .center, spacing: 0) {
-                    Image(systemName: "doc.text.magnifyingglass")
-                        .imageScale(.large)
-                        .padding(.horizontal, 20)
-                        .offset(x: 2, y: 0)
-                    TextField("Open Quickly", text: $state.openQuicklyQuery)
-                        .font(.system(size: 22, weight: .light, design: .default))
-                        .textFieldStyle(.plain)
-                        .onReceive(
-                            state.$openQuicklyQuery
-                                .debounce(for: .seconds(0.4), scheduler: DispatchQueue.main)
-                        ) { _ in
-                            state.fetchOpenQuickly()
-                        }
+                ZStack {
+                    Button("") {
+                        self.onClose()
+                    }
+                    .foregroundColor(.clear)
+                    .frame(width: 0, height: 0)
+                    .background(.clear)
+                    .keyboardShortcut(KeyEquivalent.escape, modifiers: [])
+                    HStack(alignment: .center, spacing: 0) {
+                        Image(systemName: "doc.text.magnifyingglass")
+                            .imageScale(.large)
+                            .padding(.horizontal, 20)
+                            .offset(x: 2, y: 0)
+                        TextField("Open Quickly", text: $state.openQuicklyQuery)
+                            .font(.system(size: 22, weight: .light, design: .default))
+                            .textFieldStyle(.plain)
+                            .onReceive(
+                                state.$openQuicklyQuery
+                                    .debounce(for: .seconds(0.4), scheduler: DispatchQueue.main)
+                            ) { _ in
+                                state.fetchOpenQuickly()
+                            }
+                    }
+                        .frame(height: 28)
+                        .padding(.vertical)
+                        .foregroundColor(.primary.opacity(0.85))
+                        .background(BlurView(material: .sidebar, blendingMode: .behindWindow))
                 }
-                    .frame(height: 28)
-                    .padding(.vertical)
-                    .foregroundColor(.primary.opacity(0.85))
-                    .background(BlurView(material: .sidebar, blendingMode: .behindWindow))
             }
             Divider()
             NavigationView {


### PR DESCRIPTION
Add esc keyboard shortcut close the `Quickly Open` panel

In Xcode, Quickly Open Panel is opened by `Cmd + Shift + O` or `File -> Open Quickly`, and closed by `Esc`" or click other window to make quickly view panel out of focus.

And if you fire "Cmd + Shift + O" in Xcode when Quickly Open Panel is key window, the panel refreshed instead of closed.

In README.md:
> We'd like to keep our application light as TextEdit, but provide an experience like Xcode.

This pull request implements the `ESC` close shortcut by adding an empty button with `keyboardShortcut` modifier. It's kind strange to do it in this way, open to better solutions and opinions.

