### PR TITLE
🛠 Preferences: added locations section, more cohesive layout of labels

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -213,7 +213,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
                 title: "Locations",
                 toolbarIcon: NSImage(systemSymbolName: "externaldrive", accessibilityDescription: nil)!
             ) {
-                PreferencesPlaceholderView()
+                PreferencesLocationsView()
             },
             Preferences.Pane(
                 identifier: Preferences.PaneIdentifier("Advanced"),

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>e3a67545e65e3719f05ef880787360c7551564e9</string>
+	<string>73db927603933074fe067eead100659caa76d87d</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>73db927603933074fe067eead100659caa76d87d</string>
+	<string>0573dd9eda65e78abcd878d6c912e513bea04dbd</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/AppPreferences/src/Extensions/Loopable.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Extensions/Loopable.swift
@@ -1,0 +1,52 @@
+//
+//  Loopable.swift
+//  
+//
+//  Created by Lukas Pistrol on 03.04.22.
+//
+
+import Foundation
+
+/// Loopable protocol implements a method that will return all child
+/// properties and their associated values of a `Type`
+protocol Loopable {
+    func allProperties() throws -> [String: Any]
+}
+
+extension Loopable {
+
+    /// returns all child properties and their associated values of `self`
+    ///
+    /// **Example:**
+    /// ```swift
+    /// struct Author: Loopable {
+    ///   var name: String = "Steve"
+    ///   var books: Int = 4
+    /// }
+    ///
+    /// let author = Author()
+    /// print(author.allProperties())
+    ///
+    /// // returns
+    /// ["name": "Steve", "books": 4]
+    /// ```
+    func allProperties() throws -> [String: Any] {
+        var result: [String: Any] = [:]
+
+        let mirror = Mirror(reflecting: self)
+
+        guard let style = mirror.displayStyle, style == .struct || style == .class else {
+            throw NSError()
+        }
+
+        for (property, value) in mirror.children {
+            guard let property = property else {
+                continue
+            }
+
+            result[property] = value
+        }
+
+        return result
+    }
+}

--- a/CodeEditModules/Modules/AppPreferences/src/GeneralPreferences/PreferencesGeneralView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/GeneralPreferences/PreferencesGeneralView.swift
@@ -16,41 +16,41 @@ public struct PreferencesGeneralView: View {
     public init() {}
 
     public var body: some View {
-        Form {
-            Picker("Appearance:", selection: $prefs.preferences.general.appAppearance) {
-                Text("System")
-                    .tag(AppPreferences.Appearances.system)
-                Divider()
-                Text("Light")
-                    .tag(AppPreferences.Appearances.light)
-                Text("Dark")
-                    .tag(AppPreferences.Appearances.dark)
+        PreferencesContent {
+            PreferencesSection("Appearance") {
+                Picker("Appearance:", selection: $prefs.preferences.general.appAppearance) {
+                    Text("System")
+                        .tag(AppPreferences.Appearances.system)
+                    Divider()
+                    Text("Light")
+                        .tag(AppPreferences.Appearances.light)
+                    Text("Dark")
+                        .tag(AppPreferences.Appearances.dark)
+                }
+                .onChange(of: prefs.preferences.general.appAppearance) { tag in
+                    tag.applyAppearance()
+                }
             }
-            .onChange(of: prefs.preferences.general.appAppearance) { tag in
-                tag.applyAppearance()
+            PreferencesSection("File Icon Style") {
+                Picker("File Icon Style:", selection: $prefs.preferences.general.fileIconStyle) {
+                    Text("Color")
+                        .tag(AppPreferences.FileIconStyle.color)
+                    Text("Monochrome")
+                        .tag(AppPreferences.FileIconStyle.monochrome)
+                }
+                .pickerStyle(.radioGroup)
             }
-            .fixedSize()
-
-            Picker("File Icon Style:", selection: $prefs.preferences.general.fileIconStyle) {
-                Text("Color")
-                    .tag(AppPreferences.FileIconStyle.color)
-                Text("Monochrome")
-                    .tag(AppPreferences.FileIconStyle.monochrome)
+            PreferencesSection("Reopen Behavior") {
+                Picker("Reopen Behavior:", selection: $prefs.preferences.general.reopenBehavior) {
+                    Text("Welcome Screen")
+                        .tag(AppPreferences.ReopenBehavior.welcome)
+                    Divider()
+                    Text("Open Panel")
+                        .tag(AppPreferences.ReopenBehavior.openPanel)
+                    Text("New Document")
+                        .tag(AppPreferences.ReopenBehavior.newDocument)
+                }
             }
-            .pickerStyle(.radioGroup)
-
-            Picker("Reopen Behavior:", selection: $prefs.preferences.general.reopenBehavior) {
-                Text("Welcome Screen")
-                    .tag(AppPreferences.ReopenBehavior.welcome)
-                Divider()
-                Text("Open Panel")
-                    .tag(AppPreferences.ReopenBehavior.openPanel)
-                Text("New Document")
-                    .tag(AppPreferences.ReopenBehavior.newDocument)
-            }
-            .fixedSize()
         }
-        .frame(width: 844)
-        .padding(30)
     }
 }

--- a/CodeEditModules/Modules/AppPreferences/src/HelperViews/PreferencesSection.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/HelperViews/PreferencesSection.swift
@@ -1,0 +1,66 @@
+//
+//  PreferencesSection.swift
+//  
+//
+//  Created by Lukas Pistrol on 03.04.22.
+//
+
+import SwiftUI
+
+internal struct PreferencesContent<Content: View>: View {
+
+    private var width: Double
+    private var content: Content
+
+    init(width: Double = 844, @ViewBuilder content: () -> Content) {
+        self.width = width
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            content
+        }
+        .frame(width: width)
+        .padding(30)
+    }
+}
+
+internal struct PreferencesSection<Content: View>: View {
+
+    private var title: String
+    private var width: Double
+    private var content: Content
+
+    init(_ title: String, width: Double = 300, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.width = width
+        self.content = content()
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("\(title):")
+                .frame(width: width, alignment: .trailing)
+            VStack(alignment: .leading) {
+                content
+                    .labelsHidden()
+                    .fixedSize()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(minHeight: 20)
+            }
+        }
+    }
+}
+
+struct PreferencesSection_Previews: PreviewProvider {
+    static var previews: some View {
+        PreferencesSection("Title") {
+            Picker("Test", selection: .constant(true)) {
+                Text("Hi")
+                    .tag(true)
+            }
+            Text("Whats up?")
+        }
+    }
+}

--- a/CodeEditModules/Modules/AppPreferences/src/LocationsPreferences/PreferencesLocationsView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/LocationsPreferences/PreferencesLocationsView.swift
@@ -1,0 +1,54 @@
+//
+//  PreferencesLocationsView.swift
+//  
+//
+//  Created by Lukas Pistrol on 03.04.22.
+//
+
+import SwiftUI
+import Preferences
+
+public struct PreferencesLocationsView: View {
+
+    public init() {}
+
+    public var body: some View {
+        PreferencesContent {
+            PreferencesSection("Preferences Location") {
+                HStack {
+                    Text(AppPreferencesModel.shared.baseURL.path)
+                        .foregroundColor(.secondary)
+                    Button {
+                        NSWorkspace.shared.selectFile(
+                            nil,
+                            inFileViewerRootedAtPath: AppPreferencesModel.shared.baseURL.path
+                        )
+                    } label: {
+                        Image(systemName: "arrow.right.circle.fill")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.secondary)
+                }
+            }
+            PreferencesSection("Themes Location") {
+                HStack {
+                    Text(ThemeModel.shared.themesURL.path)
+                        .foregroundColor(.secondary)
+                    Button {
+                        NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: ThemeModel.shared.themesURL.path)
+                    } label: {
+                        Image(systemName: "arrow.right.circle.fill")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+}
+
+public struct LocationsPreferences_Previews: PreviewProvider {
+    public static var previews: some View {
+        PreferencesLocationsView()
+    }
+}

--- a/CodeEditModules/Modules/AppPreferences/src/Model/AppPreferencesModel.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/AppPreferencesModel.swift
@@ -38,7 +38,7 @@ public class AppPreferencesModel: ObservableObject {
     /// Load and construct ``AppPreferences`` model from
     /// `~/.codeedit/preferences.json`
     private func loadPreferences() -> AppPreferences {
-        if !filemanager.fileExists(atPath: baseURL.path) {
+        if !filemanager.fileExists(atPath: preferencesURL.path) {
             let codeEditURL = filemanager
                 .homeDirectoryForCurrentUser
                 .appendingPathComponent(".codeedit", isDirectory: true)
@@ -46,7 +46,7 @@ public class AppPreferencesModel: ObservableObject {
             return .init()
         }
 
-        guard let json = try? Data(contentsOf: baseURL),
+        guard let json = try? Data(contentsOf: preferencesURL),
               let prefs = try? JSONDecoder().decode(AppPreferences.self, from: json)
         else {
             return .init()
@@ -60,19 +60,26 @@ public class AppPreferencesModel: ObservableObject {
         let data = try JSONEncoder().encode(preferences)
         let json = try JSONSerialization.jsonObject(with: data)
         let prettyJSON = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
-        try prettyJSON.write(to: baseURL, options: .atomic)
+        try prettyJSON.write(to: preferencesURL, options: .atomic)
     }
 
     /// Default instance of the `FileManager`
     private let filemanager = FileManager.default
 
-    /// The URL of the `preferences.json` settings file.
+    /// The base URL of preferences.
     ///
-    /// `~/.codeedit/preferences.json`
-    private var baseURL: URL {
+    /// Points to `~/.codeedit/`
+    internal var baseURL: URL {
         return filemanager
             .homeDirectoryForCurrentUser
             .appendingPathComponent(".codeedit", isDirectory: true)
+    }
+
+    /// The URL of the `preferences.json` settings file.
+    ///
+    /// Points to `~/.codeedit/preferences.json`
+    private var preferencesURL: URL {
+        return baseURL
             .appendingPathComponent("preferences")
             .appendingPathExtension("json")
     }

--- a/CodeEditModules/Modules/AppPreferences/src/TerminalPreferences/PreferencesTerminalView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/TerminalPreferences/PreferencesTerminalView.swift
@@ -17,12 +17,14 @@ public struct PreferencesTerminalView: View {
     public init() {}
 
     public var body: some View {
-        Form {
-            shellSelector
-            fontSelector
+        PreferencesContent {
+            PreferencesSection("Shell") {
+                shellSelector
+            }
+            PreferencesSection("Font") {
+                fontSelector
+            }
         }
-        .frame(width: 844)
-        .padding(30)
     }
 
     private var shellSelector: some View {
@@ -35,7 +37,6 @@ public struct PreferencesTerminalView: View {
             Text("Bash")
                 .tag(AppPreferences.TerminalShell.bash)
         }
-        .fixedSize()
     }
 
     @ViewBuilder
@@ -46,7 +47,6 @@ public struct PreferencesTerminalView: View {
             Text("Custom")
                 .tag(true)
         }
-        .fixedSize()
         if prefs.preferences.terminal.font.customFont {
             FontPicker(
                 "\(prefs.preferences.terminal.font.name) \(prefs.preferences.terminal.font.size)",

--- a/CodeEditModules/Modules/AppPreferences/src/TextEditingPreferences/PreferencesTextEditingView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/TextEditingPreferences/PreferencesTextEditingView.swift
@@ -16,17 +16,19 @@ public struct PreferencesTextEditingView: View {
     public init() {}
 
     public var body: some View {
-        Form {
-            fontSelector
-            HStack {
-                Stepper("Default Tab Width:",
-                        value: $prefs.preferences.textEditing.defaultTabWidth,
-                        in: 2...8)
-                Text(String(prefs.preferences.textEditing.defaultTabWidth))
+        PreferencesContent {
+            PreferencesSection("Default Tab Width") {
+                HStack {
+                    Stepper("Default Tab Width:",
+                            value: $prefs.preferences.textEditing.defaultTabWidth,
+                            in: 2...8)
+                    Text(String(prefs.preferences.textEditing.defaultTabWidth))
+                }
+            }
+            PreferencesSection("Font") {
+                fontSelector
             }
         }
-        .frame(width: 844)
-        .padding(30)
     }
 
     @ViewBuilder

--- a/CodeEditModules/Modules/AppPreferences/src/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/ThemePreferences/Model/ThemeModel.swift
@@ -86,7 +86,9 @@ public class ThemeModel: ObservableObject {
     /// they are applied to the loaded themes without altering the original
     /// the files in `~/.codeedit/themes/`.
     public func loadThemes() throws {
+        // remove all themes from memory
         themes.removeAll()
+
         let url = themesURL
 
         var isDir: ObjCBool = false
@@ -99,7 +101,8 @@ public class ThemeModel: ObservableObject {
         // get all filenames in themes folder that end with `.json`
         let content = try filemanager.contentsOfDirectory(atPath: url.path).filter { $0.contains(".json") }
 
-        // if the folder does not contain any themes create a default bundled theme and return
+        // if the folder does not contain any themes create a default bundled theme,
+        // write it to disk and return
         if content.isEmpty {
             guard let defaultUrl = Bundle.main.url(forResource: "default-dark", withExtension: "json") else {
                 return
@@ -119,12 +122,16 @@ public class ThemeModel: ObservableObject {
         try content.forEach { file in
             let fileURL = url.appendingPathComponent(file)
             var theme = try load(from: fileURL)
+
+            // get all properties of terminal and editor colors
             guard let terminalColors = try theme.terminal.allProperties() as? [String: Theme.Attributes],
                   let editorColors = try theme.editor.allProperties() as? [String: Theme.Attributes]
             else {
                 print("error")
                 throw NSError()
             }
+
+            // check if there are any overrides in `preferences.json`
             if let overrides = prefs?.theme.overrides[theme.name]?["terminal"] {
                 terminalColors.forEach { (key, _) in
                     if let attributes = overrides[key] {
@@ -139,9 +146,13 @@ public class ThemeModel: ObservableObject {
                     }
                 }
             }
+
+            // add the theme to themes array
             self.themes.append(theme)
+
+            // if there already is a selected theme in `preferences.json` select this theme
+            // otherwise take the first in the list
             self.selectedTheme = self.themes.first { $0.name == prefs?.theme.selectedTheme } ?? self.themes.first
-            print("loaded themes")
         }
     }
 
@@ -174,8 +185,13 @@ public class ThemeModel: ObservableObject {
             .appendingPathComponent(theme.name)
             .appendingPathExtension("json")
         do {
+            // remove the theme from the list
             try filemanager.removeItem(at: url)
+
+            // remove from overrides in `preferences.json`
             AppPreferencesModel.shared.preferences.theme.overrides.removeValue(forKey: theme.name)
+
+            // reload themes
             try self.loadThemes()
         } catch {
             print(error)
@@ -188,9 +204,12 @@ public class ThemeModel: ObservableObject {
         let url = themesURL
         themes.forEach { theme in
             do {
+                // load the original theme from `~/.codeedit/themes/`
                 let originalUrl = url.appendingPathComponent(theme.name).appendingPathExtension("json")
                 let originalData = try Data(contentsOf: originalUrl)
                 let originalTheme = try JSONDecoder().decode(Theme.self, from: originalData)
+
+                // get properties of the current theme as well as the original
                 guard let terminalColors = try theme.terminal.allProperties() as? [String: Theme.Attributes],
                       let editorColors = try theme.editor.allProperties() as? [String: Theme.Attributes],
                       let oTermColors = try originalTheme.terminal.allProperties() as? [String: Theme.Attributes],
@@ -198,6 +217,9 @@ public class ThemeModel: ObservableObject {
                 else {
                     throw NSError()
                 }
+
+                // compare the properties and if there are differences, save to overrides
+                // in `preferences.json
                 var newAttr: [String: [String: Theme.Attributes]] = ["terminal": [:], "editor": [:]]
                 terminalColors.forEach { (key, value) in
                     if value != oTermColors[key] {
@@ -229,49 +251,5 @@ public class ThemeModel: ObservableObject {
     /// The URL of the `themes` folder
     internal var themesURL: URL {
         baseURL.appendingPathComponent("themes", isDirectory: true)
-    }
-}
-
-/// Loopable protocol implements a method that will return all child
-/// properties and their associated values of a `Type`
-protocol Loopable {
-    func allProperties() throws -> [String: Any]
-}
-
-extension Loopable {
-
-    /// returns all child properties and their associated values of `self`
-    ///
-    /// **Example:**
-    /// ```swift
-    /// struct Author: Loopable {
-    ///   var name: String = "Steve"
-    ///   var books: Int = 4
-    /// }
-    ///
-    /// let author = Author()
-    /// print(author.allProperties())
-    ///
-    /// // returns
-    /// ["name": "Steve", "books": 4]
-    /// ```
-    func allProperties() throws -> [String: Any] {
-        var result: [String: Any] = [:]
-
-        let mirror = Mirror(reflecting: self)
-
-        guard let style = mirror.displayStyle, style == .struct || style == .class else {
-            throw NSError()
-        }
-
-        for (property, value) in mirror.children {
-            guard let property = property else {
-                continue
-            }
-
-            result[property] = value
-        }
-
-        return result
     }
 }

--- a/CodeEditModules/Modules/AppPreferences/src/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/ThemePreferences/Model/ThemeModel.swift
@@ -87,7 +87,7 @@ public class ThemeModel: ObservableObject {
     /// the files in `~/.codeedit/themes/`.
     public func loadThemes() throws {
         themes.removeAll()
-        let url = baseURL.appendingPathComponent("themes")
+        let url = themesURL
 
         var isDir: ObjCBool = false
 
@@ -170,8 +170,7 @@ public class ThemeModel: ObservableObject {
     ///
     /// - Parameter theme: The theme to delete
     public func delete(_ theme: Theme) {
-        let url = baseURL
-            .appendingPathComponent("themes")
+        let url = themesURL
             .appendingPathComponent(theme.name)
             .appendingPathExtension("json")
         do {
@@ -186,7 +185,7 @@ public class ThemeModel: ObservableObject {
     /// Saves changes on theme properties to `overrides`
     /// in `~/.codeedit/preferences.json`.
     private func saveThemes() {
-        let url = baseURL.appendingPathComponent("themes")
+        let url = themesURL
         themes.forEach { theme in
             do {
                 let originalUrl = url.appendingPathComponent(theme.name).appendingPathExtension("json")
@@ -225,6 +224,11 @@ public class ThemeModel: ObservableObject {
     /// The base folder url `~/.codeedit/`
     private var baseURL: URL {
         filemanager.homeDirectoryForCurrentUser.appendingPathComponent(".codeedit")
+    }
+
+    /// The URL of the `themes` folder
+    internal var themesURL: URL {
+        baseURL.appendingPathComponent("themes", isDirectory: true)
     }
 }
 


### PR DESCRIPTION
**Description**

* Added locations sections for displaying file path  locations of relevant directories.
* Labels in Preferences are now a uniform offset from the leading side.

**Releated Issue**

None

**Checklist**

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

**Screenshots**

Locations section:
<img width="1016" alt="Screen Shot 2022-04-03 at 14 06 40" src="https://user-images.githubusercontent.com/9460130/161427478-9447a3f8-e24e-4f24-9241-ad7946470ae6.png">

Offsets:
![Frame 7](https://user-images.githubusercontent.com/9460130/161427635-ef100645-fa09-479e-9065-5740711631ca.png)

