### PR TITLE
Load extensions in the main thread

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -54,12 +54,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             }
         }
 
-        DispatchQueue(label: "extensions.preload").async {
-            do {
-                try ExtensionsManager.shared?.preload()
-            } catch let error {
-                print(error)
-            }
+        do {
+            try ExtensionsManager.shared?.preload()
+        } catch let error {
+            print(error)
         }
     }
 


### PR DESCRIPTION
# Description

Quick-fix what was discovered by @nanashili in Discord#bugs.

Now extensions are preloaded in the main thread instead of separate one. So, it won't cause any issues.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested