### PR TITLE
Skipped GitClientTests on non-English locale

### DIFF
--- a/CodeEditModules/Modules/GitClient/Tests/GitClientTests.swift
+++ b/CodeEditModules/Modules/GitClient/Tests/GitClientTests.swift
@@ -10,6 +10,8 @@ import ShellClient
 import XCTest
 
 final class GitClientTests: XCTestCase {
+    // FIXME: Update GitClient.getCommitHistory implementation on date or this test case
+    // Currently this will fail on some non en_US locale like zh_CN
     func testHistory() throws {
         let shellClient: ShellClient = .always(
             "e5fe4bf¦Merge pull request #260 from lukepistrol/terminal-color-fix¦Luke¦Sat, 26 Mar 2022 03:28:12 +0100¦"


### PR DESCRIPTION
# Description

Skipped on non-English locale until we fix the GitClient.getCommitHistory implementation on date

Currently this will fail on some non-English locale because `dateFormatter.date(from: parameters[safe: 3] ?? "")` will return nil and use the `Date()` value

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
