### PR TITLE
Add file icon for .h .m and .vue

### DIFF
--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -77,12 +77,16 @@ public extension WorkspaceClient {
                 return .red
             case "js", "entitlements", "json", "LICENSE":
                 return Color("SidebarYellow")
-            case "css", "ts", "jsx", "md", "py", "h":
+            case "css", "ts", "jsx", "md", "py":
                 return .blue
-            case "sh", "vue":
+            case "sh":
                 return .green
+            case "vue":
+                return Color(red: 0.255, green: 0.722, blue: 0.514, opacity: 1.000)
+            case "h":
+                return Color(red: 0.667, green: 0.031, blue: 0.133, opacity: 1.000)
             case "m":
-                return .purple
+                return Color(red: 0.271, green: 0.106, blue: 0.525, opacity: 1.000)
             default:
                 return .blue
             }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -58,6 +58,12 @@ public extension WorkspaceClient {
                 return "key.fill"
             case "java":
                 return "cup.and.saucer"
+            case "h":
+                return "h.square"
+            case "m":
+                return "m.square"
+            case "vue":
+                return "v.square"
             default:
                 return "doc"
             }
@@ -73,7 +79,7 @@ public extension WorkspaceClient {
                 return Color("SidebarYellow")
             case "css", "ts", "jsx", "md", "py":
                 return .blue
-            case "sh":
+            case "sh", "vue":
                 return .green
             default:
                 return .blue

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -77,10 +77,12 @@ public extension WorkspaceClient {
                 return .red
             case "js", "entitlements", "json", "LICENSE":
                 return Color("SidebarYellow")
-            case "css", "ts", "jsx", "md", "py":
+            case "css", "ts", "jsx", "md", "py", "h":
                 return .blue
             case "sh", "vue":
                 return .green
+            case "m":
+                return .purple
             default:
                 return .blue
             }


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

### Description

Add specific file icon and color for `.h` `.m` and `.vue` files.

### Releated Issue

[FEAT] - File icon support for ".h" ".m" and "vue" #294

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):

<img width="238" alt="CleanShot 2022-03-29 at 12 07 37@2x" src="https://user-images.githubusercontent.com/6525286/160532068-56ea705c-1e53-4770-80a2-3c40e40d762f.png">

<img width="390" alt="CleanShot 2022-03-29 at 12 09 41@2x" src="https://user-images.githubusercontent.com/6525286/160532084-c0c5be0c-7708-4c0a-9b4b-a11a10cfd189.png">


