### PR TITLE
File Icon Colors in Tab Bar

### DIFF
--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -29,6 +29,9 @@ struct TabBarItem: View {
     @Environment(\.colorScheme)
     var colorScheme
 
+    @AppStorage(FileIconStyle.storageKey)
+    private var iconStyle: FileIconStyle = .default
+
     @State
     var isHovering: Bool = false
 
@@ -101,7 +104,9 @@ struct TabBarItem: View {
                 Image(systemName: item.systemImage)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .foregroundColor(item.iconColor)
+                    .foregroundColor(
+                        iconStyle == .color ? item.iconColor : .secondary
+                    )
                     .frame(width: 12, height: 12)
                 Text(item.url.lastPathComponent)
                     .font(.system(size: 11.0))

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -101,6 +101,7 @@ struct TabBarItem: View {
                 Image(systemName: item.systemImage)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
+                    .foregroundColor(item.iconColor)
                     .frame(width: 12, height: 12)
                 Text(item.url.lastPathComponent)
                     .font(.system(size: 11.0))


### PR DESCRIPTION
### Description

If `File Icon Style` is set to `color`, the tab bar items icon now appears in the correct color.

### Checklist (for drafts):

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

### Screenshots (if appropriate):
<img width="1112" alt="Screen Shot 2022-03-30 at 00 59 01" src="https://user-images.githubusercontent.com/9460130/160720754-98467419-7e87-4f91-b919-7f7875003492.png">

