### PR TITLE
Fix breadcrumb display having folders with same name

### DIFF
--- a/CodeEdit/Breadcrumbs/BreadcrumbsView.swift
+++ b/CodeEdit/Breadcrumbs/BreadcrumbsView.swift
@@ -65,11 +65,14 @@ struct BreadcrumbsView: View {
 	}
 
     private func fileInfo(_ file: WorkspaceClient.FileItem) {
-		guard let projName = workspace.fileURL?.lastPathComponent,
-			  var components = file.url.pathComponents.split(separator: projName).last else { return }
-		components.removeLast()
+		guard let projURL = workspace.fileURL else { return }
+		let components = file.url.path
+			.replacingOccurrences(of: projURL.path, with: "")
+			.split(separator: "/")
+			.map { String($0) }
+			.dropLast()
 
-		self.projectName = projName
+		self.projectName = projURL.lastPathComponent
 		self.folders = Array(components)
 		self.fileName = file.fileName
 		self.fileImage = file.systemImage


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

### Description

This PR fix #215 
<!--- REQUIRED: Describe what changed in detail -->

### Releated Issue

#215 

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):

<img width="1112" alt="截屏2022-03-23 下午11 08 56" src="https://user-images.githubusercontent.com/22616933/159732999-f7c39e3b-2a12-4f70-8376-66d7fe4e2f19.png">

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this issue temporarily -->
