### PR TITLE
[GitClient] feat: added option to get file commit history

### DIFF
--- a/CodeEditModules/Modules/GitClient/src/Interface.swift
+++ b/CodeEditModules/Modules/GitClient/src/Interface.swift
@@ -12,14 +12,19 @@ public struct GitClient {
     public var getBranches: () throws -> [String]
     public var checkoutBranch: (String) throws -> Void
     public var pull: () throws -> Void
-    public var getCommitHistory: (_ entries: Int?) throws -> [Commit]
+    /// Get commit history
+    /// - Parameters:
+    ///   - entries: number of commits we want to fetch. Will use max if nil
+    ///   - fileLocalPath: specify a local file (e.g. `CodeEditModules/Package.swift`)
+    ///   to retrieve a file commit history. Optional.
+    public var getCommitHistory: (_ entries: Int?, _ fileLocalPath: String?) throws -> [Commit]
 
     init(
         getCurrentBranchName: @escaping () throws -> String,
         getBranches: @escaping () throws -> [String],
         checkoutBranch: @escaping (String) throws -> Void,
         pull: @escaping () throws -> Void,
-        getCommitHistory: @escaping (_ entries: Int?) throws -> [Commit]
+        getCommitHistory: @escaping (_ entries: Int?, _ fileLocalPath: String?) throws -> [Commit]
     ) {
         self.getCurrentBranchName = getCurrentBranchName
         self.getBranches = getBranches

--- a/CodeEditModules/Modules/GitClient/src/Live.swift
+++ b/CodeEditModules/Modules/GitClient/src/Live.swift
@@ -45,14 +45,15 @@ public extension GitClient {
             }
         }
 
-        func getCommitHistory(entries: Int?) throws -> [Commit] {
+        func getCommitHistory(entries: Int?, fileLocalPath: String?) throws -> [Commit] {
             var entriesString = ""
+            let fileLocalPath = fileLocalPath ?? ""
             if let entries = entries { entriesString = "-n \(entries)" }
             let dateFormatter = DateFormatter()
             dateFormatter.locale = Locale.current
             dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
             return try shellClient.run(
-                "cd \(directoryURL.relativePath);git log --pretty=%h¦%s¦%aN¦%aD¦ \(entriesString)"
+                "cd \(directoryURL.relativePath);git log --pretty=%h¦%s¦%aN¦%aD¦ \(fileLocalPath) \(entriesString)"
             )
                 .split(separator: "\n")
                 .map { line -> Commit in
@@ -78,7 +79,7 @@ public extension GitClient {
                     throw GitClientError.notGitRepository
                 }
             },
-            getCommitHistory: getCommitHistory(entries:)
+            getCommitHistory: getCommitHistory(entries:fileLocalPath:)
         )
     }
 }


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

### Description

<!--- REQUIRED: Describe what changed in detail -->
This PR updates the `GitClient` commit history API so it can now get a specified file commit history instead of the more general branch one. I've added a simple documentation for it too!

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this issue temporarily -->
