### PR TITLE
added font picker for terminal emulator

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		0485EB1F27E7458B00138301 /* WorkspaceCodeFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485EB1E27E7458B00138301 /* WorkspaceCodeFileView.swift */; };
 		0485EB2327E7791400138301 /* QuickOpenPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485EB2227E7791400138301 /* QuickOpenPreviewView.swift */; };
 		0485EB2527E7B9C800138301 /* Overlays in Frameworks */ = {isa = PBXBuildFile; productRef = 0485EB2427E7B9C800138301 /* Overlays */; };
+		2859B93F27EB50050069BE88 /* FontPicker in Frameworks */ = {isa = PBXBuildFile; productRef = 2859B93E27EB50050069BE88 /* FontPicker */; };
+		2859B94127EB5BC00069BE88 /* TerminalSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2859B94027EB5BC00069BE88 /* TerminalSettingsView.swift */; };
 		286620A527E4AB6900E18C2B /* BreadcrumbsComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286620A427E4AB6900E18C2B /* BreadcrumbsComponent.swift */; };
 		2875A46D27E3BE5B007805F8 /* BreadcrumbsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2875A46C27E3BE5B007805F8 /* BreadcrumbsView.swift */; };
 		287776E727E3413200D46668 /* NavigatorSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776E627E3413200D46668 /* NavigatorSidebar.swift */; };
@@ -94,6 +96,7 @@
 		12F71F7127E833A000095416 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		20F8067027E65A5200EB7827 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2805D9E827E5ED180032BC56 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		2859B94027EB5BC00069BE88 /* TerminalSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSettingsView.swift; sourceTree = "<group>"; };
 		286620A427E4AB6900E18C2B /* BreadcrumbsComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbsComponent.swift; sourceTree = "<group>"; };
 		2875A46C27E3BE5B007805F8 /* BreadcrumbsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbsView.swift; sourceTree = "<group>"; };
 		287776E627E3413200D46668 /* NavigatorSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigatorSidebar.swift; sourceTree = "<group>"; };
@@ -103,8 +106,8 @@
 		289978EC27E4E97E00BB0357 /* FileIconStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIconStyle.swift; sourceTree = "<group>"; };
 		28B0A19727E385C300B73177 /* NavigatorSidebarToolbarTop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarTop.swift; sourceTree = "<group>"; };
 		28FFE1BE27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarBottom.swift; sourceTree = "<group>"; };
-		2B7C962F27EA5D4000DF58C5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2B772A4C27EA6AF800AFCD7E /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		2B7C962F27EA5D4000DF58C5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		34EE19BD27E0469C00F152CE /* BlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurView.swift; sourceTree = "<group>"; };
 		5E3C6A3427E72AE000A7CA0D /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		70F2E28327E848720002BA81 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -143,6 +146,7 @@
 				0485EB2527E7B9C800138301 /* Overlays in Frameworks */,
 				B65E614627E6765D00255275 /* Introspect in Frameworks */,
 				D70F5E2C27E4E8CF004EE4B9 /* WelcomeModule in Frameworks */,
+				2859B93F27EB50050069BE88 /* FontPicker in Frameworks */,
 				D7F72DEB27EA3574000C3064 /* Search in Frameworks */,
 				5CFA753B27E896B60002F01B /* GitClient in Frameworks */,
 				28CE5EA027E6493D0065D29C /* StatusBar in Frameworks */,
@@ -205,6 +209,7 @@
 				04660F6227E3ACA300477777 /* Models */,
 				04F2BF0E27DBB28E0024EAB1 /* SettingsView.swift */,
 				04F2BF1127DBB3C10024EAB1 /* GeneralSettingsView.swift */,
+				2859B94027EB5BC00069BE88 /* TerminalSettingsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -373,6 +378,7 @@
 				0485EB2427E7B9C800138301 /* Overlays */,
 				5CFA753A27E896B60002F01B /* GitClient */,
 				D7F72DEA27EA3574000C3064 /* Search */,
+				2859B93E27EB50050069BE88 /* FontPicker */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -557,6 +563,7 @@
 				B673FDAD27E8296A00795864 /* PressActionsModifier.swift in Sources */,
 				043C321427E31FF6006AE443 /* CodeEditDocumentController.swift in Sources */,
 				04660F6427E3ACAF00477777 /* Appearances.swift in Sources */,
