### PR TITLE
Include commit hash for debug/copy information

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 				B658FB2827DA9E0F00EA4DBD /* Sources */,
 				B658FB2927DA9E0F00EA4DBD /* Frameworks */,
 				B658FB2A27DA9E0F00EA4DBD /* Resources */,
+				2B1A76FC27F628BD008ED4A2 /* Update commit hash */,
 				2BA119D327E5274D00A996FF /* SwiftLint Run Script */,
 				04ADA0CC27E6043B00BF00B2 /* Add TODO/FIXME as warnings | Run Script */,
 			);
@@ -488,6 +489,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "TAGS=\"TODO:|FIXME:\"\necho \"searching ${SRCROOT} for ${TAGS}\"\nfind \"${SRCROOT}\" \\( -name \"*.swift\" \\) -print0 | xargs -0 egrep --with-filename --line-number --only-matching \"($TAGS).*\\$\" | perl -p -e \"s/($TAGS)/ warning: \\$1/\"\n";
+		};
+		2B1A76FC27F628BD008ED4A2 /* Update commit hash */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Update commit hash";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Hash (full length)\nGITHASH=$(git rev-parse HEAD)\n\necho \"${PROJECT_DIR}/${INFOPLIST_FILE}\"\necho $GITHASH\n# Set the hash.\n/usr/libexec/PlistBuddy -c \"Set :GitHash $GITHASH\" \"${PROJECT_DIR}/${INFOPLIST_FILE}\"\n";
 		};
 		2BA119D327E5274D00A996FF /* SwiftLint Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -44,5 +44,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>GitHash</key>
+	<string>Placeholder</string>
 </dict>
 </plist>

--- a/CodeEdit/Welcome/WelcomeView.swift
+++ b/CodeEdit/Welcome/WelcomeView.swift
@@ -52,6 +52,7 @@ struct WelcomeView: View {
         return Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
     }
 
+    /// Get the MacOS version & build
     private var macOsVersion: String {
         var osSeperated = ProcessInfo.processInfo.operatingSystemVersionString.components(separatedBy: " ")
         if osSeperated.count > 1 {
@@ -62,6 +63,7 @@ struct WelcomeView: View {
         return "\(osSeperated[0]) (\(osSeperated[1])"
     }
 
+    /// Return the Xcode version and build (if installed)
     private var xcodeVersion: String? {
         guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.dt.Xcode"),
               let bundle = Bundle(url: url),
@@ -75,6 +77,34 @@ struct WelcomeView: View {
         }
 
         return "\(version) (\(build))"
+    }
+
+    /// Get the last commit hash.
+    private var getGitHash: String? {
+        if let hash = Bundle.main.infoDictionary?["GitHash"] as? String {
+            return hash
+        }
+
+        return nil
+    }
+
+    /// Get program and operating system information
+    private func copyInformation() {
+        var copyString = "CodeEdit: \(appVersion) (\(appBuild))\n"
+
+        if let hash = getGitHash {
+            copyString.append("Commit: \(hash)\n")
+        }
+
+        copyString.append("MacOS: \(macOsVersion)\n")
+
+        if let xcodeVersion = xcodeVersion {
+            copyString.append("Xcode: \(xcodeVersion)")
+        }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(copyString, forType: .string)
     }
 
     var body: some View {
@@ -97,17 +127,9 @@ struct WelcomeView: View {
                         }
                     }
                     .onTapGesture {
-                        var copyString = "CodeEdit: \(appVersion) (\(appBuild))\n" +
-                        "MacOS: \(macOsVersion)\n"
-
-                        if let xcodeVersion = xcodeVersion {
-                            copyString.append("Xcode: \(xcodeVersion)")
-                        }
-
-                        let pasteboard = NSPasteboard.general
-                        pasteboard.clearContents()
-                        pasteboard.setString(copyString, forType: .string)
+                        copyInformation()
                     }
+
                 Spacer().frame(height: 20)
                 HStack {
                     VStack(alignment: .leading, spacing: 15) {


### PR DESCRIPTION
Include commit hash for debug/copy information

**Description**

Include commit hash for debug/copy information if you press the version number on the welcome screen.
This will output something like:
```
CodeEdit: 1.0 (1)
Commit: ee45dc239cf8cc8031b8ff50e1d9f1469351300e
MacOS: 12.3 (21E230)
Xcode: 13.3 (13E113)
```

**Releated Issue**

None, Discord: https://discord.com/channels/951544472238444645/954084547694325861/958726709513945159

**Checklist**

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested (@lukepistrol)

