### PR TITLE
fixed welcome window shortcut

### DIFF
--- a/CodeEdit/MainMenu.xib
+++ b/CodeEdit/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
@@ -645,7 +645,7 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="13H-7T-5bk"/>
-                            <menuItem title="Welcome to CodeEdit" keyEquivalent="0" id="ftv-uF-z1D" userLabel="Welcome to CodeEdit">
+                            <menuItem title="Welcome to CodeEdit" keyEquivalent="1" id="ftv-uF-z1D" userLabel="Welcome to CodeEdit">
                                 <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>
                                     <action selector="openWelcome:" target="-1" id="nj3-Ce-f7P"/>


### PR DESCRIPTION
### Description

Fixes the keyboard shortcut to open the `Welcome Window` to `⇧+⌘+1` like Xcode does.

### Releated Issue

#203 

### Checklist (for drafts):

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):
**Before**
<img width="322" alt="Screen Shot 2022-03-23 at 12 02 01" src="https://user-images.githubusercontent.com/9460130/159687126-1af4f0ab-0498-4535-9437-dad04f98ebed.png">

**After**
<img width="319" alt="Screen Shot 2022-03-23 at 12 15 23" src="https://user-images.githubusercontent.com/9460130/159687356-eed1a32c-67ca-4f1c-a3f1-5554e6f0bcb2.png">

**Reference**
<img width="325" alt="Screen Shot 2022-03-23 at 12 02 51" src="https://user-images.githubusercontent.com/9460130/159687133-21bfb617-c47f-45ac-8531-6fa0a43f32d2.png">

