### PR TITLE
Make this projects preferred indent and tab width explicit

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -273,7 +273,9 @@
 				B658FB2D27DA9E0F00EA4DBD /* Products */,
 				5C403B8D27E20F8000788241 /* Frameworks */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		B658FB2D27DA9E0F00EA4DBD /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION

<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

### Description

I personally have set my Xcode default indent and tab width to 2 instead of 4 whitespaces. This breaks the projects style guide and causes SwiftLint warnings to appear while I'm working on this project as this projects requires 4 whitespaces. This PR sets the projects preferred indent and tab width to 4 whitespaces explicitly so I can keep my global indent preference and still get 4 whitespaces whenever I press "tab" while working in this project.

Note that this only sets the setting for the code in the main app, not in the Swift package module (there's no such setting in `Package.swift` manifest file (yet)).

### Releated Issue

https://github.com/CodeEditApp/CodeEdit/issues/278

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] Review requested

