### PR TITLE
add icon support for go,go.mod,go.sum,env.example,Makefile

### DIFF
--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -45,7 +45,7 @@ public extension WorkspaceClient {
                 return "atom"
             case "swift":
                 return "swift"
-            case "env":
+            case "env", "example":
                 return "gearshape.fill"
             case "gitignore":
                 return "arrow.triangle.branch"
@@ -71,6 +71,14 @@ public extension WorkspaceClient {
                 return "m.square"
             case "vue":
                 return "v.square"
+            case "go":
+                return "g.square"
+            case "sum":
+                return "s.square"
+            case "mod":
+                return "m.square"
+            case "Makefile":
+                return "terminal"
             default:
                 return "doc"
             }
@@ -94,6 +102,12 @@ public extension WorkspaceClient {
                 return Color(red: 0.667, green: 0.031, blue: 0.133, opacity: 1.000)
             case "m":
                 return Color(red: 0.271, green: 0.106, blue: 0.525, opacity: 1.000)
+            case "go":
+                return Color(red: 0.02, green: 0.675, blue: 0.757, opacity: 1.0)
+            case "sum", "mod":
+                return Color(red: 0.925, green: 0.251, blue: 0.478, opacity: 1.0)
+            case "Makefile":
+                return Color(red: 0.937, green: 0.325, blue: 0.314, opacity: 1.0)
             default:
                 return .blue
             }
@@ -143,7 +157,8 @@ public extension WorkspaceClient {
             FileItem.fileManger.createFile(
                 atPath: fileUrl.path,
                 contents: nil,
-                attributes: [FileAttributeKey.creationDate: Date()])
+                attributes: [FileAttributeKey.creationDate: Date()]
+            )
         }
 
         /// This function deletes the item or folder from the current project
@@ -158,6 +173,7 @@ public extension WorkspaceClient {
         }
 
         // MARK: Hashable
+
         public func hash(into hasher: inout Hasher) {
             hasher.combine(id)
             hasher.combine(url)
@@ -165,6 +181,7 @@ public extension WorkspaceClient {
         }
 
         // MARK: Codable
+
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: FileItemCodingKeys.self)
             try container.encode(id, forKey: .id)


### PR DESCRIPTION
**Description**

Add specific file icon and color for `.go` `.mod` `.sum` `.example` and `Makefile` files.

**Releated Issue**

#313 

**Checklist**

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

**Screenshots**
<img width="240" alt="image" src="https://user-images.githubusercontent.com/51419655/160768396-1b5e423c-983b-4892-97fd-80d6ef056c25.png">
<img width="237" alt="CleanShot 2022-03-29 at 23 45 47@2x" src="https://user-images.githubusercontent.com/51419655/160768466-1fd652a3-4ddf-4772-968d-6f336021c9ed.png">

