### PR TITLE
Fix compile issue for GitClient Test target

### DIFF
--- a/CodeEditModules/Modules/GitClient/Tests/GitClientTests.swift
+++ b/CodeEditModules/Modules/GitClient/Tests/GitClientTests.swift
@@ -20,9 +20,8 @@ final class GitClientTests: XCTestCase {
             directoryURL: URL(fileURLWithPath: ""),
             shellClient: shellClient
         )
-        print(try gitClient.getCommitHistory(nil))
         XCTAssertEqual(
-            try gitClient.getCommitHistory(nil).first!,
+            try gitClient.getCommitHistory(nil, nil).first!,
             GitClient.Commit(
                 hash: "e5fe4bf",
                 message: "Merge pull request #260 from lukepistrol/terminal-color-fix",


### PR DESCRIPTION
# Description

Fix compile issue for GitClient Test target

This will not block the main Xcode project. However this will prevent SwiftUI to preview when opening Package.swift in CodeEditModules folder.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