+				2859B94127EB5BC00069BE88 /* TerminalSettingsView.swift in Sources */,
 				04540D5E27DD08C300E91B77 /* WorkspaceView.swift in Sources */,
 				34EE19BE27E0469C00F152CE /* BlurView.swift in Sources */,
 				D7211D4327E066CE008F2ED7 /* Localized+Ex.swift in Sources */,
@@ -970,6 +977,10 @@
 		0485EB2427E7B9C800138301 /* Overlays */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Overlays;
+		};
+		2859B93E27EB50050069BE88 /* FontPicker */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FontPicker;
 		};
 		28CE5E9F27E6493D0065D29C /* StatusBar */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit/Localization/de.lproj/Localizable.strings
+++ b/CodeEdit/Localization/de.lproj/Localizable.strings
@@ -23,9 +23,17 @@
 // Settings - Editor Theme
 "Editor Theme"="Editor Theme";
 
+// Settings - Terminal Tab
+"Terminal"="Terminal";
+
 // Settings - Terminal Shell Type
 "Terminal Shell"="Terminal Shell";
 "System Default"="System Standard";
+
+// Settings - Terminal Font
+"Terminal Font"="Terminal Schriftart";
+"System Font"="System Schriftart";
+"Custom"="Benutzerdefiniert";
 
 // Welcome Screen
 "Welcome to CodeEdit"="Willkommen zu CodeEdit";

--- a/CodeEdit/Localization/en.lproj/Localizable.strings
+++ b/CodeEdit/Localization/en.lproj/Localizable.strings
@@ -23,9 +23,17 @@
 // Settings - Editor Theme
 "Editor Theme"="Editor Theme";
 
+// Settings - Terminal Tab
+"Terminal"="Terminal";
+
 // Settings - Terminal Shell Type
 "Terminal Shell"="Terminal Shell";
 "System Default"="System Default";
+
+// Settings - Terminal Font
+"Terminal Font"="Terminal Font";
+"System Font"="System Font";
+"Custom"="Custom";
 
 // Welcome Screen
 "Welcome to CodeEdit"="Welcome to CodeEdit";

--- a/CodeEdit/Settings/GeneralSettingsView.swift
+++ b/CodeEdit/Settings/GeneralSettingsView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import CodeFile
-import TerminalEmulator
 
 // MARK: - View
 
@@ -16,7 +15,6 @@ struct GeneralSettingsView: View {
     @AppStorage(ReopenBehavior.storageKey) var reopenBehavior: ReopenBehavior = .default
     @AppStorage(FileIconStyle.storageKey) var fileIconStyle: FileIconStyle = .default
     @AppStorage(CodeFileView.Theme.storageKey) var editorTheme: CodeFileView.Theme = .atelierSavannaAuto
-	@AppStorage(TerminalShellType.storageKey) var shellType: TerminalShellType = .default
 
     var body: some View {
         Form {
@@ -64,15 +62,6 @@ struct GeneralSettingsView: View {
 					.tag(CodeFileView.Theme.agate)
 				Text("Ocean")
 					.tag(CodeFileView.Theme.ocean)
-			}
-
-			Picker("Terminal Shell".localized(), selection: $shellType) {
-				Text("System Default".localized())
-					.tag(TerminalShellType.auto)
-				Text("ZSH")
-					.tag(TerminalShellType.zsh)
-				Text("Bash")
-					.tag(TerminalShellType.bash)
 			}
         }
         .padding()

--- a/CodeEdit/Settings/SettingsView.swift
+++ b/CodeEdit/Settings/SettingsView.swift
@@ -14,9 +14,13 @@ struct SettingsView: View {
                 .tabItem {
 					Label("General".localized(), systemImage: "gearshape")
                 }
+			TerminalSettingsView()
+				.tabItem {
+					Label("Terminal", systemImage: "chevron.left.forwardslash.chevron.right")
+				}
         }
         .padding()
-        .frame(width: 450, height: 250)
+		.frame(width: 450, height: 200)
     }
 }
 

