### PR TITLE
fabs to abs

### DIFF
--- a/CodeEditModules/Modules/CodeFile/src/LineGutter/LineGutter.swift
+++ b/CodeEditModules/Modules/CodeFile/src/LineGutter/LineGutter.swift
@@ -12,7 +12,7 @@ class LineGutter: NSRulerView {
         didSet {
             DispatchQueue.main.async {
                 let newThickness = self.calculateRuleThickness()
-                if fabs(self.ruleThickness - newThickness) > 1 {
+                if abs(self.ruleThickness - newThickness) > 1 {
                     self.ruleThickness = CGFloat(ceil(newThickness))
                     self.needsDisplay = true
                 }


### PR DESCRIPTION
`fabs` to `abs` to fix Xcode warning

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested