### PR TITLE
Splitview 3-column layout for Navigator, Editor, Inspector

### DIFF
--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -10,10 +10,159 @@ import SwiftUI
 import CodeFile
 import Overlays
 
-class CodeEditWindowController: NSWindowController {
+class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
 
     var workspace: WorkspaceDocument?
     var quickOpenPanel: OverlayPanel?
+
+    init(window: NSWindow, workspace: WorkspaceDocument) {
+        super.init(window: window)
+        print("INIT")
+        self.workspace = workspace
+
+        let splitVC = NSSplitViewController()
+
+        let sidebar = NSSplitViewItem(
+            sidebarWithViewController: NSHostingController(
+                rootView: NavigatorSidebar(workspace: workspace, windowController: self)
+            )
+        )
+        sidebar.minimumThickness = 260
+        splitVC.addSplitViewItem(sidebar)
+
+        let content = NSSplitViewItem(
+            viewController: NSHostingController(
+                rootView: WorkspaceView(windowController: self, workspace: workspace)
+            )
+        )
+        splitVC.addSplitViewItem(content)
+
+        let detail = NSSplitViewItem(
+            viewController: NSHostingController(
+                rootView: InspectorSidebar(workspace: workspace, windowController: self)
+            )
+        )
+        detail.collapseBehavior = .preferResizingSiblingsWithFixedSplitView
+
+        splitVC.splitView.setHoldingPriority(.dragThatCannotResizeWindow, forSubviewAt: 2)
+        splitVC.addSplitViewItem(detail)
+
+        self.splitViewController = splitVC
+
+        let toolbar = NSToolbar(identifier: UUID().uuidString)
+        toolbar.delegate = self
+        toolbar.displayMode = .labelOnly
+        window.toolbarStyle = .unifiedCompact
+        window.titlebarSeparatorStyle = .none
+        window.toolbar = toolbar
+
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // Dangerous convenience alias so you can access the NSSplitViewController and manipulate it later on
+    private var splitViewController: NSSplitViewController! {
+        get { return contentViewController as? NSSplitViewController }
+        set { contentViewController = newValue }
+    }
+
+    @objc func toggleFirstPanel() {
+        guard let firstSplitView = splitViewController.splitViewItems.first else { return }
+        firstSplitView.animator().isCollapsed.toggle()
+    }
+
+    @objc func toggleLastPanel() {
+        guard let lastSplitView = splitViewController.splitViewItems.last else { return }
+        lastSplitView.animator().isCollapsed.toggle()
+        if lastSplitView.animator().isCollapsed {
+            window?.toolbar?.removeItem(at: 3)
+        } else {
+            window?.toolbar?.insertItem(withItemIdentifier: .itemListTrackingSeparator, at: 3)
+        }
+    }
+
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        return [
+            .toggleFirstSidebarItem,
+            .sidebarTrackingSeparator,
+            .flexibleSpace,
+            .itemListTrackingSeparator,
+            .flexibleSpace,
+            .toggleLastSidebarItem
+        ]
+    }
+
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        return [
+            .toggleFirstSidebarItem,
+            .sidebarTrackingSeparator,
+            .flexibleSpace,
+            .itemListTrackingSeparator,
+            .toggleLastSidebarItem
+        ]
+    }
+
+    // swiftlint:disable all
+    func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool
+    ) -> NSToolbarItem? {
+        switch itemIdentifier {
+        case .itemListTrackingSeparator:
+            if ((splitViewController) != nil) {
+                return NSTrackingSeparatorToolbarItem(
+                    identifier: .itemListTrackingSeparator,
+                    splitView: splitViewController.splitView,
+                    dividerIndex: 1
+                )
+            } else {
+                return nil
+            }
+        case .toggleFirstSidebarItem:
+            let toolbarItem = NSToolbarItem(itemIdentifier: NSToolbarItem.Identifier.toggleFirstSidebarItem)
+            toolbarItem.label = "Sidebar"
+            toolbarItem.paletteLabel = "Sidebar"
+            toolbarItem.toolTip = "Toggle Sidebar"
+            toolbarItem.isBordered = true
+            toolbarItem.target = self
+            toolbarItem.action = #selector(self.toggleFirstPanel)
+            toolbarItem.image = NSImage(
+                systemSymbolName: "sidebar.leading",
+                accessibilityDescription: nil
+            )?.withSymbolConfiguration(.init(scale: .large))
+
+            let menuItem = NSMenuItem()
+            menuItem.submenu = nil
+            menuItem.title = "Sidebar"
+
+            toolbarItem.menuFormRepresentation = menuItem
+            return toolbarItem
+        case .toggleLastSidebarItem:
+            let toolbarItem = NSToolbarItem(itemIdentifier: NSToolbarItem.Identifier.toggleFirstSidebarItem)
+            toolbarItem.label = "Sidebar"
+            toolbarItem.paletteLabel = "Sidebar"
+            toolbarItem.toolTip = "Toggle Sidebar"
+            toolbarItem.target = self
+            toolbarItem.action = #selector(self.toggleLastPanel)
+            toolbarItem.image = NSImage(
+                systemSymbolName: "sidebar.trailing",
+                accessibilityDescription: nil
+            )?.withSymbolConfiguration(.init(scale: .small))
+
+            let menuItem = NSMenuItem()
+            menuItem.submenu = nil
+            menuItem.title = "Sidebar"
+
+            toolbarItem.menuFormRepresentation = menuItem
+            return toolbarItem
+        default:
+            return NSToolbarItem(itemIdentifier: itemIdentifier)
+        }
+    }
+
     override func windowDidLoad() {
         super.windowDidLoad()
 
@@ -56,4 +205,10 @@ class CodeEditWindowController: NSWindowController {
             }
         }
     }
