### PR TITLE
Project Navigator: fixed yellow color being low contrast in light mode

### DIFF
--- a/CodeEdit/Assets.xcassets/SidebarYellow.colorset/Contents.json
+++ b/CodeEdit/Assets.xcassets/SidebarYellow.colorset/Contents.json
@@ -1,0 +1,33 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.689",
+          "red" : "0.931"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "platform" : "universal",
+        "reference" : "systemYellowColor"
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -70,7 +70,7 @@ public extension WorkspaceClient {
             case "java":
                 return .red
             case "js", "entitlements", "json", "LICENSE":
-                return .yellow
+                return Color("SidebarYellow")
             case "css", "ts", "jsx", "md", "py":
                 return .blue
             case "sh":


### PR DESCRIPTION
### Description

Increased the contrast of the yellow icon color in project navigator in light mode.
(subtle but noticeable, using same color as Xcode uses for `*.xib` files)

### Releated Issue

* #247 

### Checklist (for drafts):

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):

**Before:**
<img width="210" alt="Screen Shot 2022-03-26 at 12 07 04" src="https://user-images.githubusercontent.com/9460130/160236690-c7fefac9-ac31-4240-91ae-8932b59643c3.png">

**After:**
<img width="242" alt="Screen Shot 2022-03-26 at 12 00 36" src="https://user-images.githubusercontent.com/9460130/160236602-69d03da5-73a4-4d2b-ac95-491e543bd9f1.png">

