### PR TITLE
Add about screen

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		5C403B8F27E20F8000788241 /* WorkspaceClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5C403B8E27E20F8000788241 /* WorkspaceClient */; };
 		5CF38A5E27E48E6C0096A0F7 /* CodeFile in Frameworks */ = {isa = PBXBuildFile; productRef = 5CF38A5D27E48E6C0096A0F7 /* CodeFile */; };
 		5CFA753B27E896B60002F01B /* GitClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5CFA753A27E896B60002F01B /* GitClient */; };
+		64B64EDE27F7B79400C400F1 /* About in Frameworks */ = {isa = PBXBuildFile; productRef = 64B64EDD27F7B79400C400F1 /* About */; };
 		B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3327DA9E1000EA4DBD /* Assets.xcassets */; };
 		B658FB3727DA9E1000EA4DBD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3627DA9E1000EA4DBD /* Preview Assets.xcassets */; };
 		B65E614627E6765D00255275 /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = B65E614527E6765D00255275 /* Introspect */; };
@@ -126,6 +127,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				64B64EDE27F7B79400C400F1 /* About in Frameworks */,
 				5C403B8F27E20F8000788241 /* WorkspaceClient in Frameworks */,
 				2803257127F3CF1F009C7DC2 /* AppPreferences in Frameworks */,
 				0485EB2527E7B9C800138301 /* Overlays in Frameworks */,
@@ -359,6 +361,7 @@
 				2859B93E27EB50050069BE88 /* FontPicker */,
 				2803257027F3CF1F009C7DC2 /* AppPreferences */,
 				20D2A95427F72E6800E7ECF6 /* Accounts */,
+				64B64EDD27F7B79400C400F1 /* About */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -973,6 +976,10 @@
 		5CFA753A27E896B60002F01B /* GitClient */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = GitClient;
+		};
+		64B64EDD27F7B79400C400F1 /* About */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = About;
 		};
 		B65E614527E6765D00255275 /* Introspect */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "Highlightr",
-        "repositoryURL": "https://github.com/raspu/Highlightr",
+        "repositoryURL": "https://github.com/raspu/Highlightr.git",
         "state": {
           "branch": null,
           "revision": "93199b9e434f04bda956a613af8f571933f9f037",

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -131,7 +131,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         window.contentView = NSHostingView(rootView: contentView)
         window.makeKeyAndOrderFront(self)
     }
-    
+
     @IBAction func openAbout(_ sender: Any) {
         AboutView().showWindow(width: 530, height: 220)
     }

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import AppPreferences
 import Preferences
+import About
 
 class CodeEditApplication: NSApplication {
     let strongDelegate = AppDelegate()
@@ -129,6 +130,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         window.isMovableByWindowBackground = true
         window.contentView = NSHostingView(rootView: contentView)
         window.makeKeyAndOrderFront(self)
+    }
+    
+    @IBAction func openAbout(_ sender: Any) {
+        AboutView().showWindow(width: 530, height: 220)
     }
 
     // MARK: - Preferences

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>4098b14463bc18869393d31208cb00f4a37452ba</string>
+	<string>bc9506c189638920c3f409523d3e1845fa532e74</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>2796d43728c1c91879f0bde9a5b2347e546933dd</string>
+	<string>4f475962ec146a4623c7f5b2a80e10dbdf7809ae</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>4f475962ec146a4623c7f5b2a80e10dbdf7809ae</string>
+	<string>4098b14463bc18869393d31208cb00f4a37452ba</string>
 </dict>
 </plist>

--- a/CodeEdit/MainMenu.xib
+++ b/CodeEdit/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
@@ -17,7 +17,7 @@
                             <menuItem title="About CodeEdit" id="5kV-Vb-QxS">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="orderFrontStandardAboutPanel:" target="-1" id="Exp-CZ-Vem"/>
+                                    <action selector="openAbout:" target="-1" id="umi-l3-sdf"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>

