### PR TITLE
Improve sizing behaviour code file view and inspector sidebar splitiview

### DIFF
--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -64,7 +64,7 @@ struct WorkspaceView: View {
             }
             .layoutPriority(1)
             InspectorSidebar(workspace: workspace, windowController: windowController)
-                .frame(minWidth: 150, idealWidth: 200, maxHeight: .infinity)
+                .frame(minWidth: 260, idealWidth: 300, maxHeight: .infinity)
         }
 	}
 }

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -53,18 +53,19 @@ struct WorkspaceView: View {
 		LeadingSidebar(workspace: workspace, windowController: windowController)
 			.frame(minWidth: 250)
 		HSplitView {
-			ZStack {
-				WorkspaceCodeFileView(windowController: windowController,
-									  workspace: workspace)
-			}
-			.safeAreaInset(edge: .bottom) {
-				if let url = workspace.fileURL {
-					StatusBarView(workspaceURL: url)
-				}
-			}
-			InspectorSidebar(workspace: workspace, windowController: windowController)
-				.frame(minWidth: 250, maxWidth: 250, maxHeight: .infinity)
-		}
+            ZStack {
+                WorkspaceCodeFileView(windowController: windowController, workspace: workspace)
+                    .frame(minWidth: 150, maxHeight: .infinity)
+            }
+            .safeAreaInset(edge: .bottom) {
+                if let url = workspace.fileURL {
+                    StatusBarView(workspaceURL: url)
+                }
+            }
+            .layoutPriority(1)
+            InspectorSidebar(workspace: workspace, windowController: windowController)
+                .frame(minWidth: 150, idealWidth: 200, maxHeight: .infinity)
+        }
 	}
 }
 

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -55,7 +55,7 @@ struct WorkspaceView: View {
 		HSplitView {
             ZStack {
                 WorkspaceCodeFileView(windowController: windowController, workspace: workspace)
-                    .frame(minWidth: 150, maxHeight: .infinity)
+                    .frame(minWidth: 500, maxHeight: .infinity)
             }
             .safeAreaInset(edge: .bottom) {
                 if let url = workspace.fileURL {


### PR DESCRIPTION
Sets senible minimum frame widths for the `WorkspaceCodeFileView` and `InspectorSidebar`. Plus sets a `layoutPriority` so the splitview resizes correctly. 

### Description

Before:

https://user-images.githubusercontent.com/11800807/160372411-1dc873ef-5724-4005-8eb7-b73c6939e20f.mov



### Releated Issue

I was trying to fix the following issues however they are either outdated or not reproducable:
- https://github.com/CodeEditApp/CodeEdit/issues/171
- https://github.com/CodeEditApp/CodeEdit/issues/169 


### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):


After:

https://user-images.githubusercontent.com/11800807/160372482-fd70a9ed-8fed-49e8-81ea-5480f760d551.mov