--- a/CodeEdit/Settings/SettingsView.swift
+++ b/CodeEdit/Settings/SettingsView.swift
@@ -16,7 +16,7 @@ struct SettingsView: View {
                 }
 			TerminalSettingsView()
 				.tabItem {
-					Label("Terminal", systemImage: "chevron.left.forwardslash.chevron.right")
+					Label("Terminal".localized(), systemImage: "chevron.left.forwardslash.chevron.right")
 				}
         }
         .padding()

--- a/CodeEdit/Settings/TerminalSettingsView.swift
+++ b/CodeEdit/Settings/TerminalSettingsView.swift
@@ -27,9 +27,9 @@ struct TerminalSettingsView: View {
 			}
 
 			Picker("Terminal Font".localized(), selection: $terminalFontSelection) {
-				Text("System Font")
+				Text("System Font".localized())
 					.tag(TerminalFont.systemFont)
-				Text("Custom")
+				Text("Custom".localized())
 					.tag(TerminalFont.custom)
 			}
 			if terminalFontSelection == .custom {

--- a/CodeEdit/Settings/TerminalSettingsView.swift
+++ b/CodeEdit/Settings/TerminalSettingsView.swift
@@ -1,0 +1,49 @@
+//
+//  TerminalSettingsView.swift
+//  CodeEdit
+//
+//  Created by Lukas Pistrol on 23.03.22.
+//
+
+import SwiftUI
+import TerminalEmulator
+import FontPicker
+
+struct TerminalSettingsView: View {
+	@AppStorage(TerminalShellType.storageKey) var shellType: TerminalShellType = .default
+	@AppStorage(TerminalFont.storageKey) var terminalFontSelection: TerminalFont = .default
+	@AppStorage(TerminalFontName.storageKey) var terminalFontName: String = TerminalFontName.default
+	@AppStorage(TerminalFontSize.storageKey) var terminalFontSize: Int = TerminalFontSize.default
+
+    var body: some View {
+		Form {
+			Picker("Terminal Shell".localized(), selection: $shellType) {
+				Text("System Default".localized())
+					.tag(TerminalShellType.auto)
+				Text("ZSH")
+					.tag(TerminalShellType.zsh)
+				Text("Bash")
+					.tag(TerminalShellType.bash)
+			}
+
+			Picker("Terminal Font".localized(), selection: $terminalFontSelection) {
+				Text("System Font")
+					.tag(TerminalFont.systemFont)
+				Text("Custom")
+					.tag(TerminalFont.custom)
+			}
+			if terminalFontSelection == .custom {
+				HStack {
+					FontPicker("\(terminalFontName) \(terminalFontSize)", name: $terminalFontName, size: $terminalFontSize)
+				}
+			}
+		}
+		.padding()
+    }
+}
+
+struct TerminalSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        TerminalSettingsView()
+    }
+}

--- a/CodeEditModules/Modules/FontPicker/src/FontPickerView.swift
+++ b/CodeEditModules/Modules/FontPicker/src/FontPickerView.swift
@@ -1,0 +1,81 @@
+//
+//  FontPickerView.swift
+//  
+//
+//  Created by Lukas Pistrol on 23.03.22.
+//
+
+import SwiftUI
+
+class FontPickerDelegate {
+	var parent: FontPicker
+
+	init(_ parent: FontPicker) {
+		self.parent = parent
+	}
+
+	@objc
+	func changeFont(_ id: Any) {
+		parent.fontSelected()
+	}
+
+}
+
+public struct FontPicker: View {
+	let labelString: String
+
+	@Binding var fontName: String
+	@Binding var fontSize: Int
+	@State var fontPickerDelegate: FontPickerDelegate?
+
+	private var font: NSFont {
+		get {
+			NSFont(name: fontName, size: CGFloat(fontSize)) ?? .systemFont(ofSize: CGFloat(fontSize))
+		}
+		set {
+			self.fontName = newValue.fontName
+			self.fontSize = Int(newValue.pointSize)
+		}
+	}
+
+	public init(_ label: String, name: Binding<String>, size: Binding<Int>) {
+		self.labelString = label
+		self._fontName = name
+		self._fontSize = size
+	}
+
+	public var body: some View {
+		HStack {
+			Text(labelString)
+				.lineLimit(1)
+				.truncationMode(.middle)
+
+			Button {
+				if NSFontPanel.shared.isVisible {
+					NSFontPanel.shared.orderOut(nil)
+					return
+				}
+
+				self.fontPickerDelegate = FontPickerDelegate(self)
+				NSFontManager.shared.target = self.fontPickerDelegate
+				NSFontPanel.shared.setPanelFont(self.font, isMultiple: false)
+				NSFontPanel.shared.orderBack(nil)
+			} label: {
+				Image(systemName: "textformat")
+					.imageScale(.large)
+			}
+			.fixedSize()
+		}
+	}
+
+	mutating
+	func fontSelected() {
+		self.font = NSFontPanel.shared.convert(self.font)
+	}
+}
+
+struct FontPicker_Previews: PreviewProvider {
+	static var previews: some View {
+		FontPicker("font", name: .constant("Test"), size: .constant(11))
+	}
+}

