### PR TITLE
Replace all tabs with 4 spaces + SwiftLint warning for tabs

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,7 +6,15 @@ identifier_name:
   excluded:
     - id
     - vc
-    
+
 opt_in_rules:
   - empty_count
   - contains_over_first_not_nil
+
+custom_rules:
+  spaces_over_tabs:
+    included: ".*\\.swift"
+    name: "Spaces over Tabs"
+    regex: "\t"
+    message: "Prefer spaces for indents over tabs. See Xcode setting: 'Text Editing' -> 'Indentation'"
+    severity: warning

--- a/CodeEdit/Breadcrumbs/BreadcrumbsComponent.swift
+++ b/CodeEdit/Breadcrumbs/BreadcrumbsComponent.swift
@@ -8,29 +8,29 @@
 import SwiftUI
 
 struct BreadcrumbsComponent: View {
-	@AppStorage(FileIconStyle.storageKey)
+    @AppStorage(FileIconStyle.storageKey)
     var iconStyle: FileIconStyle = .default
 
-	private let title: String
-	private let image: String
-	private let color: Color
+    private let title: String
+    private let image: String
+    private let color: Color
 
     init(_ title: String, systemImage image: String, color: Color = .secondary) {
-		self.title = title
-		self.image = image
-		self.color = color
-	}
+        self.title = title
+        self.image = image
+        self.color = color
+    }
 
-	var body: some View {
-		HStack {
-			Image(systemName: image)
-				.resizable()
-				.aspectRatio(contentMode: .fit)
-				.frame(width: 12)
-				.foregroundStyle(iconStyle == .color ? color : .secondary)
-			Text(title)
-				.foregroundStyle(.primary)
-				.font(.system(size: 11))
-		}
-	}
+    var body: some View {
+        HStack {
+            Image(systemName: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 12)
+                .foregroundStyle(iconStyle == .color ? color : .secondary)
+            Text(title)
+                .foregroundStyle(.primary)
+                .font(.system(size: 11))
+        }
+    }
 }

--- a/CodeEdit/Breadcrumbs/BreadcrumbsView.swift
+++ b/CodeEdit/Breadcrumbs/BreadcrumbsView.swift
@@ -31,10 +31,10 @@ struct BreadcrumbsView: View {
         self.workspace = workspace
     }
 
-	var body: some View {
-		ZStack(alignment: .leading) {
-			Rectangle()
-				.foregroundStyle(Color(nsColor: .controlBackgroundColor))
+    var body: some View {
+        ZStack(alignment: .leading) {
+            Rectangle()
+                .foregroundStyle(Color(nsColor: .controlBackgroundColor))
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
                     BreadcrumbsComponent(
@@ -53,48 +53,48 @@ struct BreadcrumbsView: View {
                 }
                 .padding(.horizontal, 12)
             }
-		}
-		.frame(height: 29)
-		.overlay(alignment: .bottom) {
-			Divider()
-		}
-		.onAppear {
+        }
+        .frame(height: 29)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+        .onAppear {
             fileInfo(self.file)
-		}
+        }
         .onChange(of: file) { newFile in
             fileInfo(newFile)
         }
-	}
+    }
 
