### PR TITLE
`Project Navigator`: Implemented Setting for changing Item Size

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>b42fe64b91619183f753183ce52ca9f472509037</string>
+	<string>cdaf6b982864a55727edc3b1b3201e689bc2ff6d</string>
 </dict>
 </plist>

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -33,7 +33,6 @@ class OutlineTableViewCell: NSTableCellView {
         self.icon = NSImageView(frame: .zero)
         self.icon.translatesAutoresizingMaskIntoConstraints = false
         self.icon.symbolConfiguration = .init(pointSize: fontSize, weight: .regular, scale: .medium)
-        // .init(textStyle: .callout, scale: .medium)
 
         self.addSubview(icon)
         self.imageView = icon

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -55,6 +55,7 @@ class OutlineTableViewCell: NSTableCellView {
         fatalError()
     }
 
+    /// Returns the font size for the current row height. Defaults to `13.0`
     private var fontSize: Double {
         switch self.frame.height {
         case 20: return 11

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -23,7 +23,7 @@ class OutlineTableViewCell: NSTableCellView {
         self.label.drawsBackground = false
         self.label.isBordered = false
         self.label.isEditable = false
-        self.label.font = .preferredFont(forTextStyle: .subheadline)
+        self.label.font = .labelFont(ofSize: fontSize)
 
         self.addSubview(label)
         self.textField = label
@@ -32,26 +32,36 @@ class OutlineTableViewCell: NSTableCellView {
 
         self.icon = NSImageView(frame: .zero)
         self.icon.translatesAutoresizingMaskIntoConstraints = false
-        self.icon.symbolConfiguration = .init(textStyle: .callout, scale: .medium)
+        self.icon.symbolConfiguration = .init(pointSize: fontSize, weight: .regular, scale: .medium)
+        // .init(textStyle: .callout, scale: .medium)
 
         self.addSubview(icon)
         self.imageView = icon
 
         // Icon constraints
 
-        self.icon.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0).isActive = true
+        self.icon.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: -2).isActive = true
         self.icon.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-        self.icon.widthAnchor.constraint(equalToConstant: 21).isActive = true
+        self.icon.widthAnchor.constraint(equalToConstant: 25).isActive = true
         self.icon.heightAnchor.constraint(equalToConstant: frameRect.height).isActive = true
 
         // Label constraints
 
-        self.label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 2).isActive = true
+        self.label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 1).isActive = true
         self.label.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
     }
 
     required init?(coder: NSCoder) {
         fatalError()
+    }
+
+    private var fontSize: Double {
+        switch self.frame.height {
+        case 20: return 11
+        case 22: return 13
+        case 24: return 14
+        default: return 13
+        }
     }
 
 }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
@@ -35,6 +35,11 @@ struct OutlineView: NSViewControllerRepresentable {
         return
     }
 
