### PR TITLE
chore: moved QuickOpen folder and files to module

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -12,10 +12,7 @@
 		043C321A27E32295006AE443 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 043C321927E32295006AE443 /* MainMenu.xib */; };
 		04540D5E27DD08C300E91B77 /* WorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */; };
 		04660F6A27E51E5C00477777 /* CodeEditWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6927E51E5C00477777 /* CodeEditWindowController.swift */; };
-		0485EB1927E70F4900138301 /* QuickOpenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485EB1827E70F4900138301 /* QuickOpenView.swift */; };
-		0485EB1D27E7338100138301 /* QuickOpenItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485EB1C27E7338100138301 /* QuickOpenItem.swift */; };
 		0485EB1F27E7458B00138301 /* WorkspaceCodeFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485EB1E27E7458B00138301 /* WorkspaceCodeFileView.swift */; };
-		0485EB2327E7791400138301 /* QuickOpenPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485EB2227E7791400138301 /* QuickOpenPreviewView.swift */; };
 		0485EB2527E7B9C800138301 /* Overlays in Frameworks */ = {isa = PBXBuildFile; productRef = 0485EB2427E7B9C800138301 /* Overlays */; };
 		20D2A95527F72E6800E7ECF6 /* Accounts in Frameworks */ = {isa = PBXBuildFile; productRef = 20D2A95427F72E6800E7ECF6 /* Accounts */; };
 		2803257127F3CF1F009C7DC2 /* AppPreferences in Frameworks */ = {isa = PBXBuildFile; productRef = 2803257027F3CF1F009C7DC2 /* AppPreferences */; };
@@ -36,6 +33,7 @@
 		2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* AppDelegate.swift */; };
 		5C403B8F27E20F8000788241 /* WorkspaceClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5C403B8E27E20F8000788241 /* WorkspaceClient */; };
 		5CA8776327FC4FC8003F5CD5 /* Design in Frameworks */ = {isa = PBXBuildFile; productRef = 5CA8776227FC4FC8003F5CD5 /* Design */; };
+		5CA8776527FC6A95003F5CD5 /* QuickOpen in Frameworks */ = {isa = PBXBuildFile; productRef = 5CA8776427FC6A95003F5CD5 /* QuickOpen */; };
 		5CF38A5E27E48E6C0096A0F7 /* CodeFile in Frameworks */ = {isa = PBXBuildFile; productRef = 5CF38A5D27E48E6C0096A0F7 /* CodeFile */; };
 		5CFA753B27E896B60002F01B /* GitClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5CFA753A27E896B60002F01B /* GitClient */; };
 		64B64EDE27F7B79400C400F1 /* About in Frameworks */ = {isa = PBXBuildFile; productRef = 64B64EDD27F7B79400C400F1 /* About */; };
@@ -83,10 +81,7 @@
 		04660F6027E3A68A00477777 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		04660F6927E51E5C00477777 /* CodeEditWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditWindowController.swift; sourceTree = "<group>"; };
 		0468438427DC76E200F8E88E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		0485EB1827E70F4900138301 /* QuickOpenView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = QuickOpenView.swift; sourceTree = "<group>"; tabWidth = 4; };
-		0485EB1C27E7338100138301 /* QuickOpenItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickOpenItem.swift; sourceTree = "<group>"; };
 		0485EB1E27E7458B00138301 /* WorkspaceCodeFileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCodeFileView.swift; sourceTree = "<group>"; };
-		0485EB2227E7791400138301 /* QuickOpenPreviewView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = QuickOpenPreviewView.swift; sourceTree = "<group>"; tabWidth = 4; };
 		28069DA327F5BCDD0016BC47 /* default-dark.json */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = text.json; path = "default-dark.json"; sourceTree = "<group>"; tabWidth = 2; };
 		2806CBD327EE9FC0003E5523 /* ProjectNavigatorContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectNavigatorContextMenu.swift; sourceTree = "<group>"; };
 		286471AA27ED51FD0039369D /* ProjectNavigator.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ProjectNavigator.swift; sourceTree = "<group>"; tabWidth = 4; };
@@ -131,6 +126,7 @@
 				64B64EDE27F7B79400C400F1 /* About in Frameworks */,
 				5C403B8F27E20F8000788241 /* WorkspaceClient in Frameworks */,
 				2803257127F3CF1F009C7DC2 /* AppPreferences in Frameworks */,
+				5CA8776527FC6A95003F5CD5 /* QuickOpen in Frameworks */,
 				0485EB2527E7B9C800138301 /* Overlays in Frameworks */,
 				D70F5E2C27E4E8CF004EE4B9 /* WelcomeModule in Frameworks */,
 				2859B93F27EB50050069BE88 /* FontPicker in Frameworks */,
@@ -169,16 +165,6 @@
 				D7E201AD27E8B3C000CB86D0 /* String+Ranges.swift */,
 			);
 			path = Documents;
-			sourceTree = "<group>";
-		};
-		0485EB1727E7016400138301 /* Quick Open */ = {
-			isa = PBXGroup;
-			children = (
-				0485EB1827E70F4900138301 /* QuickOpenView.swift */,
-				0485EB1C27E7338100138301 /* QuickOpenItem.swift */,
-				0485EB2227E7791400138301 /* QuickOpenPreviewView.swift */,
-			);
-			path = "Quick Open";
 			sourceTree = "<group>";
 		};
 		28069DA527F5BD320016BC47 /* DefaultThemes */ = {
@@ -267,7 +253,6 @@
 				D7211D4427E066D4008F2ED7 /* Localization */,
 				287776EA27E350A100D46668 /* NavigatorSidebar */,
 				B658FB3527DA9E1000EA4DBD /* Preview Content */,
-				0485EB1727E7016400138301 /* Quick Open */,
 				287776EB27E350BA00D46668 /* TabBar */,
 				D72E1A8127E3B0A300EB11B9 /* Welcome */,
 				0468438427DC76E200F8E88E /* AppDelegate.swift */,
@@ -363,6 +348,7 @@
 				20D2A95427F72E6800E7ECF6 /* Accounts */,
 				64B64EDD27F7B79400C400F1 /* About */,
 				5CA8776227FC4FC8003F5CD5 /* Design */,
+				5CA8776427FC6A95003F5CD5 /* QuickOpen */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -564,7 +550,6 @@
 				2813F93827ECC4AA00E305E4 /* FindNavigatorResultList.swift in Sources */,
 				2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */,
 				2875A46D27E3BE5B007805F8 /* BreadcrumbsView.swift in Sources */,
-				0485EB1D27E7338100138301 /* QuickOpenItem.swift in Sources */,
 				D7012EE827E757850001E1EF /* FindNavigator.swift in Sources */,
 				D7E201AE27E8B3C000CB86D0 /* String+Ranges.swift in Sources */,
 				D7E201B027E8C07300CB86D0 /* FindNavigatorSearchBar.swift in Sources */,
@@ -577,7 +562,6 @@
 				D7E201B227E8D50000CB86D0 /* FindNavigatorModeSelector.swift in Sources */,
 				287776E927E34BC700D46668 /* TabBar.swift in Sources */,
 				0485EB1F27E7458B00138301 /* WorkspaceCodeFileView.swift in Sources */,
-				0485EB1927E70F4900138301 /* QuickOpenView.swift in Sources */,
 				286471AB27ED51FD0039369D /* ProjectNavigator.swift in Sources */,
 				D7E201BD27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift in Sources */,
 				286620A527E4AB6900E18C2B /* BreadcrumbsComponent.swift in Sources */,
@@ -590,7 +574,6 @@
 				043C321627E3201F006AE443 /* WorkspaceDocument.swift in Sources */,
 				28B0A19827E385C300B73177 /* NavigatorSidebarToolbarTop.swift in Sources */,
 				28FFE1BF27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift in Sources */,
-				0485EB2327E7791400138301 /* QuickOpenPreviewView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -983,6 +966,10 @@
 		5CA8776227FC4FC8003F5CD5 /* Design */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Design;
+		};
+		5CA8776427FC6A95003F5CD5 /* QuickOpen */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = QuickOpen;
 		};
 		5CF38A5D27E48E6C0096A0F7 /* CodeFile */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -9,8 +9,9 @@ import Cocoa
 import SwiftUI
 import CodeFile
 import Overlays
