### PR TITLE
Terminal: hook up terminal colors to selected theme

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>138b222163a5a14e2dc09bbe15d8182dcd43f108</string>
+	<string>b6ba533a9d42e71e31f4021989105c8a08c01deb</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView.swift
@@ -100,6 +100,42 @@ public struct TerminalEmulatorView: NSViewRepresentable {
         return []
     }
 
+    /// Returns the `cursor` color of the selected theme
+    private var cursorColor: NSColor {
+        if let selectedTheme = themeModel.selectedTheme,
+           let index = themeModel.themes.firstIndex(of: selectedTheme) {
+            return NSColor(themeModel.themes[index].terminal.cursor.swiftColor)
+        }
+        return NSColor(.accentColor)
+    }
+
+    /// Returns the `selection` color of the selected theme
+    private var selectionColor: NSColor {
+        if let selectedTheme = themeModel.selectedTheme,
+           let index = themeModel.themes.firstIndex(of: selectedTheme) {
+            return NSColor(themeModel.themes[index].terminal.selection.swiftColor)
+        }
+        return NSColor(.accentColor)
+    }
+
+    /// Returns the `text` color of the selected theme
+    private var textColor: NSColor {
+        if let selectedTheme = themeModel.selectedTheme,
+           let index = themeModel.themes.firstIndex(of: selectedTheme) {
+            return NSColor(themeModel.themes[index].terminal.text.swiftColor)
+        }
+        return NSColor(.primary)
+    }
+
+    /// Returns the `background` color of the selected theme
+    private var backgroundColor: NSColor {
+        if let selectedTheme = themeModel.selectedTheme,
+           let index = themeModel.themes.firstIndex(of: selectedTheme) {
+            return NSColor(themeModel.themes[index].terminal.background.swiftColor)
+        }
+        return .windowBackgroundColor
+    }
+
     /// returns a `NSAppearance` based on the user setting of the terminal appearance,
     /// `nil` if app default is not overriden
     private var colorAppearance: NSAppearance? {
@@ -132,6 +168,10 @@ public struct TerminalEmulatorView: NSViewRepresentable {
             terminal.font = font
             terminal.configureNativeColors()
             terminal.installColors(self.colors)
+            terminal.caretColor = cursorColor
+            terminal.selectedTextBackgroundColor = selectionColor
+            terminal.nativeForegroundColor = textColor
+            terminal.nativeBackgroundColor = backgroundColor
         }
         terminal.appearance = colorAppearance
         TerminalEmulatorView.lastTerminal = terminal
@@ -143,6 +183,10 @@ public struct TerminalEmulatorView: NSViewRepresentable {
         }
         view.configureNativeColors()
         view.installColors(self.colors)
+        view.caretColor = cursorColor
+        view.selectedTextBackgroundColor = selectionColor
+        view.nativeForegroundColor = textColor
+        view.nativeBackgroundColor = backgroundColor
         view.appearance = colorAppearance
         if TerminalEmulatorView.lastTerminal != nil {
             TerminalEmulatorView.lastTerminal = view


### PR DESCRIPTION
<!--- REQUIRED: Provide a general summary of your changes in the Title above -->

**Description**

Hooked up all colors (except `bold text`) to the terminal emulator.

**Checklist**

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

**Screenshots**

* exaggerated showcase of the colors in the terminal:
<img width="900" alt="Screen Shot 2022-04-03 at 21 32 37" src="https://user-images.githubusercontent.com/9460130/161445146-608fb2b1-53ff-44a6-83bf-88fa6938c073.png">

