### PR TITLE
Abbreviating with tilde in path

### DIFF
--- a/CodeEditModules/Modules/WelcomeModule/src/RecentProjectItem.swift
+++ b/CodeEditModules/Modules/WelcomeModule/src/RecentProjectItem.swift
@@ -8,6 +8,12 @@
 import SwiftUI
 import WorkspaceClient
 
+extension String {
+    func abbreviatingWithTildeInPath() -> String {
+        return (self as NSString).abbreviatingWithTildeInPath
+    }
+}
+
 public struct RecentProjectItem: View {
     let projectPath: String
 
@@ -24,7 +30,7 @@ public struct RecentProjectItem: View {
             VStack(alignment: .leading) {
                 Text(projectPath.components(separatedBy: "/").last ?? "").font(.system(size: 13))
                     .lineLimit(1)
-                Text(projectPath)
+                Text(projectPath.abbreviatingWithTildeInPath())
                     .font(.system(size: 11))
                     .lineLimit(1)
                     .truncationMode(.head)


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

**Description**
In order not to have the path displayed too long, the tilde is used to shorten it, as is done in many programs and even in shells.

<!--- REQUIRED: Tag all related issues (e.g. #23) -->

**Checklist**

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

**Screenshots**

<img width="299" alt="Schermata 2022-04-02 alle 12 14 45" src="https://user-images.githubusercontent.com/20476002/161378893-c32985b3-975c-4580-88dc-1ad1c7dd02d3.png">


<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this issue temporarily -->
