### PR TITLE
Added `TabWidth` selector to status bar

### DIFF
--- a/CodeEdit/Settings/GeneralSettingsView.swift
+++ b/CodeEdit/Settings/GeneralSettingsView.swift
@@ -23,8 +23,8 @@ struct GeneralSettingsView: View {
     @AppStorage(CodeFileView.Theme.storageKey)
     var editorTheme: CodeFileView.Theme = .atelierSavannaAuto
 
-    @AppStorage("defaultTabWidth")
-    var defaultTabWidth: Int = 4
+    @AppStorage(EditorTabWidth.storageKey)
+    var defaultTabWidth: Int = EditorTabWidth.default
 
     var body: some View {
         Form {
@@ -76,7 +76,6 @@ struct GeneralSettingsView: View {
 
             HStack {
                 Stepper("Default Tab Width".localized(), value: $defaultTabWidth, in: 2...8)
-                    .onChange(of: defaultTabWidth) { CodeEditorTextView.tabWidth = $0 }
                 Text(String(defaultTabWidth))
             }
         }

--- a/CodeEditModules/Modules/CodeFile/src/TextView/CodeEditorTextView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/TextView/CodeEditorTextView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 public class CodeEditorTextView: NSTextView {
     @AppStorage(EditorTabWidth.storageKey)
-    public static var tabWidth: Int = EditorTabWidth.default
+    private var tabWidth: Int = EditorTabWidth.default
 
     init(
         textContainer container: NSTextContainer?
@@ -84,7 +84,7 @@ public class CodeEditorTextView: NSTextView {
         super.insertText(
             String(
                 repeating: " ",
-                count: Self.tabWidth
+                count: tabWidth
             ),
             replacementRange: selectedRange()
         )

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarIndentSelector.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarIndentSelector.swift
@@ -6,11 +6,15 @@
 //
 
 import SwiftUI
+import CodeFile
 
 @available(macOS 12, *)
 internal struct StatusBarIndentSelector: View {
     @ObservedObject
     private var model: StatusBarModel
+
+    @AppStorage(EditorTabWidth.storageKey)
+    private var tabWidth: Int = EditorTabWidth.default
 
     internal init(model: StatusBarModel) {
         self.model = model
@@ -18,9 +22,24 @@ internal struct StatusBarIndentSelector: View {
 
     internal var body: some View {
         Menu {
-            // 2 spaces, 4 spaces, ...
+            Button {} label: {
+                Text("Use Tabs")
+            }.disabled(true)
+
+            Button {} label: {
+                Text("Use Spaces")
+            }.disabled(true)
+
+            Divider()
+
+            Picker("Tab Width", selection: $tabWidth) {
+                ForEach(2..<9) { index in
+                    Text("\(index) Spaces")
+                        .tag(index)
+                }
+            }
         } label: {
-            Text("2 Spaces")
+            Text("\(tabWidth) Spaces")
                 .font(model.toolbarFont)
         }
         .menuStyle(.borderlessButton)

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -113,6 +113,7 @@ let package = Package(
             dependencies: [
                 "GitClient",
                 "TerminalEmulator",
+                "CodeFile",
             ],
             path: "Modules/StatusBar/src"
         ),


### PR DESCRIPTION
### Description

The tab width selector in the status bar can now be used to set the default tab width of the code editor

### Releated Issue

#217 

### Checklist (for drafts):

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):

<img width="251" alt="Screen Shot 2022-03-29 at 09 56 36" src="https://user-images.githubusercontent.com/9460130/160562771-c67abf87-b5cb-49b8-9b61-21dcfe7b1608.png">


