### PR TITLE
Remember State: initialize `selectedId` when opening from `.codeedit/selection.json`

### DIFF
--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -141,6 +141,7 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
                     state.openFileItems.forEach { item in
                         self.openFile(item: item)
                     }
+                    self.selectionState.selectedId = state.selectedId
                 }
             }
         } catch {


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

### Description

Set `selectedId` when initializing the workspace, so the latest tab will be selected

<!--- REQUIRED: Describe what changed in detail -->

### Releated Issue

<!--- REQUIRED: Tag all related issues (e.g. #23) -->
#121

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested
