### PR TITLE
Status Bar: Fix drawer in multiple workspaces

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>ecd45fe46e275be30857fba31478cb0ed4887cea</string>
+	<string>69be9a96ac968fbce33dbc5241db0406b991e0b1</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
+++ b/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
@@ -85,9 +85,5 @@ public class StatusBarModel: ObservableObject {
         } catch {
             selectedBranch = nil
         }
-        StatusBarModel.shared = self
     }
-
-    /// shared instance that persists though session
-    public static var shared: StatusBarModel?
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
@@ -25,7 +25,7 @@ public struct StatusBarView: View {
     /// Initialize with GitClient
     /// - Parameter gitClient: a GitClient
     public init(workspaceURL: URL) {
-        self.model = .shared ?? .init(workspaceURL: workspaceURL)
+        self.model = .init(workspaceURL: workspaceURL)
     }
 
     public var body: some View {

--- a/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView+Coordinator.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView+Coordinator.swift
@@ -11,7 +11,13 @@ import SwiftTerm
 public extension TerminalEmulatorView {
     class Coordinator: NSObject, LocalProcessTerminalViewDelegate {
 
-        public override init() {}
+        @State
+        private var url: URL
+
+        public init(url: URL) {
+            self._url = .init(wrappedValue: url)
+            super.init()
+        }
 
         public func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
 
@@ -25,7 +31,7 @@ public extension TerminalEmulatorView {
             }
             source.feed(text: "Exit code: \(exitCode)\n\r\n")
             source.feed(text: "To open a new session close and reopen the terminal drawer")
-            TerminalEmulatorView.lastTerminal = nil
+            TerminalEmulatorView.lastTerminal[url.path] = nil
         }
     }
 }

--- a/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView.swift
@@ -23,7 +23,7 @@ public struct TerminalEmulatorView: NSViewRepresentable {
     @StateObject
     private var themeModel: ThemeModel = .shared
 
-    internal static var lastTerminal: LocalProcessTerminalView?
+    internal static var lastTerminal: [String: LocalProcessTerminalView] = [:]
 
     @State
     internal var terminal: LocalProcessTerminalView
@@ -44,7 +44,7 @@ public struct TerminalEmulatorView: NSViewRepresentable {
 
     public init(url: URL) {
         self.url = url
-        self._terminal = State(initialValue: TerminalEmulatorView.lastTerminal ?? .init(frame: .zero))
+        self._terminal = State(initialValue: TerminalEmulatorView.lastTerminal[url.path] ?? .init(frame: .zero))
     }
 
     /// Returns a string of a shell path to use
@@ -159,7 +159,7 @@ public struct TerminalEmulatorView: NSViewRepresentable {
 
     public func setupSession() {
         terminal.getTerminal().silentLog = true
-        if TerminalEmulatorView.lastTerminal == nil {
+        if TerminalEmulatorView.lastTerminal[url.path] == nil {
             let shell = getShell()
             let shellIdiom = "-" + NSString(string: shell).lastPathComponent
 
@@ -180,7 +180,7 @@ public struct TerminalEmulatorView: NSViewRepresentable {
             terminal.optionAsMetaKey = optionAsMeta
         }
         terminal.appearance = colorAppearance
-        TerminalEmulatorView.lastTerminal = terminal
+        TerminalEmulatorView.lastTerminal[url.path] = terminal
     }
 
     public func updateNSView(_ view: LocalProcessTerminalView, context: Context) {
@@ -195,14 +195,14 @@ public struct TerminalEmulatorView: NSViewRepresentable {
         view.nativeBackgroundColor = backgroundColor
         view.optionAsMetaKey = optionAsMeta
         view.appearance = colorAppearance
-        if TerminalEmulatorView.lastTerminal != nil {
-            TerminalEmulatorView.lastTerminal = view
+        if TerminalEmulatorView.lastTerminal[url.path] != nil {
+            TerminalEmulatorView.lastTerminal[url.path] = view
         }
         view.getTerminal().softReset()
         view.feed(text: "") // send empty character to force colors to be redrawn
     }
 
     public func makeCoordinator() -> Coordinator {
-        Coordinator()
+        Coordinator(url: url)
     }
 }


### PR DESCRIPTION
# Description

Before this PR the status bar drawer would toggle in all open workspaces if toggled in one.
Also Terminal would behave weirdly.

This is now fixed.

# Related Issue

None

# Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/9460130/161697489-57892798-822a-46ac-b600-4843a5b1c6c9.mov


