### PR TITLE
Use a UUID string as identifier for `NSToolbar`

### DIFF
--- a/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "Highlightr",
-        "repositoryURL": "https://github.com/raspu/Highlightr",
+        "repositoryURL": "https://github.com/raspu/Highlightr.git",
         "state": {
           "branch": null,
           "revision": "93199b9e434f04bda956a613af8f571933f9f037",

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -107,7 +107,7 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
             backing: .buffered, defer: false
         )
         window.center()
-        window.toolbar = NSToolbar()
+        window.toolbar = NSToolbar(identifier: UUID().uuidString)
         window.toolbarStyle = .unifiedCompact
         window.titlebarSeparatorStyle = .line
         window.toolbar?.displayMode = .iconOnly


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->
Using a UUID string as identifier for `NSToolbar`, so it won't mess up toolbar if there are multiple windows.

### Description

<!--- REQUIRED: Describe what changed in detail -->
* Add identifier to `NSToolbar`

### Releated Issue

<!--- REQUIRED: Tag all related issues (e.g. #23) -->
Fixes #236 

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):

<!--- REQUIRED: if issue is UI related -->

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/17158860/160247193-4f9711ca-e2f6-449e-84e1-ebacfc997466.png">

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this issue temporarily -->