-	private var chevron: some View {
-		Image(systemName: "chevron.compact.right")
-			.foregroundStyle(.secondary)
-			.imageScale(.large)
-	}
+    private var chevron: some View {
+        Image(systemName: "chevron.compact.right")
+            .foregroundStyle(.secondary)
+            .imageScale(.large)
+    }
 
     private func fileInfo(_ file: WorkspaceClient.FileItem) {
-		guard let projURL = workspace.fileURL else { return }
-		let components = file.url.path
-			.replacingOccurrences(of: projURL.path, with: "")
-			.split(separator: "/")
-			.map { String($0) }
-			.dropLast()
+        guard let projURL = workspace.fileURL else { return }
+        let components = file.url.path
+            .replacingOccurrences(of: projURL.path, with: "")
+            .split(separator: "/")
+            .map { String($0) }
+            .dropLast()
 
-		self.projectName = projURL.lastPathComponent
-		self.folders = Array(components)
-		self.fileName = file.fileName
-		self.fileImage = file.systemImage
-	}
+        self.projectName = projURL.lastPathComponent
+        self.folders = Array(components)
+        self.fileName = file.fileName
+        self.fileImage = file.systemImage
+    }
 }
 
 struct BreadcrumbsView_Previews: PreviewProvider {
-	static var previews: some View {
-		BreadcrumbsView(.init(url: .init(fileURLWithPath: "", isDirectory: false)), workspace: .init())
-			.previewLayout(.fixed(width: 500, height: 29))
-			.preferredColorScheme(.dark)
+    static var previews: some View {
+        BreadcrumbsView(.init(url: .init(fileURLWithPath: "", isDirectory: false)), workspace: .init())
+            .previewLayout(.fixed(width: 500, height: 29))
+            .preferredColorScheme(.dark)
 
-		BreadcrumbsView(.init(url: .init(fileURLWithPath: "", isDirectory: false)), workspace: .init())
-			.previewLayout(.fixed(width: 500, height: 29))
-			.preferredColorScheme(.light)
-	}
+        BreadcrumbsView(.init(url: .init(fileURLWithPath: "", isDirectory: false)), workspace: .init())
+            .previewLayout(.fixed(width: 500, height: 29))
+            .preferredColorScheme(.light)
+    }
 }

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -15,7 +15,7 @@ struct WorkspaceCodeFileView: View {
     @ObservedObject var workspace: WorkspaceDocument
 
     @ViewBuilder
-	var codeView: some View {
+    var codeView: some View {
         if let item = workspace.selectionState.openFileItems.first(where: { file in
             if file.id == workspace.selectionState.selectedId {
                 print("Item loaded is: ", file.url)
@@ -40,7 +40,7 @@ struct WorkspaceCodeFileView: View {
     }
 
     var body: some View {
-		codeView
-			.frame(maxWidth: .infinity, maxHeight: .infinity)
+        codeView
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorSearchBar.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorSearchBar.swift
@@ -50,10 +50,10 @@ struct SearchBar_Previews: PreviewProvider {
     static var previews: some View {
         HStack {
             FindNavigatorSearchBar(
-				state: .init(WorkspaceDocument.init()),
-				title: "placeholder",
-				text: .constant("value")
-			)
+                state: .init(WorkspaceDocument.init()),
+                title: "placeholder",
+                text: .constant("value")
+            )
         }
         .padding()
     }

--- a/CodeEdit/NavigatorSidebar/LeadingSidebar.swift
+++ b/CodeEdit/NavigatorSidebar/LeadingSidebar.swift
@@ -17,23 +17,23 @@ struct LeadingSidebar: View {
     @State
     private var selection: Int = 0
 
-	var body: some View {
-		ZStack {
-			switch selection {
-			case 0:
-				ProjectNavigator(workspace: workspace, windowController: windowController)
-			case 2:
-				FindNavigator(state: workspace.searchState ?? .init(workspace))
-			default:
-				VStack { Spacer() }
-			}
-		}
-		.safeAreaInset(edge: .top) {
-			LeadingSidebarToolbarTop(selection: $selection)
-				.padding(.bottom, -8)
-		}
-		.safeAreaInset(edge: .bottom) {
-			LeadingSidebarToolbarBottom(workspace: workspace)
-		}
-	}
+    var body: some View {
+        ZStack {
+            switch selection {
+            case 0:
+                ProjectNavigator(workspace: workspace, windowController: windowController)
+            case 2:
+                FindNavigator(state: workspace.searchState ?? .init(workspace))
+            default:
+                VStack { Spacer() }
+            }
+        }
+        .safeAreaInset(edge: .top) {
+            LeadingSidebarToolbarTop(selection: $selection)
+                .padding(.bottom, -8)
+        }
+        .safeAreaInset(edge: .bottom) {
+            LeadingSidebarToolbarBottom(workspace: workspace)
+        }
+    }
 }

--- a/CodeEdit/NavigatorSidebar/LeadingSidebarToolbarBottom.swift
+++ b/CodeEdit/NavigatorSidebar/LeadingSidebarToolbarBottom.swift
@@ -8,53 +8,53 @@
 import SwiftUI
 
 struct LeadingSidebarToolbarBottom: View {
-	@Environment(\.controlActiveState)
+    @Environment(\.controlActiveState)
     var activeState
 
-	@ObservedObject
+    @ObservedObject
     var workspace: WorkspaceDocument
 
     var body: some View {
-		HStack(spacing: 10) {
-			addNewFileButton
-			Spacer()
-			sortButton
-		}
-		.frame(height: 32, alignment: .center)
-		.frame(maxWidth: .infinity)
-		.padding(.horizontal, 4)
-		.overlay(alignment: .top) {
-			Divider()
-		}
+        HStack(spacing: 10) {
+            addNewFileButton
+            Spacer()
+            sortButton
+        }
+        .frame(height: 32, alignment: .center)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 4)
+        .overlay(alignment: .top) {
+            Divider()
+        }
     }
 
-	private var addNewFileButton: some View {
-		Menu {
-			Button("Add File") {}
-				.disabled(true)
-			Button("Not implemented yet") {}
-				.disabled(true)
-		} label: {
-			Image(systemName: "plus")
-		}
-		.menuStyle(.borderlessButton)
-		.menuIndicator(.hidden)
-		.frame(maxWidth: 30)
-		.opacity(activeState == .inactive ? 0.45 : 1)
-	}
+    private var addNewFileButton: some View {
+        Menu {
+            Button("Add File") {}
+                .disabled(true)
+            Button("Not implemented yet") {}
+                .disabled(true)
+        } label: {
+            Image(systemName: "plus")
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(maxWidth: 30)
+        .opacity(activeState == .inactive ? 0.45 : 1)
+    }
 
-	private var sortButton: some View {
-		Menu {
-			Button {
-				workspace.sortFoldersOnTop.toggle()
-			} label: {
-				Text(workspace.sortFoldersOnTop ? "Alphabetically" : "Folders on top")
-			}
-		} label: {
-			Image(systemName: "line.3.horizontal.decrease.circle")
-		}
-		.menuStyle(.borderlessButton)
-		.frame(maxWidth: 30)
-		.opacity(activeState == .inactive ? 0.45 : 1)
-	}
+    private var sortButton: some View {
+        Menu {
+            Button {
+                workspace.sortFoldersOnTop.toggle()
+            } label: {
+                Text(workspace.sortFoldersOnTop ? "Alphabetically" : "Folders on top")
+            }
+        } label: {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+        }
+        .menuStyle(.borderlessButton)
+        .frame(maxWidth: 30)
+        .opacity(activeState == .inactive ? 0.45 : 1)
+    }
 }

--- a/CodeEdit/NavigatorSidebar/LeadingSidebarToolbarTop.swift
+++ b/CodeEdit/NavigatorSidebar/LeadingSidebarToolbarTop.swift
@@ -20,40 +20,40 @@ struct LeadingSidebarToolbarTop: View {
             icon(systemImage: "globe", title: "Version Control", id: 1)
             icon(systemImage: "magnifyingglass", title: "Search", id: 2)
             icon(systemImage: "shippingbox", title: "...", id: 3)
-			icon(systemImage: "play", title: "...", id: 4)
-			icon(systemImage: "exclamationmark.triangle", title: "...", id: 5)
-			icon(systemImage: "curlybraces.square", title: "...", id: 6)
-			icon(systemImage: "puzzlepiece.extension", title: "...", id: 7)
-			icon(systemImage: "square.grid.2x2", title: "...", id: 8)
-		}
-		.frame(height: 29, alignment: .center)
-		.frame(maxWidth: .infinity)
-		.overlay(alignment: .top) {
-			Divider()
-		}
-		.overlay(alignment: .bottom) {
-			Divider()
-		}
-	}
+            icon(systemImage: "play", title: "...", id: 4)
+            icon(systemImage: "exclamationmark.triangle", title: "...", id: 5)
+            icon(systemImage: "curlybraces.square", title: "...", id: 6)
+            icon(systemImage: "puzzlepiece.extension", title: "...", id: 7)
+            icon(systemImage: "square.grid.2x2", title: "...", id: 8)
+        }
+        .frame(height: 29, alignment: .center)
+        .frame(maxWidth: .infinity)
+        .overlay(alignment: .top) {
+            Divider()
+        }
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
 
-	func icon(systemImage: String, title: String, id: Int) -> some View {
-		Button {
-			selection = id
-		} label: {
-			Image(systemName: systemImage)
-				.help(title)
-				.symbolVariant(id == selection ? .fill : .none)
-				.foregroundColor(id == selection ? .accentColor : .secondary)
-				.frame(width: 25, height: 25, alignment: .center)
-				.contentShape(Rectangle())
-				.opacity(activeState == .inactive ? 0.45 : 1)
-		}
-		.buttonStyle(.plain)
-	}
+    func icon(systemImage: String, title: String, id: Int) -> some View {
+        Button {
+            selection = id
+        } label: {
+            Image(systemName: systemImage)
+                .help(title)
+                .symbolVariant(id == selection ? .fill : .none)
+                .foregroundColor(id == selection ? .accentColor : .secondary)
+                .frame(width: 25, height: 25, alignment: .center)
+                .contentShape(Rectangle())
+                .opacity(activeState == .inactive ? 0.45 : 1)
+        }
+        .buttonStyle(.plain)
+    }
 }
 
 struct NavigatorSidebarToolbar_Previews: PreviewProvider {
-	static var previews: some View {
+    static var previews: some View {
         LeadingSidebarToolbarTop(selection: .constant(0))
-	}
+    }
 }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/ProjectNavigator.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/ProjectNavigator.swift
@@ -16,45 +16,47 @@ import WorkspaceClient
 /// When selecting a file it will open in the editor.
 ///
 struct ProjectNavigator: View {
-	@ObservedObject var workspace: WorkspaceDocument
-	var windowController: NSWindowController
+    @ObservedObject var workspace: WorkspaceDocument
+    var windowController: NSWindowController
 
-	/// The `ID` of the currently selected file/folder. If none is selected this is `nil`
-	@State
+    /// The `ID` of the currently selected file/folder. If none is selected this is `nil`
+    @State
     private var selection: WorkspaceClient.FileItem.ID?
 
     var body: some View {
-		List(selection: $selection) {
-			Section {
-				ForEach(workspace.selectionState.fileItems.sortItems(foldersOnTop: workspace.sortFoldersOnTop)) { item in
-					ProjectNavigatorItem(
-						item: item,
-						workspace: workspace,
-						windowController: windowController,
-						shouldloadChildren: .constant(true), // First level of children should always be loaded
-						selectedId: $selection
-					)
-				}
-			} header: {
-				Text(projectName)
-					.padding(.vertical, 8)
-			}
-		}
-		.listRowInsets(.init())
-		.onChange(of: selection) { newValue in
-			guard let id = newValue,
-				  let item = try? workspace.workspaceClient?.getFileItem(id),
-				  item.children == nil
-			else { return }
-			workspace.openFile(item: item)
-		}
-		.onChange(of: workspace.selectionState.selectedId) { newValue in
-			selection = newValue
-		}
+        List(selection: $selection) {
+            Section {
+                ForEach(
+                    workspace.selectionState.fileItems.sortItems(foldersOnTop: workspace.sortFoldersOnTop)
+                ) { item in
+                    ProjectNavigatorItem(
+                        item: item,
+                        workspace: workspace,
+                        windowController: windowController,
+                        shouldloadChildren: .constant(true), // First level of children should always be loaded
+                        selectedId: $selection
+                    )
+                }
+            } header: {
+                Text(projectName)
+                    .padding(.vertical, 8)
+            }
+        }
+        .listRowInsets(.init())
+        .onChange(of: selection) { newValue in
+            guard let id = newValue,
+                  let item = try? workspace.workspaceClient?.getFileItem(id),
+                  item.children == nil
+            else { return }
+            workspace.openFile(item: item)
+        }
+        .onChange(of: workspace.selectionState.selectedId) { newValue in
+            selection = newValue
+        }
     }
 
-	/// The name of the project (name of the selected top-level folder)
-	private var projectName: String {
-		workspace.workspaceClient?.folderURL()?.lastPathComponent ?? "Project"
-	}
+    /// The name of the project (name of the selected top-level folder)
+    private var projectName: String {
+        workspace.workspaceClient?.folderURL()?.lastPathComponent ?? "Project"
+    }
 }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/ProjectNavigatorContextMenu.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/ProjectNavigatorContextMenu.swift
@@ -16,130 +16,130 @@ import WorkspaceClient
 ///
 struct ProjectNavigatorContextMenu: View {
 
-	private var item: WorkspaceClient.FileItem
-	private var isFolder: Bool
+    private var item: WorkspaceClient.FileItem
+    private var isFolder: Bool
 
-	init(_ item: WorkspaceClient.FileItem, isFolder: Bool) {
-		self.item = item
-		self.isFolder = isFolder
-	}
-
-	@ViewBuilder
-    var body: some View {
-		showInFinder
-		openSection
-		showFileInspector
-		addSection
-		delete
-		newFolderSection
-		sortSection
-		findInSelectedGroups
-		sourceControl
+    init(_ item: WorkspaceClient.FileItem, isFolder: Bool) {
+        self.item = item
+        self.isFolder = isFolder
     }
 
-	private var showInFinder: some View {
-		Group {
-			Button("Show in Finder") {
-				item.showInFinder()
-			}
-			Divider()
-		}
-	}
+    @ViewBuilder
+    var body: some View {
+        showInFinder
+        openSection
+        showFileInspector
+        addSection
+        delete
+        newFolderSection
+        sortSection
+        findInSelectedGroups
+        sourceControl
+    }
 
-	private var openSection: some View {
-		Group {
-			Button("Open in Tab") {
-				// Open a new tab
-			}
-			Button("Open in New Window") {
-				// Open a new window
-			}
-			Divider()
-		}
-	}
+    private var showInFinder: some View {
+        Group {
+            Button("Show in Finder") {
+                item.showInFinder()
+            }
+            Divider()
+        }
+    }
 
-	private var showFileInspector: some View {
-		Group {
-			Button("Show File Inspector") {
-				// Show File Inspector
-			}
-			Divider()
-		}
-	}
+    private var openSection: some View {
+        Group {
+            Button("Open in Tab") {
+                // Open a new tab
+            }
+            Button("Open in New Window") {
+                // Open a new window
+            }
+            Divider()
+        }
+    }
 
-	private var addSection: some View {
-		Group {
-			Button("New File") {
-				item.addFile(fileName: "randomFile.txt")
-			}
-			Button("Add files to folder") {
-				// Add Files to Folder
-			}
-			Divider()
-		}
-	}
+    private var showFileInspector: some View {
+        Group {
+            Button("Show File Inspector") {
+                // Show File Inspector
+            }
+            Divider()
+        }
+    }
 
-	private var delete: some View {
-		Group {
-			Button("Delete") {
-				item.delete()
-			}
-			Divider()
-		}
-	}
+    private var addSection: some View {
+        Group {
+            Button("New File") {
+                item.addFile(fileName: "randomFile.txt")
+            }
+            Button("Add files to folder") {
+                // Add Files to Folder
+            }
+            Divider()
+        }
+    }
 
-	private var newFolderSection: some View {
-		Group {
-			Button("New Folder") {
-				item.addFolder(folderName: "Test Folder")
-			}
-			Button("New Folder from Selection") {
-				// New Group from Selection
-			}
-			Divider()
-		}
-	}
+    private var delete: some View {
+        Group {
+            Button("Delete") {
+                item.delete()
+            }
+            Divider()
+        }
+    }
 
-	private var sortSection: some View {
-		Group {
-			Button("Sort by Name") {
-				// Sort folder items by name
-			}
-			.disabled(!isFolder)
-			Button("Sort by Type") {
-				// Sort folder items by file type
-			}
-			.disabled(!isFolder)
-			Divider()
-		}
-	}
+    private var newFolderSection: some View {
+        Group {
+            Button("New Folder") {
+                item.addFolder(folderName: "Test Folder")
+            }
+            Button("New Folder from Selection") {
+                // New Group from Selection
+            }
+            Divider()
+        }
+    }
 
-	private var findInSelectedGroups: some View {
-		Group {
-			Button("Find in Selected Groups...") {
-				// Find in selected groups...
-			}
-			.disabled(!isFolder)
-			Divider()
-		}
-	}
+    private var sortSection: some View {
+        Group {
+            Button("Sort by Name") {
+                // Sort folder items by name
+            }
+            .disabled(!isFolder)
+            Button("Sort by Type") {
+                // Sort folder items by file type
+            }
+            .disabled(!isFolder)
+            Divider()
+        }
+    }
 
-	private var sourceControl: some View {
-		Menu("Source Control") {
-			Button("Commit Selected File") {
-				// Commit selected file
-			}
-			Divider()
-			Button("Discard Changes in Selected File") {
-				// Discard changes made to the selected file
-			}
-			Divider()
-			Button("Add") {
-				// Add file to git
-			}
-			Button("Mark as Resolved") {
-				// Mark file as resolved
-			}
-		}
-	}
+    private var findInSelectedGroups: some View {
+        Group {
+            Button("Find in Selected Groups...") {
+                // Find in selected groups...
+            }
+            .disabled(!isFolder)
+            Divider()
+        }
+    }
+
+    private var sourceControl: some View {
+        Menu("Source Control") {
+            Button("Commit Selected File") {
+                // Commit selected file
+            }
+            Divider()
+            Button("Discard Changes in Selected File") {
+                // Discard changes made to the selected file
+            }
+            Divider()
+            Button("Add") {
+                // Add file to git
+            }
+            Button("Mark as Resolved") {
+                // Mark file as resolved
+            }
+        }
+    }
 }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/ProjectNavigatorItem.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/ProjectNavigatorItem.swift
@@ -15,83 +15,83 @@ import CodeFile
 /// Displays a File or Folder in the ``ProjectNavigator``.
 ///
 struct ProjectNavigatorItem: View {
-	@AppStorage(FileIconStyle.storageKey)
+    @AppStorage(FileIconStyle.storageKey)
     var iconStyle: FileIconStyle = .default
 
-	/// The `FileItem` for this view
-	var item: WorkspaceClient.FileItem
+    /// The `FileItem` for this view
+    var item: WorkspaceClient.FileItem
 
-	/// The current ``WorkspaceDocument``
-	@ObservedObject
+    /// The current ``WorkspaceDocument``
+    @ObservedObject
     var workspace: WorkspaceDocument
 
-	/// The current `NSWindowController`
-	var windowController: NSWindowController
+    /// The current `NSWindowController`
+    var windowController: NSWindowController
 
-	/// If ``item`` is a folder, load one level of children if expanded
-	/// This fixes animation glitches when unfolding a folder while
-	/// maintaining performance.
-	///
-	/// This will be set to true once a parent folder expands
-	@Binding
+    /// If ``item`` is a folder, load one level of children if expanded
+    /// This fixes animation glitches when unfolding a folder while
+    /// maintaining performance.
+    ///
+    /// This will be set to true once a parent folder expands
+    @Binding
     var shouldloadChildren: Bool
 
-	/// The current selected ``item`` in the list
-	@Binding
+    /// The current selected ``item`` in the list
+    @Binding
     var selectedId: WorkspaceClient.FileItem.ID?
 
-	/// Tracks the `DisclosureGroup`s `isExpanded` property in order
-	/// to set ``shouldloadChildren`` for its child items
-	@State
+    /// Tracks the `DisclosureGroup`s `isExpanded` property in order
+    /// to set ``shouldloadChildren`` for its child items
+    @State
     private var isExpanded: Bool = false
 
-	var body: some View {
-		if item.children == nil {
-			sidebarFileItem(item)
-				.id(item)
-		} else {
-			sidebarFolderItem(item)
-				.id(item.id)
-		}
-	}
+    var body: some View {
+        if item.children == nil {
+            sidebarFileItem(item)
+                .id(item)
+        } else {
+            sidebarFolderItem(item)
+                .id(item.id)
+        }
+    }
 
-	/// A `Label` representing a file
-	private func sidebarFileItem(_ item: WorkspaceClient.FileItem) -> some View {
-		Label(item.url.lastPathComponent, systemImage: item.systemImage)
-			.accentColor(iconColor)
-			.contextMenu {
-				ProjectNavigatorContextMenu(item, isFolder: false)
-			}
-	}
+    /// A `Label` representing a file
+    private func sidebarFileItem(_ item: WorkspaceClient.FileItem) -> some View {
+        Label(item.url.lastPathComponent, systemImage: item.systemImage)
+            .accentColor(iconColor)
+            .contextMenu {
+                ProjectNavigatorContextMenu(item, isFolder: false)
+            }
+    }
 
-	/// A `DisclosureGroup` representing a folder.
-	///
-	/// When expanded, it shows files/folders inside
-	@ViewBuilder
-	private func sidebarFolderItem(_ item: WorkspaceClient.FileItem) -> some View {
-		DisclosureGroup(isExpanded: $isExpanded) {
-			if shouldloadChildren { // Only load when parent is expanded -> Improves performance massively
-				ForEach(item.children!.sortItems(foldersOnTop: workspace.sortFoldersOnTop)) { child in
-					ProjectNavigatorItem(
-						item: child,
-						workspace: workspace,
-						windowController: windowController,
-						shouldloadChildren: $isExpanded,
-						selectedId: $selectedId
-					)
-				}
-			}
-		} label: {
-			Label(item.url.lastPathComponent, systemImage: item.systemImage)
-				.accentColor(.secondary)
-				.contextMenu {
-					ProjectNavigatorContextMenu(item, isFolder: true)
-				}
-		}
-	}
+    /// A `DisclosureGroup` representing a folder.
+    ///
+    /// When expanded, it shows files/folders inside
+    @ViewBuilder
+    private func sidebarFolderItem(_ item: WorkspaceClient.FileItem) -> some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            if shouldloadChildren { // Only load when parent is expanded -> Improves performance massively
+                ForEach(item.children!.sortItems(foldersOnTop: workspace.sortFoldersOnTop)) { child in
+                    ProjectNavigatorItem(
+                        item: child,
+                        workspace: workspace,
+                        windowController: windowController,
+                        shouldloadChildren: $isExpanded,
+                        selectedId: $selectedId
+                    )
+                }
+            }
+        } label: {
+            Label(item.url.lastPathComponent, systemImage: item.systemImage)
+                .accentColor(.secondary)
+                .contextMenu {
+                    ProjectNavigatorContextMenu(item, isFolder: true)
+                }
+        }
+    }
 
-	/// Returns a color depending on the set icon color style in preferences
-	private var iconColor: Color {
-		return iconStyle == .color ? item.iconColor : .secondary
-	}
+    /// Returns a color depending on the set icon color style in preferences
+    private var iconColor: Color {
+        return iconStyle == .color ? item.iconColor : .secondary
+    }
 }

--- a/CodeEdit/Settings/GeneralSettingsView.swift
+++ b/CodeEdit/Settings/GeneralSettingsView.swift
@@ -28,51 +28,51 @@ struct GeneralSettingsView: View {
 
     var body: some View {
         Form {
-			Picker("Appearance".localized(), selection: $appearance) {
-				Text("System".localized())
+            Picker("Appearance".localized(), selection: $appearance) {
+                Text("System".localized())
                     .tag(Appearances.system)
                 Divider()
-				Text("Light".localized())
+                Text("Light".localized())
                     .tag(Appearances.light)
-				Text("Dark".localized())
+                Text("Dark".localized())
                     .tag(Appearances.dark)
             }
             .onChange(of: appearance) { tag in
                 tag.applyAppearance()
             }
 
-			Picker("File Icon Style".localized(), selection: $fileIconStyle) {
-				Text("Color".localized())
-					.tag(FileIconStyle.color)
-				Text("Monochrome".localized())
-					.tag(FileIconStyle.monochrome)
-			}
+            Picker("File Icon Style".localized(), selection: $fileIconStyle) {
+                Text("Color".localized())
+                    .tag(FileIconStyle.color)
+                Text("Monochrome".localized())
+                    .tag(FileIconStyle.monochrome)
+            }
 
-			Picker("Reopen Behavior".localized(), selection: $reopenBehavior) {
+            Picker("Reopen Behavior".localized(), selection: $reopenBehavior) {
                 Text("Welcome Screen".localized())
                     .tag(ReopenBehavior.welcome)
                 Divider()
-				Text("Open Panel".localized())
+                Text("Open Panel".localized())
                     .tag(ReopenBehavior.openPanel)
-				Text("New Document".localized())
+                Text("New Document".localized())
                     .tag(ReopenBehavior.newDocument)
             }
 
-			Picker("Editor Theme".localized(), selection: $editorTheme) {
-				Text("Atelier Savanna (Auto)")
+            Picker("Editor Theme".localized(), selection: $editorTheme) {
+                Text("Atelier Savanna (Auto)")
                     .tag(CodeFileView.Theme.atelierSavannaAuto)
-				Text("Atelier Savanna Dark")
+                Text("Atelier Savanna Dark")
                     .tag(CodeFileView.Theme.atelierSavannaDark)
-				Text("Atelier Savanna Light")
+                Text("Atelier Savanna Light")
                     .tag(CodeFileView.Theme.atelierSavannaLight)
-				// TODO: Pojoaque does not seem to work (does not change from previous selection)
-//				Text("Pojoaque")
-//					.tag(CodeEditor.ThemeName.pojoaque)
-				Text("Agate")
-					.tag(CodeFileView.Theme.agate)
-				Text("Ocean")
-					.tag(CodeFileView.Theme.ocean)
-			}
+                // TODO: Pojoaque does not seem to work (does not change from previous selection)
+//                Text("Pojoaque")
+//                    .tag(CodeEditor.ThemeName.pojoaque)
+                Text("Agate")
+                    .tag(CodeFileView.Theme.agate)
+                Text("Ocean")
+                    .tag(CodeFileView.Theme.ocean)
+            }
 
             HStack {
                 Stepper("Default Tab Width".localized(), value: $defaultTabWidth, in: 2...8)

--- a/CodeEdit/Settings/Models/FileIconStyle.swift
+++ b/CodeEdit/Settings/Models/FileIconStyle.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 enum FileIconStyle: String, CaseIterable, Hashable {
-	case color
-	case monochrome
+    case color
+    case monochrome
 
-	static let `default` = FileIconStyle.color
-	static let storageKey = "fileIconStyle"
+    static let `default` = FileIconStyle.color
+    static let storageKey = "fileIconStyle"
 }

--- a/CodeEdit/Settings/SettingsView.swift
+++ b/CodeEdit/Settings/SettingsView.swift
@@ -12,15 +12,15 @@ struct SettingsView: View {
         TabView {
             GeneralSettingsView()
                 .tabItem {
-					Label("General".localized(), systemImage: "gearshape")
+                    Label("General".localized(), systemImage: "gearshape")
                 }
-			TerminalSettingsView()
-				.tabItem {
-					Label("Terminal".localized(), systemImage: "chevron.left.forwardslash.chevron.right")
-				}
+            TerminalSettingsView()
+                .tabItem {
+                    Label("Terminal".localized(), systemImage: "chevron.left.forwardslash.chevron.right")
+                }
         }
         .padding()
-		.frame(width: 600, height: 300)
+        .frame(width: 600, height: 300)
     }
 }
 

--- a/CodeEdit/Settings/TerminalSettingsView.swift
+++ b/CodeEdit/Settings/TerminalSettingsView.swift
@@ -29,77 +29,81 @@ struct TerminalSettingsView: View {
     private var colors = AnsiColors.shared
 
     var body: some View {
-		Form {
-			Picker("Terminal Shell".localized(), selection: $shellType) {
-				Text("System Default".localized())
-					.tag(TerminalShellType.auto)
-				Divider()
-				Text("ZSH")
-					.tag(TerminalShellType.zsh)
-				Text("Bash")
-					.tag(TerminalShellType.bash)
-			}
+        Form {
+            Picker("Terminal Shell".localized(), selection: $shellType) {
+                Text("System Default".localized())
+                    .tag(TerminalShellType.auto)
+                Divider()
+                Text("ZSH")
+                    .tag(TerminalShellType.zsh)
+                Text("Bash")
+                    .tag(TerminalShellType.bash)
+            }
 
-			Picker("Terminal Appearance", selection: $terminalColorSchmeme) {
-				Text("App Default")
-					.tag(TerminalColorScheme.auto)
-				Divider()
-				Text("Light")
-					.tag(TerminalColorScheme.light)
-				Text("Dark")
-					.tag(TerminalColorScheme.dark)
-			}
+            Picker("Terminal Appearance", selection: $terminalColorSchmeme) {
+                Text("App Default")
+                    .tag(TerminalColorScheme.auto)
+                Divider()
+                Text("Light")
+                    .tag(TerminalColorScheme.light)
+                Text("Dark")
+                    .tag(TerminalColorScheme.dark)
+            }
 
-			Picker("Terminal Font".localized(), selection: $terminalFontSelection) {
-				Text("System Font".localized())
-					.tag(TerminalFont.systemFont)
-				Divider()
-				Text("Custom".localized())
-					.tag(TerminalFont.custom)
-			}
-			if terminalFontSelection == .custom {
-				HStack {
-					FontPicker("\(terminalFontName) \(terminalFontSize)", name: $terminalFontName, size: $terminalFontSize)
-				}
-			}
-			Divider()
-			Section {
-				VStack(alignment: .leading, spacing: 0) {
-					HStack(spacing: 0) {
+            Picker("Terminal Font".localized(), selection: $terminalFontSelection) {
+                Text("System Font".localized())
+                    .tag(TerminalFont.systemFont)
+                Divider()
+                Text("Custom".localized())
+                    .tag(TerminalFont.custom)
+            }
+            if terminalFontSelection == .custom {
+                HStack {
+                    FontPicker(
+                        "\(terminalFontName) \(terminalFontSize)",
+                        name: $terminalFontName,
+                        size: $terminalFontSize
+                    )
+                }
+            }
+            Divider()
+            Section {
+                VStack(alignment: .leading, spacing: 0) {
+                    HStack(spacing: 0) {
                         ansiColorPicker($colors.colors[0])
-						ansiColorPicker($colors.colors[1])
-						ansiColorPicker($colors.colors[2])
-						ansiColorPicker($colors.colors[3])
-						ansiColorPicker($colors.colors[4])
-						ansiColorPicker($colors.colors[5])
-						ansiColorPicker($colors.colors[6])
-						ansiColorPicker($colors.colors[7])
-						Text("Normal").padding(.leading, 4)
-					}
-					HStack(spacing: 0) {
-						ansiColorPicker($colors.colors[8])
-						ansiColorPicker($colors.colors[9])
-						ansiColorPicker($colors.colors[10])
-						ansiColorPicker($colors.colors[11])
-						ansiColorPicker($colors.colors[12])
-						ansiColorPicker($colors.colors[13])
-						ansiColorPicker($colors.colors[14])
-						ansiColorPicker($colors.colors[15])
-						Text("Bright").padding(.leading, 4)
-					}
-				}
-			}
-			Button("Restore Defaults") {
-				AnsiColors.shared.resetDefault()
-			}
-		}
-		.padding()
+                        ansiColorPicker($colors.colors[1])
+                        ansiColorPicker($colors.colors[2])
+                        ansiColorPicker($colors.colors[3])
+                        ansiColorPicker($colors.colors[4])
+                        ansiColorPicker($colors.colors[5])
+                        ansiColorPicker($colors.colors[6])
+                        ansiColorPicker($colors.colors[7])
+                        Text("Normal").padding(.leading, 4)
+                    }
+                    HStack(spacing: 0) {
+                        ansiColorPicker($colors.colors[8])
+                        ansiColorPicker($colors.colors[9])
+                        ansiColorPicker($colors.colors[10])
+                        ansiColorPicker($colors.colors[11])
+                        ansiColorPicker($colors.colors[12])
+                        ansiColorPicker($colors.colors[13])
+                        ansiColorPicker($colors.colors[14])
+                        ansiColorPicker($colors.colors[15])
+                        Text("Bright").padding(.leading, 4)
+                    }
+                }
+            }
+            Button("Restore Defaults") {
+                AnsiColors.shared.resetDefault()
+            }
+        }
+        .padding()
     }
 
-	private func ansiColorPicker(_ color: Binding<Color>) -> some View {
-		ColorPicker(selection: color, supportsOpacity: false) { }
-			.labelsHidden()
-	}
+    private func ansiColorPicker(_ color: Binding<Color>) -> some View {
+        ColorPicker(selection: color, supportsOpacity: false) { }
+            .labelsHidden()
+    }
 }
 
 struct TerminalSettingsView_Previews: PreviewProvider {

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -37,7 +37,7 @@ struct WorkspaceView: View {
     var body: some View {
         NavigationView {
             if workspace.workspaceClient != nil {
-				content
+                content
             } else {
                 EmptyView()
             }
@@ -56,11 +56,11 @@ struct WorkspaceView: View {
         }
     }
 
-	@ViewBuilder
-	private var content: some View {
-		LeadingSidebar(workspace: workspace, windowController: windowController)
-			.frame(minWidth: 250)
-		HSplitView {
+    @ViewBuilder
+    private var content: some View {
+        LeadingSidebar(workspace: workspace, windowController: windowController)
+            .frame(minWidth: 250)
+        HSplitView {
             ZStack {
                 WorkspaceCodeFileView(windowController: windowController, workspace: workspace)
                     .frame(minWidth: 500, maxHeight: .infinity)
@@ -74,7 +74,7 @@ struct WorkspaceView: View {
             InspectorSidebar(workspace: workspace, windowController: windowController)
                 .frame(minWidth: 260, idealWidth: 300, maxHeight: .infinity)
         }
-	}
+    }
 }
 
 struct WorkspaceView_Previews: PreviewProvider {

--- a/CodeEditModules/Modules/FontPicker/src/FontPickerView.swift
+++ b/CodeEditModules/Modules/FontPicker/src/FontPickerView.swift
@@ -8,16 +8,16 @@
 import SwiftUI
 
 class FontPickerDelegate {
-	var parent: FontPicker
+    var parent: FontPicker
 
-	init(_ parent: FontPicker) {
-		self.parent = parent
-	}
+    init(_ parent: FontPicker) {
+        self.parent = parent
+    }
 
-	@objc
-	func changeFont(_ id: Any) {
-		parent.fontSelected()
-	}
+    @objc
+    func changeFont(_ id: Any) {
+        parent.fontSelected()
+    }
 
 }
 
@@ -43,44 +43,44 @@ public struct FontPicker: View {
         }
     }
 
-	public init(_ label: String, name: Binding<String>, size: Binding<Int>) {
-		self.labelString = label
-		self._fontName = name
-		self._fontSize = size
-	}
+    public init(_ label: String, name: Binding<String>, size: Binding<Int>) {
+        self.labelString = label
+        self._fontName = name
+        self._fontSize = size
+    }
 
-	public var body: some View {
-		HStack {
-			Text(labelString)
-				.lineLimit(1)
-				.truncationMode(.middle)
+    public var body: some View {
+        HStack {
+            Text(labelString)
+                .lineLimit(1)
+                .truncationMode(.middle)
 
-			Button {
-				if NSFontPanel.shared.isVisible {
-					NSFontPanel.shared.orderOut(nil)
-					return
-				}
+            Button {
+                if NSFontPanel.shared.isVisible {
+                    NSFontPanel.shared.orderOut(nil)
+                    return
+                }
 
-				self.fontPickerDelegate = FontPickerDelegate(self)
-				NSFontManager.shared.target = self.fontPickerDelegate
-				NSFontPanel.shared.setPanelFont(self.font, isMultiple: false)
-				NSFontPanel.shared.orderBack(nil)
-			} label: {
-				Image(systemName: "textformat")
-					.imageScale(.large)
-			}
-			.fixedSize()
-		}
-	}
+                self.fontPickerDelegate = FontPickerDelegate(self)
+                NSFontManager.shared.target = self.fontPickerDelegate
+                NSFontPanel.shared.setPanelFont(self.font, isMultiple: false)
+                NSFontPanel.shared.orderBack(nil)
+            } label: {
+                Image(systemName: "textformat")
+                    .imageScale(.large)
+            }
+            .fixedSize()
+        }
+    }
 
-	mutating
-	func fontSelected() {
-		self.font = NSFontPanel.shared.convert(self.font)
-	}
+    mutating
+    func fontSelected() {
+        self.font = NSFontPanel.shared.convert(self.font)
+    }
 }
 
 struct FontPicker_Previews: PreviewProvider {
-	static var previews: some View {
-		FontPicker("font", name: .constant("Test"), size: .constant(11))
-	}
+    static var previews: some View {
+        FontPicker("font", name: .constant("Test"), size: .constant(11))
+    }
 }

--- a/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
+++ b/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
@@ -13,41 +13,41 @@ import SwiftUI
 /// A model class to host and manage data for the ``StatusBarView``
 ///
 public class StatusBarModel: ObservableObject {
-	// TODO: Implement logic for updating values
-	/// Returns number of errors during comilation
-	@Published
+    // TODO: Implement logic for updating values
+    /// Returns number of errors during comilation
+    @Published
     public var errorCount: Int = 0 // Implementation missing
 
-	/// Returns number of warnings during comilation
-	@Published
+    /// Returns number of warnings during comilation
+    @Published
     public var warningCount: Int = 0 // Implementation missing
 
-	/// The selected branch from the GitClient
-	@Published
+    /// The selected branch from the GitClient
+    @Published
     public var selectedBranch: String?
 
-	/// State of pulling from git
-	@Published
+    /// State of pulling from git
+    @Published
     public var isReloading: Bool = false // Implementation missing
 
-	/// Returns the current line of the cursor in an editing view
-	@Published
+    /// Returns the current line of the cursor in an editing view
+    @Published
     public var currentLine: Int = 1 // Implementation missing
 
-	/// Returns the current column of the cursor in an editing view
-	@Published
+    /// Returns the current column of the cursor in an editing view
+    @Published
     public var currentCol: Int = 1 // Implementation missing
 
-	/// Returns true when the drawer is visible
-	@Published
+    /// Returns true when the drawer is visible
+    @Published
     public var isExpanded: Bool = false
 
-	/// The current height of the drawer. Zero if hidden
-	@Published
+    /// The current height of the drawer. Zero if hidden
+    @Published
     public var currentHeight: Double = 0
 
-	/// Indicates whether the drawer is beeing resized or not
-	@Published
+    /// Indicates whether the drawer is beeing resized or not
+    @Published
     public var isDragging: Bool = false
 
     /// Returns the font for status bar items to use

--- a/CodeEditModules/Modules/StatusBar/src/Model/View+isHovering.swift
+++ b/CodeEditModules/Modules/StatusBar/src/Model/View+isHovering.swift
@@ -9,17 +9,17 @@ import SwiftUI
 
 internal extension View {
 
-	/// Changes the cursor appearance when hovering attached View
-	/// - Parameters:
-	///   - active: onHover() value
-	///   - isDragging: indicate that dragging is happening. If true this will not change the cursor.
-	///   - cursor: the cursor to display on hover
-	func isHovering(_ active: Bool, isDragging: Bool = false, cursor: NSCursor = .arrow) {
-		if isDragging { return }
-		if active {
-			cursor.push()
-		} else {
-			NSCursor.pop()
-		}
-	}
+    /// Changes the cursor appearance when hovering attached View
+    /// - Parameters:
+    ///   - active: onHover() value
+    ///   - isDragging: indicate that dragging is happening. If true this will not change the cursor.
+    ///   - cursor: the cursor to display on hover
+    func isHovering(_ active: Bool, isDragging: Bool = false, cursor: NSCursor = .arrow) {
+        if isDragging { return }
+        if active {
+            cursor.push()
+        } else {
+            NSCursor.pop()
+        }
+    }
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
@@ -19,95 +19,99 @@ import GitClient
 ///
 @available(macOS 12, *)
 public struct StatusBarView: View {
-	@ObservedObject
+    @ObservedObject
     private var model: StatusBarModel
 
-	/// Initialize with GitClient
-	/// - Parameter gitClient: a GitClient
-	public init(workspaceURL: URL) {
-		self.model = .shared ?? .init(workspaceURL: workspaceURL)
-	}
+    /// Initialize with GitClient
+    /// - Parameter gitClient: a GitClient
+    public init(workspaceURL: URL) {
+        self.model = .shared ?? .init(workspaceURL: workspaceURL)
+    }
 
-	public var body: some View {
-		VStack(spacing: 0) {
-			bar
-			if model.isExpanded {
-				StatusBarDrawer(model: model)
-					.transition(.move(edge: .bottom))
-			}
-		}
-		// removes weird light gray bar above when in light mode
-		.padding(.top, -8) // (comment out to make it look normal in preview)
-	}
+    public var body: some View {
+        VStack(spacing: 0) {
+            bar
+            if model.isExpanded {
+                StatusBarDrawer(model: model)
+                    .transition(.move(edge: .bottom))
+            }
+        }
+        // removes weird light gray bar above when in light mode
+        .padding(.top, -8) // (comment out to make it look normal in preview)
+    }
 
-	/// The actual status bar
-	private var bar: some View {
-		ZStack {
-			Rectangle()
-				.foregroundStyle(.bar)
-			HStack(spacing: 15) {
-				HStack(spacing: 5) {
-					StatusBarLabelButton(model: model, title: model.errorCount.formatted(), image: "xmark.octagon")
-					StatusBarLabelButton(model: model, title: model.warningCount.formatted(), image: "exclamationmark.triangle")
-				}
-				if model.selectedBranch != nil {
-					StatusBarBranchPicker(model: model)
-					StatusBarPullButton(model: model)
-				}
-				Spacer()
-				StatusBarCursorLocationLabel(model: model)
-				StatusBarIndentSelector(model: model)
-				StatusBarEncodingSelector(model: model)
-				StatusBarLineEndSelector(model: model)
-				StatusBarToggleDrawerButton(model: model)
-			}
-			.padding(.horizontal, 10)
-		}
-		.overlay(alignment: .top) {
-			Divider()
-		}
-		.overlay(alignment: .bottom) {
-			if model.isExpanded {
-				Divider()
-			}
-		}
-		.frame(height: 32)
-		.gesture(dragGesture)
-		.onHover { isHovering($0, isDragging: model.isDragging, cursor: .resizeUpDown) }
-	}
+    /// The actual status bar
+    private var bar: some View {
+        ZStack {
+            Rectangle()
+                .foregroundStyle(.bar)
+            HStack(spacing: 15) {
+                HStack(spacing: 5) {
+                    StatusBarLabelButton(model: model, title: model.errorCount.formatted(), image: "xmark.octagon")
+                    StatusBarLabelButton(
+                        model: model,
+                        title: model.warningCount.formatted(),
+                        image: "exclamationmark.triangle"
+                    )
+                }
+                if model.selectedBranch != nil {
+                    StatusBarBranchPicker(model: model)
+                    StatusBarPullButton(model: model)
+                }
+                Spacer()
+                StatusBarCursorLocationLabel(model: model)
+                StatusBarIndentSelector(model: model)
+                StatusBarEncodingSelector(model: model)
+                StatusBarLineEndSelector(model: model)
+                StatusBarToggleDrawerButton(model: model)
+            }
+            .padding(.horizontal, 10)
+        }
+        .overlay(alignment: .top) {
+            Divider()
+        }
+        .overlay(alignment: .bottom) {
+            if model.isExpanded {
+                Divider()
+            }
+        }
+        .frame(height: 32)
+        .gesture(dragGesture)
+        .onHover { isHovering($0, isDragging: model.isDragging, cursor: .resizeUpDown) }
+    }
 
-	/// A drag gesture to resize the drawer beneath the status bar
-	private var dragGesture: some Gesture {
-		DragGesture()
-			.onChanged { value in
-				model.isDragging = true
-				var newHeight = max(0, min(model.currentHeight - value.translation.height, 500))
-				if newHeight-0.5 > model.currentHeight || newHeight+0.5 < model.currentHeight {
-					if newHeight < model.minHeight { // simulate the snapping/resistance after reaching minimal height
-						if newHeight > model.minHeight / 2 {
-							newHeight = model.minHeight
-						} else {
-							newHeight = 0
-						}
-					}
-					model.currentHeight = newHeight
-				}
-				model.isExpanded = model.currentHeight < 1 ? false : true
-			}
-			.onEnded { _ in
-				model.isDragging = false
-			}
-	}
+    /// A drag gesture to resize the drawer beneath the status bar
+    private var dragGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                model.isDragging = true
+                var newHeight = max(0, min(model.currentHeight - value.translation.height, 500))
+                if newHeight-0.5 > model.currentHeight || newHeight+0.5 < model.currentHeight {
+                    if newHeight < model.minHeight { // simulate the snapping/resistance after reaching minimal height
+                        if newHeight > model.minHeight / 2 {
+                            newHeight = model.minHeight
+                        } else {
+                            newHeight = 0
+                        }
+                    }
+                    model.currentHeight = newHeight
+                }
+                model.isExpanded = model.currentHeight < 1 ? false : true
+            }
+            .onEnded { _ in
+                model.isDragging = false
+            }
+    }
 }
 
 @available(macOS 12, *)
 struct SwiftUIView_Previews: PreviewProvider {
-	static var previews: some View {
-		ZStack(alignment: .bottom) {
-			Color.white
-			StatusBarView(workspaceURL: URL(fileURLWithPath: ""))
-				.previewLayout(.fixed(width: 1.336, height: 500.0))
-				.preferredColorScheme(.light)
-		}
-	}
+    static var previews: some View {
+        ZStack(alignment: .bottom) {
+            Color.white
+            StatusBarView(workspaceURL: URL(fileURLWithPath: ""))
+                .previewLayout(.fixed(width: 1.336, height: 500.0))
+                .preferredColorScheme(.light)
+        }
+    }
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarBranchPicker.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarBranchPicker.swift
@@ -9,12 +9,12 @@ import GitClient
 import SwiftUI
 
 internal struct StatusBarBranchPicker: View {
-	@ObservedObject
+    @ObservedObject
     private var model: StatusBarModel
 
-	internal init(model: StatusBarModel) {
-		self.model = model
-	}
+    internal init(model: StatusBarModel) {
+        self.model = model
+    }
 
     internal var body: some View {
         Menu {

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarCursorLocationLabel.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarCursorLocationLabel.swift
@@ -12,15 +12,15 @@ internal struct StatusBarCursorLocationLabel: View {
     @ObservedObject
     private var model: StatusBarModel
 
-	internal init(model: StatusBarModel) {
-		self.model = model
-	}
+    internal init(model: StatusBarModel) {
+        self.model = model
+    }
 
-	internal var body: some View {
-		Text("Ln \(model.currentLine), Col \(model.currentCol)")
-			.font(model.toolbarFont)
-			.foregroundStyle(.primary)
-			.lineLimit(1)
-			.onHover { isHovering($0) }
-	}
+    internal var body: some View {
+        Text("Ln \(model.currentLine), Col \(model.currentCol)")
+            .font(model.toolbarFont)
+            .foregroundStyle(.primary)
+            .lineLimit(1)
+            .onHover { isHovering($0) }
+    }
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarDrawer.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarDrawer.swift
@@ -9,17 +9,17 @@ import SwiftUI
 import TerminalEmulator
 
 internal struct StatusBarDrawer: View {
-	@ObservedObject
+    @ObservedObject
     private var model: StatusBarModel
 
-	internal init(model: StatusBarModel) {
-		self.model = model
-	}
+    internal init(model: StatusBarModel) {
+        self.model = model
+    }
 
-	internal var body: some View {
-		TerminalEmulatorView(url: model.workspaceURL)
-			.frame(minHeight: 0,
-				   idealHeight: model.isExpanded ? model.currentHeight : 0,
-				   maxHeight: model.isExpanded ? model.currentHeight : 0)
-	}
+    internal var body: some View {
+        TerminalEmulatorView(url: model.workspaceURL)
+            .frame(minHeight: 0,
+                   idealHeight: model.isExpanded ? model.currentHeight : 0,
+                   maxHeight: model.isExpanded ? model.currentHeight : 0)
+    }
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarEncodingSelector.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarEncodingSelector.swift
@@ -9,22 +9,22 @@ import SwiftUI
 
 @available(macOS 12, *)
 internal struct StatusBarEncodingSelector: View {
-	@ObservedObject
+    @ObservedObject
     private var model: StatusBarModel
 
-	internal init(model: StatusBarModel) {
-		self.model = model
-	}
+    internal init(model: StatusBarModel) {
+        self.model = model
+    }
 
-	internal var body: some View {
-		Menu {
-			// UTF 8, ASCII, ...
-		} label: {
-			Text("UTF 8")
-				.font(model.toolbarFont)
-		}
-		.menuStyle(.borderlessButton)
-		.fixedSize()
-		.onHover { isHovering($0) }
-	}
+    internal var body: some View {
+        Menu {
+            // UTF 8, ASCII, ...
+        } label: {
+            Text("UTF 8")
+                .font(model.toolbarFont)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .onHover { isHovering($0) }
+    }
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarIndentSelector.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarIndentSelector.swift
@@ -9,22 +9,22 @@ import SwiftUI
 
 @available(macOS 12, *)
 internal struct StatusBarIndentSelector: View {
-	@ObservedObject
+    @ObservedObject
     private var model: StatusBarModel
 
-	internal init(model: StatusBarModel) {
-		self.model = model
-	}
+    internal init(model: StatusBarModel) {
+        self.model = model
+    }
 
-	internal var body: some View {
-		Menu {
-			// 2 spaces, 4 spaces, ...
-		} label: {
-			Text("2 Spaces")
-				.font(model.toolbarFont)
-		}
-		.menuStyle(.borderlessButton)
-		.fixedSize()
-		.onHover { isHovering($0) }
-	}
+    internal var body: some View {
+        Menu {
+            // 2 spaces, 4 spaces, ...
+        } label: {
+            Text("2 Spaces")
+                .font(model.toolbarFont)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .onHover { isHovering($0) }
+    }
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarLabelButton.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarLabelButton.swift
@@ -9,32 +9,32 @@ import SwiftUI
 
 @available(macOS 12, *)
 internal struct StatusBarLabelButton: View {
-	@ObservedObject
+    @ObservedObject
     private var model: StatusBarModel
 
-	private var title: String
-	private var image: String
+    private var title: String
+    private var image: String
 
-	internal init(model: StatusBarModel, title: String, image: String) {
-		self.model = model
-		self.title = title
-		self.image = image
-	}
+    internal init(model: StatusBarModel, title: String, image: String) {
+        self.model = model
+        self.title = title
+        self.image = image
+    }
 
-	internal var body: some View {
-		Button {
-			// show errors/warnings
-		} label: {
-			HStack(spacing: 2) {
-				Image(systemName: image)
-					.font(.callout.bold())
-				Text(title)
-					.font(model.toolbarFont)
-			}
-		}
-		.buttonStyle(.borderless)
-		.foregroundStyle(.primary)
-		.onHover { isHovering($0) }
-	}
+    internal var body: some View {
+        Button {
+            // show errors/warnings
+        } label: {
+            HStack(spacing: 2) {
+                Image(systemName: image)
+                    .font(.callout.bold())
+                Text(title)
+                    .font(model.toolbarFont)
+            }
+        }
+        .buttonStyle(.borderless)
+        .foregroundStyle(.primary)
+        .onHover { isHovering($0) }
+    }
 
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarLineEndSelector.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarLineEndSelector.swift
@@ -9,22 +9,22 @@ import SwiftUI
 
 @available(macOS 12, *)
 internal struct StatusBarLineEndSelector: View {
-	@ObservedObject
+    @ObservedObject
     private var model: StatusBarModel
 
-	internal init(model: StatusBarModel) {
-		self.model = model
-	}
+    internal init(model: StatusBarModel) {
+        self.model = model
+    }
 
-	internal var body: some View {
-		Menu {
-			// LF, CRLF
-		} label: {
-			Text("LF")
-				.font(model.toolbarFont)
-		}
-		.menuStyle(.borderlessButton)
-		.fixedSize()
-		.onHover { isHovering($0) }
-	}
+    internal var body: some View {
+        Menu {
+            // LF, CRLF
+        } label: {
+            Text("LF")
+                .font(model.toolbarFont)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .onHover { isHovering($0) }
+    }
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarPullButton.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarPullButton.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 @available(macOS 12, *)
 internal struct StatusBarPullButton: View {
-	@ObservedObject
+    @ObservedObject
     private var model: StatusBarModel
 
-	internal init(model: StatusBarModel) {
-		self.model = model
-	}
+    internal init(model: StatusBarModel) {
+        self.model = model
+    }
 
     internal var body: some View {
         Button {

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarToggleDrawerButton.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarToggleDrawerButton.swift
@@ -13,25 +13,25 @@ internal struct StatusBarToggleDrawerButton: View {
     private var model: StatusBarModel
 
     internal init(model: StatusBarModel) {
-		self.model = model
-	}
+        self.model = model
+    }
 
-	internal var body: some View {
-		Button {
-			withAnimation {
-				model.isExpanded.toggle()
-				if model.isExpanded && model.currentHeight < 1 {
-					model.currentHeight = 300
-				}
-			}
-			// Show/hide terminal window
-		} label: {
-			Image(systemName: "rectangle.bottomthird.inset.filled")
-				.imageScale(.medium)
-		}
-		.tint(model.isExpanded ? .accentColor : .primary)
-		.keyboardShortcut("Y", modifiers: [.command, .shift])
-		.buttonStyle(.borderless)
-		.onHover { isHovering($0) }
-	}
+    internal var body: some View {
+        Button {
+            withAnimation {
+                model.isExpanded.toggle()
+                if model.isExpanded && model.currentHeight < 1 {
+                    model.currentHeight = 300
+                }
+            }
+            // Show/hide terminal window
+        } label: {
+            Image(systemName: "rectangle.bottomthird.inset.filled")
+                .imageScale(.medium)
+        }
+        .tint(model.isExpanded ? .accentColor : .primary)
+        .keyboardShortcut("Y", modifiers: [.command, .shift])
+        .buttonStyle(.borderless)
+        .onHover { isHovering($0) }
+    }
 }

--- a/CodeEditModules/Modules/TerminalEmulator/src/Extensions/SwiftTerm+Color+Init.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/Extensions/SwiftTerm+Color+Init.swift
@@ -8,27 +8,27 @@
 import SwiftTerm
 
 internal extension SwiftTerm.Color {
-	/// 0.0-1.0
-	convenience init(dRed red: Double, green: Double, blue: Double) {
-		let multiplier: Double = 65535
-		self.init(red: UInt16(red * multiplier),
-				  green: UInt16(green * multiplier),
-				  blue: UInt16(blue * multiplier))
-	}
+    /// 0.0-1.0
+    convenience init(dRed red: Double, green: Double, blue: Double) {
+        let multiplier: Double = 65535
+        self.init(red: UInt16(red * multiplier),
+                  green: UInt16(green * multiplier),
+                  blue: UInt16(blue * multiplier))
+    }
 
-	/// 0-255
-	convenience init(iRed red: UInt8, green: UInt8, blue: UInt8) {
-		let divisor: Double = 255
-		self.init(dRed: Double(red) / divisor,
-				  green: Double(green) / divisor,
-				  blue: Double(blue) / divisor)
-	}
+    /// 0-255
+    convenience init(iRed red: UInt8, green: UInt8, blue: UInt8) {
+        let divisor: Double = 255
+        self.init(dRed: Double(red) / divisor,
+                  green: Double(green) / divisor,
+                  blue: Double(blue) / divisor)
+    }
 
-	/// 0x000000 - 0xFFFFFF
-	convenience init(hex: Int) {
-		let red = UInt8((hex >> 16) & 0xFF)
-		let green = UInt8((hex >> 8) & 0xFF)
-		let blue = UInt8(hex & 0xFF)
-		self.init(iRed: red, green: green, blue: blue)
-	}
+    /// 0x000000 - 0xFFFFFF
+    convenience init(hex: Int) {
+        let red = UInt8((hex >> 16) & 0xFF)
+        let green = UInt8((hex >> 8) & 0xFF)
+        let blue = UInt8(hex & 0xFF)
+        self.init(iRed: red, green: green, blue: blue)
+    }
 }

--- a/CodeEditModules/Modules/TerminalEmulator/src/Model/AnsiColors.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/Model/AnsiColors.swift
@@ -11,35 +11,35 @@ import SwiftUI
 public class AnsiColors: ObservableObject {
     //    public static let `default` =
     public static let storageKey: String = "ANSIColors"
-	public static let shared: AnsiColors = .init()
+    public static let shared: AnsiColors = .init()
 
     public init() {
         guard let loadColors = UserDefaults.standard.object(forKey: Self.storageKey) as? [Int] else {
-			resetDefault()
+            resetDefault()
             return
         }
         self.mappedColors = loadColors
     }
 
-	public func resetDefault() {
-		colors.removeAll()
-		colors.append(Color(red: 0.000, green: 0.000, blue: 0.000))
-		colors.append(Color(red: 0.600, green: 0.000, blue: 0.000))
-		colors.append(Color(red: 0.000, green: 0.651, blue: 0.004))
-		colors.append(Color(red: 0.600, green: 0.600, blue: 0.000))
-		colors.append(Color(red: 0.000, green: 0.031, blue: 0.702))
-		colors.append(Color(red: 0.702, green: 0.020, blue: 0.702))
-		colors.append(Color(red: 0.000, green: 0.647, blue: 0.702))
-		colors.append(Color(red: 0.749, green: 0.749, blue: 0.749))
-		colors.append(Color(red: 0.400, green: 0.400, blue: 0.400))
-		colors.append(Color(red: 0.902, green: 0.000, blue: 0.004))
-		colors.append(Color(red: 0.004, green: 0.851, blue: 0.000))
-		colors.append(Color(red: 0.902, green: 0.898, blue: 0.012))
-		colors.append(Color(red: 0.000, green: 0.063, blue: 1.000))
-		colors.append(Color(red: 0.902, green: 0.035, blue: 0.902))
-		colors.append(Color(red: 0.008, green: 0.902, blue: 0.898))
-		colors.append(Color(red: 0.902, green: 0.902, blue: 0.902))
-	}
+    public func resetDefault() {
+        colors.removeAll()
+        colors.append(Color(red: 0.000, green: 0.000, blue: 0.000))
+        colors.append(Color(red: 0.600, green: 0.000, blue: 0.000))
+        colors.append(Color(red: 0.000, green: 0.651, blue: 0.004))
+        colors.append(Color(red: 0.600, green: 0.600, blue: 0.000))
+        colors.append(Color(red: 0.000, green: 0.031, blue: 0.702))
+        colors.append(Color(red: 0.702, green: 0.020, blue: 0.702))
+        colors.append(Color(red: 0.000, green: 0.647, blue: 0.702))
+        colors.append(Color(red: 0.749, green: 0.749, blue: 0.749))
+        colors.append(Color(red: 0.400, green: 0.400, blue: 0.400))
+        colors.append(Color(red: 0.902, green: 0.000, blue: 0.004))
+        colors.append(Color(red: 0.004, green: 0.851, blue: 0.000))
+        colors.append(Color(red: 0.902, green: 0.898, blue: 0.012))
+        colors.append(Color(red: 0.000, green: 0.063, blue: 1.000))
+        colors.append(Color(red: 0.902, green: 0.035, blue: 0.902))
+        colors.append(Color(red: 0.008, green: 0.902, blue: 0.898))
+        colors.append(Color(red: 0.902, green: 0.902, blue: 0.902))
+    }
 
     @Published
     public var mappedColors: [Int] = [] {

--- a/CodeEditModules/Modules/TerminalEmulator/src/Model/TerminalColorScheme.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/Model/TerminalColorScheme.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public enum TerminalColorScheme: String, CaseIterable, Hashable {
-	case auto
-	case light
-	case dark
+    case auto
+    case light
+    case dark
 
-	static public let `default` = TerminalColorScheme.auto
-	static public let storageKey = "terminalColorScheme"
+    static public let `default` = TerminalColorScheme.auto
+    static public let storageKey = "terminalColorScheme"
 }

--- a/CodeEditModules/Modules/TerminalEmulator/src/Model/TerminalFont.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/Model/TerminalFont.swift
@@ -8,19 +8,19 @@
 import Foundation
 
 public enum TerminalFont: String, CaseIterable, Hashable {
-	case systemFont
-	case custom
+    case systemFont
+    case custom
 
-	static public let `default`: TerminalFont = .systemFont
-	static public let storageKey = "terminalFontSelection"
+    static public let `default`: TerminalFont = .systemFont
+    static public let storageKey = "terminalFontSelection"
 }
 
 public enum TerminalFontName {
-	static public let `default`: String = "SFMono-Medium"
-	static public let storageKey = "terminalFontName"
+    static public let `default`: String = "SFMono-Medium"
+    static public let storageKey = "terminalFontName"
 }
 
 public enum TerminalFontSize {
-	static public let `default`: Int = 11
-	static public let storageKey = "terminalFontSize"
+    static public let `default`: Int = 11
+    static public let storageKey = "terminalFontSize"
 }

--- a/CodeEditModules/Modules/TerminalEmulator/src/Model/TerminalShellType.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/Model/TerminalShellType.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public enum TerminalShellType: String, CaseIterable, Hashable {
-	case bash
-	case zsh
-	case auto
+    case bash
+    case zsh
+    case auto
 
-	static public let `default` = TerminalShellType.auto
-	static public let storageKey = "terminalShellType"
+    static public let `default` = TerminalShellType.auto
+    static public let storageKey = "terminalShellType"
 }

--- a/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView+Coordinator.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView+Coordinator.swift
@@ -9,23 +9,23 @@ import SwiftUI
 import SwiftTerm
 
 public extension TerminalEmulatorView {
-	class Coordinator: NSObject, LocalProcessTerminalViewDelegate {
+    class Coordinator: NSObject, LocalProcessTerminalViewDelegate {
 
-		public override init() {}
+        public override init() {}
 
-		public func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+        public func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
 
-		public func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {}
+        public func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {}
 
-		public func setTerminalTitle(source: LocalProcessTerminalView, title: String) {}
+        public func setTerminalTitle(source: LocalProcessTerminalView, title: String) {}
 
-		public func processTerminated(source: TerminalView, exitCode: Int32?) {
-			guard let exitCode = exitCode else {
-				return
-			}
-			source.feed(text: "Exit code: \(exitCode)\n\r\n")
-			source.feed(text: "To open a new session close and reopen the terminal drawer")
-			TerminalEmulatorView.lastTerminal = nil
-		}
-	}
+        public func processTerminated(source: TerminalView, exitCode: Int32?) {
+            guard let exitCode = exitCode else {
+                return
+            }
+            source.feed(text: "Exit code: \(exitCode)\n\r\n")
+            source.feed(text: "To open a new session close and reopen the terminal drawer")
+            TerminalEmulatorView.lastTerminal = nil
+        }
+    }
 }

--- a/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView.swift
@@ -16,145 +16,145 @@ import SwiftTerm
 /// for use in SwiftUI.
 ///
 public struct TerminalEmulatorView: NSViewRepresentable {
-	@AppStorage(TerminalShellType.storageKey)
+    @AppStorage(TerminalShellType.storageKey)
     var shellType: TerminalShellType = .default
 
     @AppStorage(TerminalFont.storageKey)
     var terminalFontSelection: TerminalFont = .default
 
-	@AppStorage(TerminalFontName.storageKey)
+    @AppStorage(TerminalFontName.storageKey)
     var terminalFontName: String = TerminalFontName.default
 
-	@AppStorage(TerminalFontSize.storageKey)
+    @AppStorage(TerminalFontSize.storageKey)
     var terminalFontSize: Int = TerminalFontSize.default
 
-	@AppStorage(TerminalColorScheme.storageKey)
+    @AppStorage(TerminalColorScheme.storageKey)
     var terminalColorSchmeme: TerminalColorScheme = .default
 
-	@StateObject
+    @StateObject
     private var ansiColors: AnsiColors = .shared
 
-	internal static var lastTerminal: LocalProcessTerminalView?
+    internal static var lastTerminal: LocalProcessTerminalView?
 
     @State
     internal var terminal: LocalProcessTerminalView
 
-	private let systemFont: NSFont = .monospacedSystemFont(ofSize: 11, weight: .medium)
+    private let systemFont: NSFont = .monospacedSystemFont(ofSize: 11, weight: .medium)
 
-	private var font: NSFont {
-		if terminalFontSelection == .systemFont {
-			return systemFont
-		}
-		return NSFont(name: terminalFontName, size: CGFloat(terminalFontSize)) ?? systemFont
-	}
+    private var font: NSFont {
+        if terminalFontSelection == .systemFont {
+            return systemFont
+        }
+        return NSFont(name: terminalFontName, size: CGFloat(terminalFontSize)) ?? systemFont
+    }
 
-	private var url: URL
+    private var url: URL
 
-	public init(url: URL) {
-		self.url = url
-		self._terminal = State(initialValue: TerminalEmulatorView.lastTerminal ?? .init(frame: .zero))
-	}
+    public init(url: URL) {
+        self.url = url
+        self._terminal = State(initialValue: TerminalEmulatorView.lastTerminal ?? .init(frame: .zero))
+    }
 
-	/// Returns a string of a shell path to use
-	///
-	/// Default implementation pulled from Example app from "SwiftTerm":
-	/// ```swift
-	///	let bufsize = sysconf(_SC_GETPW_R_SIZE_MAX)
-	///	guard bufsize != -1 else { return "/bin/bash" }
-	///	let buffer = UnsafeMutablePointer<Int8>.allocate(capacity: bufsize)
-	/// defer {
-	///		buffer.deallocate()
-	///	}
-	///	var pwd = passwd()
-	///	var result: UnsafeMutablePointer<passwd>? = UnsafeMutablePointer<passwd>.allocate(capacity: 1)
-	///
-	/// if getpwuid_r(getuid(), &pwd, buffer, bufsize, &result) != 0 { return "/bin/bash" }
-	///	return String(cString: pwd.pw_shell)
-	/// ```
-	private func getShell() -> String {
-		switch shellType {
-		case .auto:
-			return autoDetectDefaultShell()
-		case .bash:
-			return "/bin/bash"
-		case .zsh:
-			return "/bin/zsh"
-		}
-	}
+    /// Returns a string of a shell path to use
+    ///
+    /// Default implementation pulled from Example app from "SwiftTerm":
+    /// ```swift
+    ///    let bufsize = sysconf(_SC_GETPW_R_SIZE_MAX)
+    ///    guard bufsize != -1 else { return "/bin/bash" }
+    ///    let buffer = UnsafeMutablePointer<Int8>.allocate(capacity: bufsize)
+    /// defer {
+    ///        buffer.deallocate()
+    ///    }
+    ///    var pwd = passwd()
+    ///    var result: UnsafeMutablePointer<passwd>? = UnsafeMutablePointer<passwd>.allocate(capacity: 1)
+    ///
+    /// if getpwuid_r(getuid(), &pwd, buffer, bufsize, &result) != 0 { return "/bin/bash" }
+    ///    return String(cString: pwd.pw_shell)
+    /// ```
+    private func getShell() -> String {
+        switch shellType {
+        case .auto:
+            return autoDetectDefaultShell()
+        case .bash:
+            return "/bin/bash"
+        case .zsh:
+            return "/bin/zsh"
+        }
+    }
 
-	/// Gets the default shell from the current user and returns the string of the shell path.
-	private func autoDetectDefaultShell() -> String {
-		let bufsize = sysconf(_SC_GETPW_R_SIZE_MAX)
-		guard bufsize != -1 else { return "/bin/bash" }
-		let buffer = UnsafeMutablePointer<Int8>.allocate(capacity: bufsize)
-		defer {
-			buffer.deallocate()
-		}
-		var pwd = passwd()
-		var result: UnsafeMutablePointer<passwd>? = UnsafeMutablePointer<passwd>.allocate(capacity: 1)
+    /// Gets the default shell from the current user and returns the string of the shell path.
+    private func autoDetectDefaultShell() -> String {
+        let bufsize = sysconf(_SC_GETPW_R_SIZE_MAX)
+        guard bufsize != -1 else { return "/bin/bash" }
+        let buffer = UnsafeMutablePointer<Int8>.allocate(capacity: bufsize)
+        defer {
+            buffer.deallocate()
+        }
+        var pwd = passwd()
+        var result: UnsafeMutablePointer<passwd>? = UnsafeMutablePointer<passwd>.allocate(capacity: 1)
 
-		if getpwuid_r(getuid(), &pwd, buffer, bufsize, &result) != 0 { return "/bin/bash" }
-		return String(cString: pwd.pw_shell)
-	}
+        if getpwuid_r(getuid(), &pwd, buffer, bufsize, &result) != 0 { return "/bin/bash" }
+        return String(cString: pwd.pw_shell)
+    }
 
-	/// Returns the mapped array of `SwiftTerm.Color` objects of ANSI Colors
-	private var colors: [SwiftTerm.Color] {
-		return ansiColors.mappedColors.map { SwiftTerm.Color(hex: $0) }
-	}
+    /// Returns the mapped array of `SwiftTerm.Color` objects of ANSI Colors
+    private var colors: [SwiftTerm.Color] {
+        return ansiColors.mappedColors.map { SwiftTerm.Color(hex: $0) }
+    }
 
-	/// returns a `NSAppearance` based on the user setting of the terminal appearance,
-	/// `nil` if app default is not overriden
-	private var colorAppearance: NSAppearance? {
-		switch terminalColorSchmeme {
-		case .auto: return nil
-		case .light: return .init(named: .aqua)
-		case .dark: return .init(named: .darkAqua)
-		}
-	}
+    /// returns a `NSAppearance` based on the user setting of the terminal appearance,
+    /// `nil` if app default is not overriden
+    private var colorAppearance: NSAppearance? {
+        switch terminalColorSchmeme {
+        case .auto: return nil
+        case .light: return .init(named: .aqua)
+        case .dark: return .init(named: .darkAqua)
+        }
+    }
 
-	/// Inherited from NSViewRepresentable.makeNSView(context:).
-	public func makeNSView(context: Context) -> LocalProcessTerminalView {
-		terminal.processDelegate = context.coordinator
-		setupSession()
-		return terminal
-	}
+    /// Inherited from NSViewRepresentable.makeNSView(context:).
+    public func makeNSView(context: Context) -> LocalProcessTerminalView {
+        terminal.processDelegate = context.coordinator
+        setupSession()
+        return terminal
+    }
 
-	public func setupSession() {
-		terminal.getTerminal().silentLog = true
-		if TerminalEmulatorView.lastTerminal == nil {
-			let shell = getShell()
-			let shellIdiom = "-" + NSString(string: shell).lastPathComponent
+    public func setupSession() {
+        terminal.getTerminal().silentLog = true
+        if TerminalEmulatorView.lastTerminal == nil {
+            let shell = getShell()
+            let shellIdiom = "-" + NSString(string: shell).lastPathComponent
 
-			// changes working directory to project root
-			// TODO: Get rid of FileManager shared instance to prevent problems
-			// using shared instance of FileManager might lead to problems when using
-			// multiple workspaces. This works for now but most probably will need
-			// to be changed later on
-			FileManager.default.changeCurrentDirectoryPath(url.path)
-			terminal.startProcess(executable: shell, execName: shellIdiom)
-			terminal.font = font
-			terminal.configureNativeColors()
-			terminal.installColors(self.colors)
-		}
-		terminal.appearance = colorAppearance
-		TerminalEmulatorView.lastTerminal = terminal
-	}
+            // changes working directory to project root
+            // TODO: Get rid of FileManager shared instance to prevent problems
+            // using shared instance of FileManager might lead to problems when using
+            // multiple workspaces. This works for now but most probably will need
+            // to be changed later on
+            FileManager.default.changeCurrentDirectoryPath(url.path)
+            terminal.startProcess(executable: shell, execName: shellIdiom)
+            terminal.font = font
+            terminal.configureNativeColors()
+            terminal.installColors(self.colors)
+        }
+        terminal.appearance = colorAppearance
+        TerminalEmulatorView.lastTerminal = terminal
+    }
 
-	public func updateNSView(_ view: LocalProcessTerminalView, context: Context) {
-		if view.font != font { // Fixes Memory leak
-			view.font = font
-		}
-		view.configureNativeColors()
-		view.installColors(self.colors)
-		view.appearance = colorAppearance
-		if TerminalEmulatorView.lastTerminal != nil {
-			TerminalEmulatorView.lastTerminal = view
-		}
-		view.getTerminal().softReset()
-		view.feed(text: "") // send empty character to force colors to be redrawn
-	}
+    public func updateNSView(_ view: LocalProcessTerminalView, context: Context) {
+        if view.font != font { // Fixes Memory leak
+            view.font = font
+        }
+        view.configureNativeColors()
+        view.installColors(self.colors)
+        view.appearance = colorAppearance
+        if TerminalEmulatorView.lastTerminal != nil {
+            TerminalEmulatorView.lastTerminal = view
+        }
+        view.getTerminal().softReset()
+        view.feed(text: "") // send empty character to force colors to be redrawn
+    }
 
-	public func makeCoordinator() -> Coordinator {
-		Coordinator()
-	}
+    public func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
 }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Interface.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Interface.swift
@@ -10,20 +10,19 @@ import Foundation
 
 public struct WorkspaceClient {
 
-	public var folderURL: () -> URL?
+    public var folderURL: () -> URL?
 
     public var getFiles: AnyPublisher<[FileItem], Never>
 
     public var getFileItem: (_ id: String) throws -> FileItem
 
     // For some strange reason, swiftlint thinks this is wrong?
-    // swiftlint:disable vertical_parameter_alignment
     public init(
-		folderURL: @escaping () -> URL?,
+        folderURL: @escaping () -> URL?,
         getFiles: AnyPublisher<[FileItem], Never>,
         getFileItem: @escaping (_ id: String) throws -> FileItem
     ) {
-		self.folderURL = folderURL
+        self.folderURL = folderURL
         self.getFiles = getFiles
         self.getFileItem = getFileItem
     }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
@@ -83,7 +83,7 @@ public extension WorkspaceClient {
         }
 
         return Self(
-			folderURL: { folderURL },
+            folderURL: { folderURL },
             getFiles: subject
                 .handleEvents(receiveSubscription: { _ in
                     startListeningToDirectory()

--- a/CodeEditModules/Modules/WorkspaceClient/src/Mocks.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Mocks.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public extension WorkspaceClient {
     static var empty = Self(
-		folderURL: { nil },
+        folderURL: { nil },
         getFiles: CurrentValueSubject<[FileItem], Never>([]).eraseToAnyPublisher(),
         getFileItem: { _ in throw WorkspaceClientError.fileNotExist }
     )


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

### Description

This introduces a new custom SwiftLint rule that reports warnings when coming across tabs in Swift files. It also fixes all SwiftLint warnings by converting tabs into 4 spaces.

### Releated Issue

#291 

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):

Before:

![](https://user-images.githubusercontent.com/6942160/160406633-b3bed90b-2ca7-4898-a9d6-227a91dc618d.png)

After:
![Screenshot 2022-03-28 at 17 44 10](https://user-images.githubusercontent.com/6942160/160436276-1de755f0-801e-4d64-95fc-2121d9784996.png)

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this issue temporarily -->
