### PR TITLE
Function to reduce the amount of Copy/Paste in the StatusBar regarding checks for NSCursor() push and pop

### DIFF
--- a/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
@@ -146,11 +146,7 @@ public struct StatusBarView: View {
 		.menuStyle(.borderlessButton)
 		.fixedSize()
 		.onHover { hovering in
-			if hovering {
-				NSCursor.pointingHand.push()
-			} else {
-				NSCursor.pop()
-			}
+			checkIfHovering(isHovering: Bool)
 		}
 	}
 

--- a/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
@@ -8,6 +8,13 @@
 import SwiftUI
 import GitClient
 
+func checkIfHovering(isHovering: Bool) {
+    switch isHovering {
+    case true: NSCursor.pointingHand.push()
+    case false: NSCursor.pop()
+    }
+}
+
 @available(macOS 12, *)
 public struct StatusBarView: View {
 
@@ -173,11 +180,7 @@ public struct StatusBarView: View {
 		.buttonStyle(.borderless)
 		.foregroundStyle(.primary)
 		.onHover { hovering in
-			if hovering {
-				NSCursor.pointingHand.push()
-			} else {
-				NSCursor.pop()
-			}
+			checkIfHovering(isHovering: hovering)
 		}
 	}
 
@@ -192,11 +195,7 @@ public struct StatusBarView: View {
 			.font(toolbarFont)
 			.foregroundStyle(.primary)
 			.onHover { hovering in
-				if hovering {
-					NSCursor.pointingHand.push()
-				} else {
-					NSCursor.pop()
-				}
+                checkIfHovering(isHovering: hovering)
 			}
 	}
 
@@ -210,11 +209,7 @@ public struct StatusBarView: View {
 		.menuStyle(.borderlessButton)
 		.fixedSize()
 		.onHover { hovering in
-			if hovering {
-				NSCursor.pointingHand.push()
-			} else {
-				NSCursor.pop()
-			}
+			checkIfHovering(isHovering: hovering)
 		}
 	}
 
@@ -228,11 +223,7 @@ public struct StatusBarView: View {
 		.menuStyle(.borderlessButton)
 		.fixedSize()
 		.onHover { hovering in
-			if hovering {
-				NSCursor.pointingHand.push()
-			} else {
-				NSCursor.pop()
-			}
+			checkIfHovering(isHovering: hovering)
 		}
 	}
 
@@ -246,11 +237,7 @@ public struct StatusBarView: View {
 		.menuStyle(.borderlessButton)
 		.fixedSize()
 		.onHover { hovering in
-			if hovering {
-				NSCursor.pointingHand.push()
-			} else {
-				NSCursor.pop()
-			}
+			checkIfHovering(isHovering: hovering)
 		}
 	}
 
@@ -270,11 +257,7 @@ public struct StatusBarView: View {
 		.tint(model.isExpanded ? .accentColor : .primary)
 		.buttonStyle(.borderless)
 		.onHover { hovering in
-			if hovering {
-				NSCursor.pointingHand.push()
-			} else {
-				NSCursor.pop()
-			}
+			checkIfHovering(isHovering: hovering)
 		}
 	}
 }


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

### I noticed a lot of copying for a check that could easily be reduced to a simple function

<!--- REQUIRED: Describe what changed in detail -->

### Made a function called checkIfHovering(isHovering: Bool). Also switched if-then-else to switch-case to improve readability

Issues N/A

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] Review requested

### Screenshots (if appropriate):

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this issue temporarily -->