+import QuickOpen
 
-class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
+final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
 
     var workspace: WorkspaceDocument?
     var quickOpenPanel: OverlayPanel?
@@ -189,9 +190,11 @@ class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
             } else {
                 let panel = OverlayPanel()
                 self.quickOpenPanel = panel
-                let contentView = QuickOpenView(state: state) {
-                    panel.close()
-                }
+                let contentView = QuickOpenView(
+                    state: state,
+                    onClose: { panel.close() },
+                    openFile: workspace.openFile(item:)
+                )
                 panel.contentView = NSHostingView(rootView: contentView)
                 window?.addChildWindow(panel, ordered: .above)
                 panel.makeKeyAndOrderFront(self)

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>fc103116c8be2a89c94c2f67c800b7ea816f9a65</string>
+	<string>aaa3b5f35c2de1d8ad3d4131eb34e7dd058d12c5</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/QuickOpen/src/QuickOpenItem.swift
+++ b/CodeEditModules/Modules/QuickOpen/src/QuickOpenItem.swift
@@ -9,8 +9,16 @@ import SwiftUI
 import WorkspaceClient
 
 public struct QuickOpenItem: View {
-    let baseDirectory: URL
-    let fileItem: WorkspaceClient.FileItem
+    private let baseDirectory: URL
+    private let fileItem: WorkspaceClient.FileItem
+
+    public init(
+        baseDirectory: URL,
+        fileItem: WorkspaceClient.FileItem
+    ) {
+        self.baseDirectory = baseDirectory
+        self.fileItem = fileItem
+    }
 
     public var body: some View {
         HStack(spacing: 8) {

--- a/CodeEditModules/Modules/QuickOpen/src/QuickOpenPreviewView.swift
+++ b/CodeEditModules/Modules/QuickOpen/src/QuickOpenPreviewView.swift
@@ -9,19 +9,20 @@ import SwiftUI
 import WorkspaceClient
 import CodeFile
 
-struct QuickOpenPreviewView: View {
-    var item: WorkspaceClient.FileItem
+public struct QuickOpenPreviewView: View {
+    private let queue = DispatchQueue(label: "austincondiff.CodeEdit.quickOpen.preview")
+    private let item: WorkspaceClient.FileItem
+    @State private var content: String = ""
+    @State private var loaded = false
+    @State private var error: String?
 
-    @State
-    var content: String = ""
+    public init(
+        item: WorkspaceClient.FileItem
+    ) {
+        self.item = item
+    }
 
-    @State
-    var loaded = false
-
-    @State
-    var error: String?
-
-    var body: some View {
+    public var body: some View {
         VStack {
             if let codeFile = try? CodeFileDocument(
                 for: item.url,
@@ -38,7 +39,7 @@ struct QuickOpenPreviewView: View {
         .onAppear {
             loaded = false
             error = nil
-            DispatchQueue(label: "austincondiff.CodeEdit.quickOpen.preview").async {
+            queue.async {
                 do {
                     let data = try String(contentsOf: item.url)
                     DispatchQueue.main.async {

--- a/CodeEditModules/Modules/QuickOpen/src/QuickOpenState.swift
+++ b/CodeEditModules/Modules/QuickOpen/src/QuickOpenState.swift
@@ -1,0 +1,61 @@
+//
+//  QuickOpenState.swift
+//  CodeEdit
+//
+//  Created by Marco Carnevali on 05/04/22.
+//
+import Combine
+import Foundation
+import WorkspaceClient
+
+public final class QuickOpenState: ObservableObject {
+    @Published var openQuicklyQuery: String = ""
+    @Published var openQuicklyFiles: [WorkspaceClient.FileItem] = []
+    @Published var isShowingOpenQuicklyFiles: Bool = false
+
+    public let fileURL: URL
+    private let queue = DispatchQueue(label: "austincondiff.CodeEdit.quickOpen.searchFiles")
+
+    public init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    func fetchOpenQuickly() {
+        guard openQuicklyQuery != "" else {
+            openQuicklyFiles = []
+            self.isShowingOpenQuicklyFiles = !openQuicklyFiles.isEmpty
+            return
+        }
+
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            let enumerator = FileManager.default.enumerator(
+                at: self.fileURL,
+                includingPropertiesForKeys: [
+                    .isRegularFileKey
+                ],
+                options: [
+                    .skipsHiddenFiles,
+                    .skipsPackageDescendants
+                ]
+            )
+            if let filePaths = enumerator?.allObjects as? [URL] {
+                let files = filePaths.filter { url in
+                    let state1 = url.lastPathComponent.lowercased().contains(self.openQuicklyQuery.lowercased())
+                    do {
+                        let values = try url.resourceValues(forKeys: [.isRegularFileKey])
+                        return state1 && (values.isRegularFile ?? false)
+                    } catch {
+                        return false
+                    }
+                }.map { url in
+                    WorkspaceClient.FileItem(url: url, children: nil)
+                }
+                DispatchQueue.main.async {
+                    self.openQuicklyFiles = files
+                    self.isShowingOpenQuicklyFiles = !self.openQuicklyFiles.isEmpty
+                }
+            }
+        }
+    }
+}

--- a/CodeEditModules/Modules/QuickOpen/src/QuickOpenView.swift
+++ b/CodeEditModules/Modules/QuickOpen/src/QuickOpenView.swift
@@ -9,15 +9,23 @@ import SwiftUI
 import WorkspaceClient
 import Design
 
-struct QuickOpenView: View {
-    @ObservedObject
-    var state: WorkspaceDocument.QuickOpenState
+public struct QuickOpenView: View {
+    @ObservedObject private var state: QuickOpenState
+    private let onClose: () -> Void
+    private let openFile: (WorkspaceClient.FileItem) -> Void
+    @State private var selectedItem: WorkspaceClient.FileItem?
 
-    @State
-    var selectedItem: WorkspaceClient.FileItem?
-    var onClose: () -> Void
+    public init(
+        state: QuickOpenState,
+        onClose: @escaping () -> Void,
+        openFile: @escaping (WorkspaceClient.FileItem) -> Void
+    ) {
+        self.state = state
+        self.onClose = onClose
+        self.openFile = openFile
+    }
 
-    var body: some View {
+    public var body: some View {
         VStack(spacing: 0.0) {
             VStack {
                 HStack(alignment: .center, spacing: 0) {
@@ -47,10 +55,10 @@ struct QuickOpenView: View {
                     NavigationLink(tag: file, selection: $selectedItem) {
                         QuickOpenPreviewView(item: file)
                     } label: {
-                        QuickOpenItem(baseDirectory: state.workspace.fileURL!, fileItem: file)
+                        QuickOpenItem(baseDirectory: state.fileURL, fileItem: file)
                     }
                     .onTapGesture(count: 2) {
-                        state.workspace.openFile(item: file)
+                        self.openFile(file)
                         self.onClose()
                     }
                     .onTapGesture(count: 1) {
@@ -76,6 +84,10 @@ struct QuickOpenView: View {
 
 struct QuickOpenView_Previews: PreviewProvider {
     static var previews: some View {
-        QuickOpenView(state: .init(.init()), onClose: {})
+        QuickOpenView(
+            state: .init(fileURL: .init(fileURLWithPath: "")),
+            onClose: {},
+            openFile: { _ in }
+        )
     }
 }

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -62,6 +62,10 @@ let package = Package(
             targets: ["About"]
         ),
         .library(
+            name: "QuickOpen",
+            targets: ["QuickOpen"]
+        ),
+        .library(
             name: "Design",
             targets: ["Design"]
         ),
@@ -201,6 +205,15 @@ let package = Package(
         .target(
             name: "About",
             path: "Modules/About/src"
+        ),
+        .target(
+            name: "QuickOpen",
+            dependencies: [
+                "WorkspaceClient",
+                "CodeFile",
+                "Design",
+            ],
+            path: "Modules/QuickOpen/src"
         ),
         .target(
             name: "Design",


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->
In an effort to modularize the code, I moved the `QuickOpen` folder into it's own module. I've also moved the QuickOpenStatus ObservedObject inside this module instead of it living inside the WorkspaceDocument (didn't make much sense). 
If you can please give it a test!
# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. #23) -->
#233 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