--- a/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView.swift
@@ -18,15 +18,23 @@ import SwiftTerm
 public struct TerminalEmulatorView: NSViewRepresentable {
 
 	@AppStorage(TerminalShellType.storageKey) var shellType: TerminalShellType = .default
+	@AppStorage(TerminalFont.storageKey) var terminalFontSelection: TerminalFont = .default
+	@AppStorage(TerminalFontName.storageKey) var terminalFontName: String = TerminalFontName.default
+	@AppStorage(TerminalFontSize.storageKey) var terminalFontSize: Int = TerminalFontSize.default
 
 	private var terminal: LocalProcessTerminalView
-	private var font: NSFont
+	private var font: NSFont {
+		if terminalFontSelection == .systemFont {
+			return .monospacedSystemFont(ofSize: 11, weight: .medium)
+		}
+		return NSFont(name: terminalFontName, size: CGFloat(terminalFontSize)) ??
+			.monospacedSystemFont(ofSize: 11, weight: .medium)
+	}
 	private var url: URL
 
-	public init(url: URL, font: NSFont = .monospacedSystemFont(ofSize: 12, weight: .medium)) {
+	public init(url: URL) {
 		self.url = url
 		self.terminal = .init(frame: .zero)
-		self.font = font
 	}
 
 	/// Returns a string of a shell path to use

--- a/CodeEditModules/Modules/TerminalEmulator/src/TerminalFont.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/TerminalFont.swift
@@ -1,0 +1,26 @@
+//
+//  File.swift
+//  
+//
+//  Created by Lukas Pistrol on 23.03.22.
+//
+
+import Foundation
+
+public enum TerminalFont: String, CaseIterable, Hashable {
+	case systemFont
+	case custom
+
+	static public let `default`: TerminalFont = .systemFont
+	static public let storageKey = "terminalFontSelection"
+}
+
+public enum TerminalFontName {
+	static public let `default`: String = "SFMono-Medium"
+	static public let storageKey = "terminalFontName"
+}
+
+public enum TerminalFontSize {
+	static public let `default`: Int = 11
+	static public let storageKey = "terminalFontSize"
+}

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -40,7 +40,11 @@ let package = Package(
         .library(
             name: "Search",
             targets: ["Search"]
-        )
+        ),
+		.library(
+			name: "FontPicker",
+			targets: ["FontPicker"]
+		)
     ],
     dependencies: [
         .package(
@@ -127,6 +131,10 @@ let package = Package(
                 "WorkspaceClient"
             ],
             path: "Modules/Search/src"
-        )
+        ),
+		.target(
+			name: "FontPicker",
+			path: "Modules/FontPicker/src"
+		)
     ]
 )


### PR DESCRIPTION
### Description

Added Font Picker to Preferences in order to change the terminal emulator's font.
Useful when using custom ZSH themes that require `Powerline` fonts.

Defaults to `SF Mono`

### Releated Issue

#200 

### Checklist (for drafts):

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested 

### Screenshots (if appropriate):

https://user-images.githubusercontent.com/9460130/159717227-6ef6a867-992e-49ee-8e1a-e9e5841895e6.mov


