### PR TITLE
Breadcrumbs: fix menu position after resizing window

### DIFF
--- a/CodeEdit/Breadcrumbs/BreadcrumbsComponent.swift
+++ b/CodeEdit/Breadcrumbs/BreadcrumbsComponent.swift
@@ -68,9 +68,11 @@ struct BreadcrumbsComponent: View {
         .onTapGesture {
             if let siblings = fileItem.parent?.children?.sortItems(foldersOnTop: true), !siblings.isEmpty {
                 let menu = BreadcrumsMenu(siblings, workspace: workspace)
-                if let position = position {
+                if let position = position,
+                   let windowHeight = NSApp.keyWindow?.contentView?.frame.height {
+                    let pos = NSPoint(x: position.x, y: windowHeight - 72) // 72 = offset from top to breadcrumbs bar
                     menu.popUp(positioning: menu.item(withTitle: fileItem.fileName),
-                               at: position,
+                               at: pos,
                                in: NSApp.keyWindow?.contentView)
                 }
             }

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>0573dd9eda65e78abcd878d6c912e513bea04dbd</string>
+	<string>203385f07dbb8bcb7aad5218734f5a2db3cc223a</string>
 </dict>
 </plist>


### PR DESCRIPTION
**Description**

This fixes the positioning issues of the breadcrumbs menu after resizing the window.

**Releated Issue**

* #309 

**Checklist**

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

**Screenshots**

https://user-images.githubusercontent.com/9460130/161435666-4533dd6a-1d20-4c4e-adc7-546d98d00284.mov


