### PR TITLE
QuickOpen: fixed non-breaking space

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>aaa3b5f35c2de1d8ad3d4131eb34e7dd058d12c5</string>
+	<string>213bbbcea5ac2b7f9cb39d63f6a3a1c479165dc5</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/QuickOpen/src/QuickOpenState.swift
+++ b/CodeEditModules/Modules/QuickOpen/src/QuickOpenState.swift
@@ -28,7 +28,7 @@ public final class QuickOpenState: ObservableObject {
         }
 
         queue.async { [weak self] in
-            guard let self = self else { return }
+            guard let self = self else { return }
             let enumerator = FileManager.default.enumerator(
                 at: self.fileURL,
                 includingPropertiesForKeys: [


### PR DESCRIPTION
# Description

fixed warning about `non-breaking space` in `QuickOpen` module.

# Related Issue

none

# Screenshots

<img width="258" alt="Screen Shot 2022-04-05 at 14 36 16" src="https://user-images.githubusercontent.com/9460130/161755205-7fc54077-2810-4d68-ab72-4a5ce37eb0b4.png">