--- a/CodeEditModules/Modules/About/src/AboutView.swift
+++ b/CodeEditModules/Modules/About/src/AboutView.swift
@@ -54,7 +54,15 @@ public struct AboutView: View {
                 Spacer().frame(height: 20)
             }
         }
-        .background(Color(nsColor: colorScheme == .dark ? .windowBackgroundColor : .white))
+        .background(backgroundColor)
+    }
+
+    public var backgroundColor: Color? {
+        if #available(macOS 12.0, *) {
+            return Color(nsColor: colorScheme == .dark ? .windowBackgroundColor : .white)
+        } else {
+            return nil
+        }
     }
 
     public func showWindow(width: CGFloat, height: CGFloat) {

--- a/CodeEditModules/Modules/About/src/AboutView.swift
+++ b/CodeEditModules/Modules/About/src/AboutView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+public struct AboutView: View {
+    @Environment(\.colorScheme)
+    var colorScheme
+
+    public init() {}
+    
+    private var appVersion: String {
+        return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+    }
+
+    private var appBuild: String {
+        return Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
+    }
+    
+    public var body: some View {
+        HStack(spacing: 0) {
+            Spacer().frame(width: 32)
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 128, height: 128)
+            Spacer().frame(width: 32)
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 0) {
+                    Spacer().frame(width: 6)
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text("CodeEdit").font(.system(size: 38, weight: .regular))
+                        Text("Version \(appVersion) (\(appBuild))")
+                            .foregroundColor(.secondary)
+                            .font(.system(size: 13, weight: .light))
+                        Spacer().frame(height: 36)
+                        Text("Copyright (c) 2022 CodeEdit\n\nMIT License")
+                            .foregroundColor(.secondary)
+                            .font(.system(size: 9, weight: .light))
+                            .lineSpacing(0.2)
+                    }
+                    Spacer().frame(width: 32)
+                }
+                Spacer()
+                HStack(spacing: 0) {
+                    Spacer().frame(width: 6)
+                    Button(action: {}, label: {
+                        Text("Acknowledgments")
+                            .frame(width: 136, height: 20)
+                    })
+                    Spacer().frame(width: 12)
+                    Button(action: {}, label: {
+                        Text("License Agreement")
+                            .frame(width: 136, height: 20)
+                    })
+                    Spacer().frame(width: 16)
+                }.frame(maxWidth: .infinity)
+                Spacer().frame(height: 20)
+            }
+        }
+        .background(Color(nsColor: colorScheme == .dark ? .windowBackgroundColor : .white))
+    }
+
+    public func showWindow(width: CGFloat, height: CGFloat) {
+        PlaceholderWindowController(view: self, size: NSSize(width: width, height: height)).showWindow(nil)
+    }
+}
+
+final class PlaceholderWindowController: NSWindowController {
+    convenience init<T: View>(view: T, size: NSSize) {
+        let hostingController = NSHostingController(rootView: view)
+        
+        //New window holding our SwiftUI view
+        let window = NSWindow(contentViewController: hostingController)
+        self.init(window: window)
+        window.setContentSize(size)
+        window.styleMask.remove(.resizable)
+        window.styleMask.insert(.fullSizeContentView)
+        window.alphaValue = 0.5
+        window.styleMask.remove(.miniaturizable)
+    }
+    
+    override func showWindow(_ sender: Any?) {
+        window?.center()
+        window?.alphaValue = 0.0
+        
+        super.showWindow(sender)
+        
+        window?.animator().alphaValue = 1.0
+        
+        // close the window when the escape key is pressed
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.keyCode == 53 else { return event }
+            
+            self.closeAnimated()
+            
+            return nil
+        }
+        
+        window?.collectionBehavior = [.transient, .ignoresCycle]
+        window?.isMovableByWindowBackground = true
+        window?.titlebarAppearsTransparent = true
+        window?.titleVisibility = .hidden
+    }
+    
+    func closeAnimated() {
+        NSAnimationContext.beginGrouping()
+        NSAnimationContext.current.duration = 0.4
+        NSAnimationContext.current.completionHandler = {
+            self.close()
+        }
+        window?.animator().alphaValue = 0.0
+        NSAnimationContext.endGrouping()
+    }
+}