+    /// Returns the row height depending on the `projectNavigatorSize` in `AppPreferences`.
+    ///
+    /// * `small`: 20
+    /// * `medium`: 22
+    /// * `large`: 24
     private var rowHeight: Double {
         switch prefs.preferences.general.projectNavigatorSize {
         case .small: return 20

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
@@ -31,7 +31,15 @@ struct OutlineView: NSViewControllerRepresentable {
     func updateNSViewController(_ nsViewController: OutlineViewController, context: Context) {
         nsViewController.iconColor = prefs.preferences.general.fileIconStyle
         nsViewController.updateSelection()
+        nsViewController.rowHeight = rowHeight
         return
     }
 
+    private var rowHeight: Double {
+        switch prefs.preferences.general.projectNavigatorSize {
+        case .small: return 20
+        case .medium: return 22
+        case .large: return 24
+        }
+    }
 }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -35,6 +35,13 @@ class OutlineViewController: NSViewController {
 
     var iconColor: AppPreferences.FileIconStyle = .color
 
+    var rowHeight: Double = 22 {
+        didSet {
+            outlineView.rowHeight = rowHeight
+            outlineView.reloadData()
+        }
+    }
+
     /// Setup the ``scrollView`` and ``outlineView``
     override func loadView() {
         self.scrollView = NSScrollView()
@@ -136,7 +143,7 @@ extension OutlineViewController: NSOutlineViewDelegate {
 
         guard let tableColumn = tableColumn else { return nil }
 
-        let frameRect = NSRect(x: 0, y: 0, width: tableColumn.width, height: 17)
+        let frameRect = NSRect(x: 0, y: 0, width: tableColumn.width, height: rowHeight)
 
         let view = OutlineTableViewCell(frame: frameRect)
 
@@ -166,7 +173,7 @@ extension OutlineViewController: NSOutlineViewDelegate {
     }
 
     func outlineView(_ outlineView: NSOutlineView, heightOfRowByItem item: Any) -> CGFloat {
-        return 22 // This can be changed to 20 to match Xcodes row height.
+        return rowHeight // This can be changed to 20 to match Xcodes row height.
     }
 
     func outlineViewItemDidExpand(_ notification: Notification) {

--- a/CodeEditModules/Modules/AppPreferences/src/Model/AppPreferences.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/AppPreferences.swift
@@ -61,6 +61,7 @@ public extension AppPreferences {
         /// The reopen behavior of the app
         public var reopenBehavior: ReopenBehavior = .welcome
 
+        /// The size of the project navigators rows.
         public var projectNavigatorSize: ProjectNavigatorSize = .medium
 
         /// Default initializer
@@ -120,6 +121,14 @@ public extension AppPreferences {
         case newDocument
     }
 
+    /// The size of the project navigators rows.
+    ///
+    /// To match Xcode's settings the row height should be:
+    /// * ``small``: `20pt` (fontSize: `11pt`)
+    /// * ``medium``: `22pt` (fontSize: `13pt`)
+    /// * ``small``: `24pt` (fontSize: `14pt`)
+    ///
+    /// - note: This should be implemented for all lists in a `NavigatorSidebar`
     enum ProjectNavigatorSize: String, Codable {
         case small
         case medium

--- a/CodeEditModules/Modules/AppPreferences/src/Model/AppPreferences.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/AppPreferences.swift
@@ -61,6 +61,8 @@ public extension AppPreferences {
         /// The reopen behavior of the app
         public var reopenBehavior: ReopenBehavior = .welcome
 
+        public var projectNavigatorSize: ProjectNavigatorSize = .medium
+
         /// Default initializer
         public init() {}
 
@@ -71,6 +73,8 @@ public extension AppPreferences {
             self.fileIconStyle = try container.decodeIfPresent(FileIconStyle.self, forKey: .fileIconStyle) ?? .color
             self.reopenBehavior = try container.decodeIfPresent(ReopenBehavior.self,
                                                                 forKey: .reopenBehavior) ?? .welcome
+            self.projectNavigatorSize = try container.decodeIfPresent(ProjectNavigatorSize.self,
+                                                                      forKey: .projectNavigatorSize) ?? .medium
         }
     }
 
@@ -114,6 +118,12 @@ public extension AppPreferences {
         case welcome
         case openPanel
         case newDocument
+    }
+
+    enum ProjectNavigatorSize: String, Codable {
+        case small
+        case medium
+        case large
     }
 
 }

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
@@ -51,6 +51,16 @@ public struct GeneralPreferencesView: View {
                         .tag(AppPreferences.ReopenBehavior.newDocument)
                 }
             }
+            PreferencesSection("Project Navigator Size") {
+                Picker("Project Navigator Size", selection: $prefs.preferences.general.projectNavigatorSize) {
+                    Text("Small")
+                        .tag(AppPreferences.ProjectNavigatorSize.small)
+                    Text("Medium")
+                        .tag(AppPreferences.ProjectNavigatorSize.medium)
+                    Text("Large")
+                        .tag(AppPreferences.ProjectNavigatorSize.large)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

The item size of the project navigator can now be adjusted within the `preferences/general`.

The sizes are matched to Xcode's project navigator:

* On `small` the row is `20pt` tall. (Font size: 11pt)
* On `medium` the row is `22pt` tall. (Font size: 13pt)
* On `large` the row is `24pt` tall. (Font size: 14 pt)

> Futur sections of `ProjectNavigator` should also implement this setting to be adjustable.

# Related Issue

* #100 

# Checklist

- [x] Finish documentation
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/9460130/162620397-44ec37d4-ac1b-4738-a46b-f18a43134811.mov


