### PR TITLE
Fix `Fatal not a git repository`

### DIFF
--- a/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
+++ b/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
@@ -22,7 +22,7 @@ public class StatusBarModel: ObservableObject {
 	@Published public var warningCount: Int = 0 // Implementation missing
 
 	/// The selected branch from the GitClient
-	@Published public var selectedBranch: String = ""
+	@Published public var selectedBranch: String?
 
 	/// State of pulling from git
 	@Published public var isReloading: Bool = false // Implementation missing
@@ -63,6 +63,10 @@ public class StatusBarModel: ObservableObject {
 	/// - Parameter gitClient: a GitClient
 	public init(gitClient: GitClient) {
 		self.gitClient = gitClient
-		self.selectedBranch = gitClient.getCurrentBranchName()
+		if gitClient.getCurrentBranchName().contains("fatal: not a git repository") {
+			self.selectedBranch = nil
+		} else {
+			self.selectedBranch = gitClient.getCurrentBranchName()
+		}
 	}
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
@@ -47,8 +47,10 @@ public struct StatusBarView: View {
 					StatusBarLabelButton(model: model, title: model.errorCount.formatted(), image: "xmark.octagon")
 					StatusBarLabelButton(model: model, title: model.warningCount.formatted(), image: "exclamationmark.triangle")
 				}
-				StatusBarBranchPicker(model: model)
-				StatusBarPullButton(model: model)
+				if model.selectedBranch != nil {
+					StatusBarBranchPicker(model: model)
+					StatusBarPullButton(model: model)
+				}
 				Spacer()
 				StatusBarCursorLocationLabel(model: model)
 				StatusBarIndentSelector(model: model)

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarBranchPicker.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarBranchPicker.swift
@@ -18,6 +18,7 @@ internal struct StatusBarBranchPicker: View {
 
 	internal var body: some View {
 		Menu {
+
 			ForEach(model.gitClient.getBranches(), id: \.self) { branch in
 				Button {
 					do {
@@ -41,11 +42,12 @@ internal struct StatusBarBranchPicker: View {
 				}
 			}
 		} label: {
-			Text(model.selectedBranch)
+			Text(model.selectedBranch ?? "No Git Repository")
 				.font(model.toolbarFont)
 		}
 		.menuStyle(.borderlessButton)
 		.fixedSize()
 		.onHover { isHovering($0) }
+		.disabled(model.selectedBranch == nil)
 	}
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarPullButton.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarPullButton.swift
@@ -39,9 +39,10 @@ internal struct StatusBarPullButton: View {
 				}
 
 		}
-		.buttonStyle(.borderless)
+		.buttonStyle(.plain)
 		.foregroundStyle(.primary)
 		.onHover { isHovering($0) }
+		.disabled(model.selectedBranch == nil)
 	}
 
 	// Temporary


### PR DESCRIPTION
### Description

Fixes issue #178. 
~~Now shows `No Git Repository` instead of `fatal: not a git repository (or any of the parent directories): git` and disables the picker.
Also the `pull` button is disabled.~~
Hides the branch picker & pull button when no git repo is present

### Releated Issue

#178 

### Checklist (for drafts):

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):

<img width="912" alt="Screen Shot 2022-03-23 at 00 52 24" src="https://user-images.githubusercontent.com/9460130/159595504-5a99674c-3952-4ca8-b37c-60d51bb68884.png">

