### PR TITLE
Fixed status bar branch picker width

### DIFF
--- a/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
@@ -47,7 +47,11 @@ public struct StatusBarView: View {
                 .foregroundStyle(.bar)
             HStack(spacing: 15) {
                 HStack(spacing: 5) {
-                    StatusBarLabelButton(model: model, title: model.errorCount.formatted(), image: "xmark.octagon")
+                    StatusBarLabelButton(
+                        model: model,
+                        title: model.errorCount.formatted(),
+                        image: "xmark.octagon"
+                    )
                     StatusBarLabelButton(
                         model: model,
                         title: model.warningCount.formatted(),

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarBranchPicker.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarBranchPicker.swift
@@ -47,7 +47,8 @@ internal struct StatusBarBranchPicker: View {
                 .font(model.toolbarFont)
         }
         .menuStyle(.borderlessButton)
-        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: 150)
+        .fixedSize(horizontal: true, vertical: true)
         .onHover { isHovering($0) }
         .disabled(model.selectedBranch == nil)
     }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarCursorLocationLabel.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarCursorLocationLabel.swift
@@ -20,6 +20,7 @@ internal struct StatusBarCursorLocationLabel: View {
         Text("Ln \(model.currentLine), Col \(model.currentCol)")
             .font(model.toolbarFont)
             .foregroundStyle(.primary)
+            .fixedSize()
             .lineLimit(1)
             .onHover { isHovering($0) }
     }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarLabelButton.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarLabelButton.swift
@@ -34,6 +34,7 @@ internal struct StatusBarLabelButton: View {
         }
         .buttonStyle(.borderless)
         .foregroundStyle(.primary)
+        .fixedSize()
         .onHover { isHovering($0) }
     }
 


### PR DESCRIPTION
### Description

The branch picker in status bar now only takes a maximum of 150pt in width

### Releated Issue

#209 

### Checklist (for drafts):

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):

**Before**
<img width="806" alt="Screen Shot 2022-03-29 at 10 10 39" src="https://user-images.githubusercontent.com/9460130/160565347-fb6a40cd-c414-41f5-b4c5-544c0b01cb8d.png">

**After**
<img width="807" alt="Screen Shot 2022-03-29 at 10 10 12" src="https://user-images.githubusercontent.com/9460130/160565362-e09d1ff0-8f5e-461d-bee4-4882cb934493.png">

