### PR TITLE
Fix the issue of an infinite loop while updating OutlineView.

### DIFF
--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -87,7 +87,9 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
 
                 selectionState.openedCodeFiles[item] = codeFile
             }
-            selectionState.selectedId = item.id
+            if selectionState.selectedId != item.id {
+                selectionState.selectedId = item.id
+            }
             Swift.print("Opening file for item: ", item.url)
             self.windowControllers.first?.window?.subtitle = item.url.lastPathComponent
         } catch let err {


### PR DESCRIPTION
# Description

To avoid an infinite loop of setting the `selectedId`, updating the OutlineView, setting the `selectedId` again (while updating the OutlineView), and then updating the OutlineView again, and so on.

When the selected id is already matched, we can simply update the opened file and there is no need to update the `selectedId` again, which will trigger the unnecessary update of OutlineView.

# Related Issue

* #427

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [ ] Review requested

# Screenshots

The video of UI and a screenshot of the console are both included in issue #427.
