### PR TITLE
Project Navigator: Fixed icon/label alignments & sizes

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>5a976aabec4dddcf27ac783a0912cbd3dea72694</string>
+	<string>5add4e55482d493e601d9fe5a3c06608f896425c</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>b37f5d154833073bf902e7f987b2fd7a773eaa4d</string>
+	<string>b42fe64b91619183f753183ce52ca9f472509037</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>5add4e55482d493e601d9fe5a3c06608f896425c</string>
+	<string>b37f5d154833073bf902e7f987b2fd7a773eaa4d</string>
 </dict>
 </plist>

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -30,12 +30,9 @@ class OutlineTableViewCell: NSTableCellView {
 
         // Create the icon
 
-        // TODO: Icon clips
-
-        self.icon = NSImageView(frame: .init(origin: .zero, size: .zero))
+        self.icon = NSImageView(frame: .zero)
         self.icon.translatesAutoresizingMaskIntoConstraints = false
         self.icon.symbolConfiguration = .init(textStyle: .subheadline, scale: .medium)
-        self.icon.imageAlignment = .alignCenter
 
         self.addSubview(icon)
         self.imageView = icon
@@ -44,7 +41,7 @@ class OutlineTableViewCell: NSTableCellView {
 
         self.icon.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0).isActive = true
         self.icon.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-        self.icon.widthAnchor.constraint(equalToConstant: 20).isActive = true
+        self.icon.widthAnchor.constraint(equalToConstant: 21).isActive = true
         self.icon.heightAnchor.constraint(equalToConstant: frameRect.height).isActive = true
 
         // Label constraints

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -16,8 +16,6 @@ class OutlineTableViewCell: NSTableCellView {
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
 
-        let iconHeight = frameRect.height - 2
-
         // Create the label
 
         self.label = NSTextField(frame: .zero)
@@ -25,30 +23,33 @@ class OutlineTableViewCell: NSTableCellView {
         self.label.drawsBackground = false
         self.label.isBordered = false
         self.label.isEditable = false
+        self.label.font = .preferredFont(forTextStyle: .subheadline)
 
         self.addSubview(label)
         self.textField = label
 
         // Create the icon
 
+        // TODO: Icon clips
+
         self.icon = NSImageView(frame: .init(origin: .zero, size: .zero))
         self.icon.translatesAutoresizingMaskIntoConstraints = false
-        self.icon.symbolConfiguration = .init(pointSize: 13, weight: .regular, scale: .medium)
-        self.icon.imageScaling = .scaleProportionallyDown
+        self.icon.symbolConfiguration = .init(textStyle: .subheadline, scale: .medium)
+        self.icon.imageAlignment = .alignCenter
 
         self.addSubview(icon)
         self.imageView = icon
 
         // Icon constraints
 
-        self.icon.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 2).isActive = true
+        self.icon.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0).isActive = true
         self.icon.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-        self.icon.widthAnchor.constraint(equalToConstant: iconHeight).isActive = true
-        self.icon.heightAnchor.constraint(equalToConstant: iconHeight).isActive = true
+        self.icon.widthAnchor.constraint(equalToConstant: 20).isActive = true
+        self.icon.heightAnchor.constraint(equalToConstant: frameRect.height).isActive = true
 
         // Label constraints
 
-        self.label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 5).isActive = true
+        self.label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 3).isActive = true
         self.label.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
     }
 

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -32,7 +32,7 @@ class OutlineTableViewCell: NSTableCellView {
 
         self.icon = NSImageView(frame: .zero)
         self.icon.translatesAutoresizingMaskIntoConstraints = false
-        self.icon.symbolConfiguration = .init(textStyle: .subheadline, scale: .medium)
+        self.icon.symbolConfiguration = .init(textStyle: .callout, scale: .medium)
 
         self.addSubview(icon)
         self.imageView = icon
@@ -46,7 +46,7 @@ class OutlineTableViewCell: NSTableCellView {
 
         // Label constraints
 
-        self.label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 3).isActive = true
+        self.label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 2).isActive = true
         self.label.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
     }
 


### PR DESCRIPTION
# Description

Fixed the alignments so it exactly matches Xcode's project navigator

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

# Screenshots

## Before:

<img width="260" alt="Screen Shot 2022-04-10 at 11 50 59" src="https://user-images.githubusercontent.com/9460130/162612595-befd679e-be67-41c5-8e57-d47443e21034.png">

## After:

<img width="259" alt="Screen Shot 2022-04-10 at 11 48 29" src="https://user-images.githubusercontent.com/9460130/162612545-3d60e772-f55c-4a3c-ae01-59c1c2b45581.png">

