### PR TITLE
Fix status bar preventing window resizing

### DIFF
--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarBranchPicker.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarBranchPicker.swift
@@ -45,7 +45,7 @@ internal struct StatusBarBranchPicker: View {
 				.font(model.toolbarFont)
 		}
 		.menuStyle(.borderlessButton)
-		.fixedSize()
+        .fixedSize(horizontal: false, vertical: true)
 		.onHover { isHovering($0) }
 	}
 }


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

### Description

Fixes #177 by replacing the `.fixedSize()` modifier from the largest status bar item with `.fixedSize(horizontal: false, vertical: true)`. The `.fixedSize()` was causing the sidebar to stay the same width even when the window needed to shrink to a smaller width.

PR #193 fixed this by removing the long error message that was causing the problem, but this PR removes the underlying layout problem. This will also fix the issue if someone in the future has a very long branch name.

Also, as you can see in the screen recording, it fixes this bug when other long errors are present.

<!--- REQUIRED: Describe what changed in detail -->

### Releated Issue

PR #193 and issue #177

<!--- REQUIRED: Tag all related issues (e.g. #23) -->

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] Review requested

### Screenshots (if appropriate):

<!--- REQUIRED: if issue is UI related -->
Status bar item resizing with width change:

https://user-images.githubusercontent.com/35942988/159599180-2899545d-fad9-454b-ae04-0cd5dadc5e47.mov


<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this issue temporarily -->