--- a/CodeEditModules/Modules/About/src/AboutView.swift
+++ b/CodeEditModules/Modules/About/src/AboutView.swift
@@ -5,7 +5,7 @@ public struct AboutView: View {
     var colorScheme
 
     public init() {}
-    
+
     private var appVersion: String {
         return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
     }
@@ -13,7 +13,7 @@ public struct AboutView: View {
     private var appBuild: String {
         return Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
     }
-    
+
     public var body: some View {
         HStack(spacing: 0) {
             Spacer().frame(width: 32)
@@ -65,8 +65,7 @@ public struct AboutView: View {
 final class PlaceholderWindowController: NSWindowController {
     convenience init<T: View>(view: T, size: NSSize) {
         let hostingController = NSHostingController(rootView: view)
-        
-        //New window holding our SwiftUI view
+        // New window holding our SwiftUI view
         let window = NSWindow(contentViewController: hostingController)
         self.init(window: window)
         window.setContentSize(size)
@@ -75,30 +74,30 @@ final class PlaceholderWindowController: NSWindowController {
         window.alphaValue = 0.5
         window.styleMask.remove(.miniaturizable)
     }
-    
+
     override func showWindow(_ sender: Any?) {
         window?.center()
         window?.alphaValue = 0.0
-        
+
         super.showWindow(sender)
-        
+
         window?.animator().alphaValue = 1.0
-        
+
         // close the window when the escape key is pressed
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             guard event.keyCode == 53 else { return event }
-            
+
             self.closeAnimated()
-            
+
             return nil
         }
-        
+
         window?.collectionBehavior = [.transient, .ignoresCycle]
         window?.isMovableByWindowBackground = true
         window?.titlebarAppearsTransparent = true
         window?.titleVisibility = .hidden
     }
-    
+
     func closeAnimated() {
         NSAnimationContext.beginGrouping()
         NSAnimationContext.current.duration = 0.4

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "CodeEditModules",
     defaultLocalization: "en",
     platforms: [
-        .macOS(.v11),
+        .macOS(.v12),
     ],
     products: [
         .library(
@@ -56,6 +56,10 @@ let package = Package(
         .library(
             name: "Accounts",
             targets: ["Accounts"]
+        ),
+        .library(
+            name: "About",
+            targets: ["About"]
         ),
     ],
     dependencies: [
@@ -182,6 +186,10 @@ let package = Package(
         .target(
             name: "Accounts",
             path: "Modules/Accounts/src"
+        ),
+        .target(
+            name: "About",
+            path: "Modules/About/src"
         ),
     ]
 )

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "CodeEditModules",
     defaultLocalization: "en",
     platforms: [
-        .macOS(.v12),
+        .macOS(.v11),
     ],
     products: [
         .library(


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

**Description**

Add screen for showing about page. Tried to match one-to-one with Xcode page.

<!--- REQUIRED: Describe what changed in detail -->

**Releated Issue**

As first step of showing acknowledgments https://github.com/CodeEditApp/CodeEdit/issues/340, we need first to show About

<!--- REQUIRED: Tag all related issues (e.g. #23) -->

**Checklist**

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

**Screenshots**

<!--- REQUIRED: if issue is UI related -->
<img width="552" alt="Screenshot 2022-04-02 at 00 51 39" src="https://user-images.githubusercontent.com/4473783/161352209-c7e9309b-5162-41c0-96e6-cabbc00c9f75.png">
<img width="567" alt="Screenshot 2022-04-02 at 00 51 56" src="https://user-images.githubusercontent.com/4473783/161352219-6330c0b4-2312-4c96-9089-9ed405a95fa6.png">

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this issue temporarily -->
