### PR TITLE
Updated Terminal Related Localizations for zh-Hans

### DIFF
--- a/CodeEdit/Localization/zh-Hans.lproj/Localizable.strings
+++ b/CodeEdit/Localization/zh-Hans.lproj/Localizable.strings
@@ -23,6 +23,18 @@
 // Settings - Editor Theme
 "Editor Theme"="编辑器主题";
 
+// Settings - Terminal Tab
+"Terminal"="终端";
+
+// Settings - Terminal Shell Type
+"Terminal Shell"="终端 Shell";
+"System Default"="系统默认";
+
+// Settings - Terminal Font
+"Terminal Font"="终端字体";
+"System Font"="系统字体";
+"Custom"="自定义";
+
 // Welcome Screen
 "Welcome to CodeEdit"="欢迎使用 CodeEdit";
 "Version %@ (%@)"="版本 %@ (%@)";


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

### Description

Added localizations (zh-Hans) for strings  related to terminal enumerator.

<!--- REQUIRED: Describe what changed in detail -->

### Releated Issue
N/A

<!--- REQUIRED: Tag all related issues (e.g. #23) -->

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):
N/A

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this issue temporarily -->