+}
+
+private extension NSToolbarItem.Identifier {
+    static let toggleFirstSidebarItem: NSToolbarItem.Identifier = NSToolbarItem.Identifier("ToggleFirstSidebarItem")
+    static let toggleLastSidebarItem: NSToolbarItem.Identifier = NSToolbarItem.Identifier("ToggleLastSidebarItem")
+    static let itemListTrackingSeparator = NSToolbarItem.Identifier("ItemListTrackingSeparator")
 }

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -53,6 +53,7 @@ class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
             viewController: NSHostingController(rootView: inspectorView)
         )
         inspector.minimumThickness = 260
+        inspector.maximumThickness = 260
         inspector.isCollapsed = true
         inspector.collapseBehavior = .preferResizingSiblingsWithFixedSplitView
         splitVC.addSplitViewItem(inspector)

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -107,15 +107,11 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
             backing: .buffered, defer: false
         )
         window.center()
-        window.toolbar = NSToolbar(identifier: UUID().uuidString)
-        window.toolbarStyle = .unifiedCompact
-        window.titlebarSeparatorStyle = .line
-        window.toolbar?.displayMode = .iconOnly
-        window.toolbar?.insertItem(withItemIdentifier: .toggleSidebar, at: 0)
-        let windowController = CodeEditWindowController(window: window)
-        windowController.workspace = self
-        let contentView = WorkspaceView(windowController: windowController, workspace: self)
-        window.contentView = NSHostingView(rootView: contentView)
+        window.minSize = .init(width: 1000, height: 600)
+        let windowController = CodeEditWindowController(
+            window: window,
+            workspace: self
+        )
         self.addWindowController(windowController)
     }
 

--- a/CodeEdit/InspectorSidebar/InspectorSidebar.swift
+++ b/CodeEdit/InspectorSidebar/InspectorSidebar.swift
@@ -31,6 +31,7 @@ struct InspectorSidebar: View {
         }
         .frame(
             minWidth: 250,
+            idealWidth: 260,
             minHeight: 0,
             maxHeight: .infinity,
             alignment: .center

--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigator.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigator.swift
@@ -44,6 +44,7 @@ struct FindNavigator: View {
             Divider()
             FindNavigatorResultList(state: state)
         }
+        .background(.clear)
         .onSubmit {
             state.search(searchText)
         }

--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigator.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigator.swift
@@ -44,7 +44,6 @@ struct FindNavigator: View {
             Divider()
             FindNavigatorResultList(state: state)
         }
-        .background(.clear)
         .onSubmit {
             state.search(searchText)
         }

--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultList.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultList.swift
@@ -35,7 +35,6 @@ struct FindNavigatorResultList: View {
             }
         }
         .listStyle(.sidebar)
-        .background(.clear)
         .onChange(of: selectedResult) { newValue in
             if let file = newValue?.file {
                 state.workspace.openFile(item: file)

--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultList.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultList.swift
@@ -33,7 +33,10 @@ struct FindNavigatorResultList: View {
                         state.workspace.openFile(item: foundFile.file)
                     }
             }
-        }.onChange(of: selectedResult) { newValue in
+        }
+        .listStyle(.sidebar)
+        .background(.clear)
+        .onChange(of: selectedResult) { newValue in
             if let file = newValue?.file {
                 state.workspace.openFile(item: file)
             }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/ProjectNavigator.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/ProjectNavigator.swift
@@ -42,6 +42,7 @@ struct ProjectNavigator: View {
                     .padding(.vertical, 8)
             }
         }
+        .listStyle(.sidebar)
         .listRowInsets(.init())
         .onChange(of: selection) { newValue in
             guard let id = newValue,

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -35,14 +35,21 @@ struct WorkspaceView: View {
     var showInspector = true
 
     var body: some View {
-        NavigationView {
+        ZStack {
             if workspace.workspaceClient != nil {
-                content
+                WorkspaceCodeFileView(windowController: windowController, workspace: workspace)
+                    .safeAreaInset(edge: .bottom) {
+                        if let url = workspace.fileURL {
+                            StatusBarView(workspaceURL: url)
+                        }
+                    }
+                    .overlay(alignment: .top) {
+                        Divider()
+                    }
             } else {
                 EmptyView()
             }
         }
-        .frame(minWidth: 1000, minHeight: 600)
         .alert(alertTitle, isPresented: $showingAlert, actions: {
             Button(
                 action: { showingAlert = false },
@@ -53,27 +60,6 @@ struct WorkspaceView: View {
             if newValue == nil {
                 windowController.window?.subtitle = ""
             }
-        }
-    }
-
-    @ViewBuilder
-    private var content: some View {
-        NavigatorSidebar(workspace: workspace, windowController: windowController)
-        .frame(minWidth: 250)
-
-        HSplitView {
-            ZStack {
-                WorkspaceCodeFileView(windowController: windowController, workspace: workspace)
-                    .frame(minWidth: 500, maxHeight: .infinity)
-            }
-            .safeAreaInset(edge: .bottom) {
-                if let url = workspace.fileURL {
-                    StatusBarView(workspaceURL: url)
-                }
-            }
-            .layoutPriority(1)
-            InspectorSidebar(workspace: workspace, windowController: windowController)
-                .frame(minWidth: 260, idealWidth: 300, maxHeight: .infinity)
         }
     }
 }


### PR DESCRIPTION
### Description

Implemented a `NSSplitView` for the main structure of the app. Allows to customize the toolbar, and make the inspector collapsible.

### Releated Issue

* #270 
* #173 
* #172 

### Checklist (for drafts):

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):

https://user-images.githubusercontent.com/9460130/160615967-f34aa11d-d332-4c46-aa72-c85dd7ed2e5e.mov



