### PR TITLE
Added functionality to close welcome screen when file is selected

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -144,10 +144,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
                         }
                     }
 
-                } else {
-                    CodeEditDocumentController.shared.openDocument { _, _ in
+                }
+                else {
+                    windowController.window?.close()
+                    CodeEditDocumentController.shared.openDocument(completionHandler: { _, _ in
                         opened()
-                    }
+                    }, cancelHandler: {
+                        self.openWelcome(self)
+                    })
                 }
             },
             newDocument: {

--- a/CodeEdit/Documents/CodeEditDocumentController.swift
+++ b/CodeEdit/Documents/CodeEditDocumentController.swift
@@ -9,7 +9,7 @@ import Cocoa
 
 class CodeEditDocumentController: NSDocumentController {
     override func openDocument(_ sender: Any?) {
-        self.openDocument { document, documentWasAlreadyOpen in
+        self.openDocument(completionHandler: { document, documentWasAlreadyOpen in
             // TODO: handle errors
 
             guard let document = document else {
@@ -18,7 +18,7 @@ class CodeEditDocumentController: NSDocumentController {
             }
 
             print(document, documentWasAlreadyOpen)
-        }
+        }, cancelHandler: {})
     }
 
     override func openDocument(withContentsOf url: URL,
@@ -41,7 +41,7 @@ class CodeEditDocumentController: NSDocumentController {
 }
 
 extension NSDocumentController {
-    func openDocument(completionHandler: @escaping (NSDocument?, Bool) -> Void) {
+    func openDocument(completionHandler: @escaping (NSDocument?, Bool) -> Void, cancelHandler: @escaping () -> Void) {
         let dialog = NSOpenPanel()
 
         dialog.title = "Open Workspace or File"
@@ -70,6 +70,9 @@ extension NSDocumentController {
                     print("Document:", document)
                     print("Was already open?", documentWasAlreadyOpen)
                 }
+            }
+            else if result == NSApplication.ModalResponse.cancel {
+                cancelHandler()
             }
         }
     }


### PR DESCRIPTION
# Description

Welcome screen now disappears when the 'Open a file or folder' is pressed. This is done by adding a cancel handler parameter to the openDocument function which calls the openWelcome function once cancel is pressed.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #272 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
