### PR TITLE
🛠 Preferences: `TextField` for setting tab width

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>203385f07dbb8bcb7aad5218734f5a2db3cc223a</string>
+	<string>138b222163a5a14e2dc09bbe15d8182dcd43f108</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/AppPreferences/src/TextEditingPreferences/PreferencesTextEditingView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/TextEditingPreferences/PreferencesTextEditingView.swift
@@ -15,6 +15,7 @@ public struct PreferencesTextEditingView: View {
 
     public init() {}
 
+    /// only allows integer values in the range of `[1...8]`
     private var numberFormat: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.allowsFloats = false

--- a/CodeEditModules/Modules/AppPreferences/src/TextEditingPreferences/PreferencesTextEditingView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/TextEditingPreferences/PreferencesTextEditingView.swift
@@ -15,14 +15,26 @@ public struct PreferencesTextEditingView: View {
 
     public init() {}
 
+    private var numberFormat: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.allowsFloats = false
+        formatter.minimum = 1
+        formatter.maximum = 8
+
+        return formatter
+    }
+
     public var body: some View {
         PreferencesContent {
             PreferencesSection("Default Tab Width") {
-                HStack {
+                HStack(spacing: 5) {
+                    TextField("", value: $prefs.preferences.textEditing.defaultTabWidth, formatter: numberFormat)
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 40)
                     Stepper("Default Tab Width:",
                             value: $prefs.preferences.textEditing.defaultTabWidth,
-                            in: 2...8)
-                    Text(String(prefs.preferences.textEditing.defaultTabWidth))
+                            in: 1...8)
+                    Text("spaces")
                 }
             }
             PreferencesSection("Font") {


### PR DESCRIPTION
**Description**

Implemented a TextField for the `Default Tab Width` setting which only allows values in `[1…8]`.

**Releated Issue**

None

**Checklist**

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

**Screenshots**

<img width="1016" alt="Screen Shot 2022-04-03 at 20 22 43" src="https://user-images.githubusercontent.com/9460130/161442535-4223cda1-6ecf-43b5-b31d-2cf2888eac55.png">

