### PR TITLE
fix: code editor highlight load

### DIFF
--- a/CodeEditModules/Modules/CodeFile/src/CodeEditor.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeEditor.swift
@@ -37,6 +37,16 @@ struct CodeEditor: NSViewRepresentable {
                 scrollView: scrollView
             )
         )
+
+        if let highlightr = highlightr,
+           let string = highlightr.highlight(
+            content.wrappedValue,
+            as: language?.rawValue,
+            fastRender: true
+           ) {
+            textView.textStorage?.append(string)
+        }
+
         textView.autoresizingMask = .width
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         textView.minSize = NSSize(width: 0, height: scrollView.contentSize.height)

--- a/CodeEditModules/Modules/CodeFile/src/Model/Language.swift
+++ b/CodeEditModules/Modules/CodeFile/src/Model/Language.swift
@@ -84,6 +84,7 @@ extension CodeEditor {
         case haxe
         case hsp
         case htmlbars
+        case html
         case http
         case hy
         case inform7


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

### Description
<!--- REQUIRED: Describe what changed in detail -->
This PR should fix the _CodeEditor_ loading issue we've seen. The issue in particular was that the code editor was loading the text without highlighting first resulting in a weird UI. This PR fixes that by manually highlight the text upon creating the view using a fast renderer solution. I've also added support to html syntax which for some reason wasn't added before.

### Releated Issue

<!--- REQUIRED: Tag all related issues (e.g. #23) -->
#144 

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

