### PR TITLE
Remove Tab Removal Animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,4 +93,3 @@ iOSInjectionProject/
 # System files
 
 .DS_Store
-CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ iOSInjectionProject/
 # System files
 
 .DS_Store
+CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -34,19 +34,20 @@ struct TabBar: View {
                     .frame(height: 28)
                 ScrollView(.horizontal, showsIndicators: false) {
                     ScrollViewReader { value in
-                        HStack(alignment: .center, spacing: -1) {
+                        LazyHStack(alignment: .center, spacing: -1) {
                             ForEach(workspace.openFileItems, id: \.id) { item in
                                 TabBarItem(
                                     item: item,
                                     windowController: windowController,
                                     workspace: workspace
                                 )
-                                .animation(nil, value: UUID())
+                                    .animation(.easeOut(duration: 0.05), value: UUID())
                             }
                         }
                         .onAppear {
                             value.scrollTo(self.workspace.selectedId)
                         }
+                        .frame(height: 28)
                     }
                 }
                 .padding(.leading, -1)

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -41,6 +41,7 @@ struct TabBar: View {
                                     windowController: windowController,
                                     workspace: workspace
                                 )
+                                    .transition(.opacity)
                                     .animation(.easeOut(duration: 0.05), value: UUID())
                             }
                         }

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -41,6 +41,7 @@ struct TabBar: View {
                                     windowController: windowController,
                                     workspace: workspace
                                 )
+                                .animation(nil, value: UUID())
                             }
                         }
                         .onAppear {


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

### Description

Removes the default animation when removing tabs from the tab list. By default SwiftUI adds a 0.35 second animation to items, but this makes for an unresponsive and slow tab bar. I've removed the animation by adding an `.animation(nil, value: UUID())` to each tab item in the `TabBar.swift` file.

<!--- REQUIRED: Describe what changed in detail -->

### Releated Issue

* #221.

<!--- REQUIRED: Tag all related issues (e.g. #23) -->

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] Review requested

### Screenshots (if appropriate):

Before (with animation):
https://user-images.githubusercontent.com/35942988/159793534-18dc09ab-7411-4c0b-8997-f01e4ea95726.mov

After (no animation):
https://user-images.githubusercontent.com/35942988/159793576-f1299a64-3bef-4a05-af46-8a270b1b6d35.mov


