### PR TITLE
BUG: fixed UI inconsistencies in `Accounts` and `Source Control` preferences

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>1084e1b16d934b2ab969762897c78185b352634d</string>
+	<string>cdb6eb675f459e8decf789d41e1aada72f710465</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/AppPreferences/src/HelperViews/PreferencesToolbar.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/HelperViews/PreferencesToolbar.swift
@@ -1,0 +1,37 @@
+//
+//  SwiftUIView.swift
+//  
+//
+//  Created by Lukas Pistrol on 13.04.22.
+//
+
+import SwiftUI
+
+struct PreferencesToolbar<T: View>: View {
+
+    private var height: Double
+    private var bgColor: Color
+    private var content: () -> T
+
+    init(
+        height: Double = 27,
+        bgColor: Color = Color(NSColor.controlBackgroundColor),
+        @ViewBuilder content: @escaping () -> T
+    ) {
+        self.height = height
+        self.bgColor = bgColor
+        self.content = content
+    }
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .foregroundColor(bgColor)
+            HStack {
+                content()
+                    .padding(.horizontal, 8)
+            }
+        }
+        .frame(height: height)
+    }
+}

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/PreferenceAccountsView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/PreferenceAccountsView.swift
@@ -22,10 +22,9 @@ public struct PreferenceAccountsView: View {
     public init() {}
 
     public var body: some View {
-        PreferencesContent {
-            HStack(alignment: .top) {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 1) {
                 accountSelectionView
-                Divider().padding([.leading, .trailing], -10)
                 if prefs.preferences.accounts.sourceControlAccounts.gitAccount.isEmpty {
                     emptyView
                 } else if
@@ -35,27 +34,27 @@ public struct PreferenceAccountsView: View {
                     accountTypeView
                 }
             }
-            .background(Rectangle().foregroundColor(Color(NSColor.controlBackgroundColor)))
-            .frame(height: 468)
+            .padding(1)
+            .background(Rectangle().foregroundColor(Color(NSColor.separatorColor)))
+            .frame(width: 872, height: 468)
+            .padding()
         }
     }
 
     private var accountSelectionView: some View {
         VStack(alignment: .leading, spacing: 1) {
-            Text("Source Control Accounts")
-                .font(.system(size: 12))
-                .foregroundColor(Color.secondary)
-                .padding([.leading, .top], 10)
-                .padding(.bottom, 5)
-
-            Divider().padding([.trailing, .leading], 10)
-
+            PreferencesToolbar {
+                Text("Source Control Accounts")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
             List($prefs.preferences.accounts.sourceControlAccounts.gitAccount,
                  selection: $accountSelection) { gitAccount in
                 GitAccountItem(sourceControlAccount: gitAccount)
-            }.listRowBackground(Color(NSColor.controlBackgroundColor))
+            }
+                 .listRowBackground(Color(NSColor.controlBackgroundColor))
 
-            toolbar {
+            PreferencesToolbar {
                 sidebarBottomToolbar
             }.frame(height: 27)
         }
@@ -106,7 +105,8 @@ public struct PreferenceAccountsView: View {
             }
         }
         .padding(.trailing, 20)
-        .frame(width: 615)
+        .frame(maxWidth: .infinity)
+        .background(Color(NSColor.controlBackgroundColor))
     }
 
     private var sidebarBottomToolbar: some View {
@@ -135,30 +135,16 @@ public struct PreferenceAccountsView: View {
         VStack {
             Text("Click the add (+) button to create a new account")
         }
-        .frame(maxWidth: 615, maxHeight: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.controlBackgroundColor))
     }
 
     private var selectAccount: some View {
         VStack {
             Text("Select an account from the list in the left panel")
         }
-        .frame(maxWidth: 615, maxHeight: .infinity)
-    }
-
-    private func toolbar<T: View>(
-        height: Double = 27,
-        bgColor: Color = Color(NSColor.controlBackgroundColor),
-        @ViewBuilder content: @escaping () -> T
-    ) -> some View {
-        ZStack {
-            Rectangle()
-                .foregroundColor(bgColor)
-            HStack {
-                content()
-                    .padding(.horizontal, 8)
-            }
-        }
-        .frame(height: height)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.controlBackgroundColor))
     }
 
     private func getSourceControlAccount(selectedAccountId: String) -> SourceControlAccounts? {

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/SourceControlPreferences/PreferenceSourceControlView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/SourceControlPreferences/PreferenceSourceControlView.swift
@@ -6,21 +6,31 @@
 //
 
 import SwiftUI
+import CodeEditUI
 
 public struct PreferenceSourceControlView: View {
 
     public init() {}
 
+    @State private var selectedSection: Int = 0
+
     public var body: some View {
-        PreferencesContent {
-            TabView {
-                SourceControlGeneralView(isChecked: true, branchName: "main").tabItem {
-                    Text("General")
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(spacing: 1) {
+                PreferencesToolbar {
+                    SegmentedControl($selectedSection, options: ["General", "Git"])
                 }
-                SourceControlGitView().tabItem {
-                    Text("Git")
+                if selectedSection == 0 {
+                    SourceControlGeneralView(isChecked: true, branchName: "main")
+                }
+                if selectedSection == 1 {
+                    SourceControlGitView()
                 }
             }
+            .padding(1)
+            .background(Rectangle().foregroundColor(Color(NSColor.separatorColor)))
+            .frame(width: 872)
+            .padding()
         }
     }
 }

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/SourceControlPreferences/SourceControlGeneralView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/SourceControlPreferences/SourceControlGeneralView.swift
@@ -16,7 +16,7 @@ struct SourceControlGeneralView: View {
     private var prefs: AppPreferencesModel = .shared
 
     var body: some View {
-        PreferencesContent {
+        VStack {
 
             PreferencesSection("Source Control", hideLabels: false) {
                 Toggle("Enable Source Control", isOn: $prefs.preferences.sourceControl.general.enableSourceControl)
@@ -36,7 +36,7 @@ struct SourceControlGeneralView: View {
                            isOn: $prefs.preferences.sourceControl.general.selectFilesToCommit)
                         .toggleStyle(.checkbox)
                 }
-                .padding(.leading, 10)
+                .padding(.leading, 20)
             }
 
             PreferencesSection("Text Editing", hideLabels: false) {
@@ -75,9 +75,8 @@ struct SourceControlGeneralView: View {
                     .font(.system(size: 12))
             }
         }
-        .frame(width: 844, height: 350)
+        .frame(height: 350)
         .background(Color(NSColor.controlBackgroundColor))
-
     }
 }
 

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/SourceControlPreferences/SourceControlGitView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/SourceControlPreferences/SourceControlGitView.swift
@@ -15,7 +15,7 @@ struct SourceControlGitView: View {
     private var prefs: AppPreferencesModel = .shared
 
     var body: some View {
-        PreferencesContent {
+        VStack {
             PreferencesSection("Author Name", hideLabels: false) {
                 TextField("Git Author Name", text: $prefs.preferences.sourceControl.git.authorName)
                     .frame(width: 280)
@@ -38,7 +38,7 @@ struct SourceControlGitView: View {
                     .frame(width: 280, height: 180)
                     .background(Color(NSColor.textBackgroundColor))
                 }
-                toolbar {
+                PreferencesToolbar {
                     bottomToolbar
                 }.frame(width: 280, height: 27)
             }
@@ -54,7 +54,7 @@ struct SourceControlGitView: View {
                     .frame(width: 280, alignment: .leading)
             }
         }
-        .frame(width: 844, height: 350)
+        .frame(height: 230)
         .background(Color(NSColor.controlBackgroundColor))
     }
 
@@ -71,22 +71,6 @@ struct SourceControlGitView: View {
             .buttonStyle(.plain)
             Spacer()
         }
-    }
-
-    private func toolbar<T: View>(
-        height: Double = 27,
-        bgColor: Color = Color(NSColor.controlBackgroundColor),
-        @ViewBuilder content: @escaping () -> T
-    ) -> some View {
-        ZStack {
-            Rectangle()
-                .foregroundColor(bgColor)
-            HStack {
-                content()
-                    .padding(.horizontal, 8)
-            }
-        }
-        .frame(height: height)
     }
 }
 

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/ThemePreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/ThemePreferencesView.swift
@@ -59,7 +59,7 @@ public struct ThemePreferencesView: View {
 
     private var sidebar: some View {
         VStack(spacing: 1) {
-            toolbar {
+            PreferencesToolbar {
                 let options = [
                     "Dark Mode",
                     "Light Mode"
@@ -71,7 +71,7 @@ public struct ThemePreferencesView: View {
             } else {
                 sidebarScrollView
             }
-            toolbar {
+            PreferencesToolbar {
                 sidebarBottomToolbar
             }
             .frame(height: 27)
@@ -179,7 +179,7 @@ public struct ThemePreferencesView: View {
                 "Editor",
                 "Terminal"
             ]
-            toolbar {
+            PreferencesToolbar {
                 SegmentedControl($themeModel.selectedTab, options: options)
             }
             switch themeModel.selectedTab {
@@ -190,7 +190,7 @@ public struct ThemePreferencesView: View {
             default:
                 PreviewThemeView()
             }
-            toolbar {
+            PreferencesToolbar {
                 HStack {
                     Spacer()
                     Button {} label: {
@@ -200,22 +200,6 @@ public struct ThemePreferencesView: View {
                 }
             }
         }
-    }
-
-    private func toolbar<T: View>(
-        height: Double = 27,
-        bgColor: Color = Color(NSColor.controlBackgroundColor),
-        @ViewBuilder content: @escaping () -> T
-    ) -> some View {
-        ZStack {
-            Rectangle()
-                .foregroundColor(bgColor)
-            HStack {
-                content()
-                    .padding(.horizontal, 8)
-            }
-        }
-        .frame(height: height)
     }
 }
 


### PR DESCRIPTION
# Description

Removed spacing, implemented header and tab views as `PreferencesToolbar`.

Used the same hierarchy as in `Theme` preferences

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="1016" alt="Screen Shot 2022-04-13 at 23 26 21" src="https://user-images.githubusercontent.com/9460130/163274409-50c501e2-d4fa-45c7-b4a5-7c959b8d916d.png">
<img width="1016" alt="Screen Shot 2022-04-13 at 23 26 25" src="https://user-images.githubusercontent.com/9460130/163274414-c049bf57-f873-4791-a434-2278e912ddda.png">
<img width="1016" alt="Screen Shot 2022-04-13 at 23 26 29" src="https://user-images.githubusercontent.com/9460130/163274417-a017c64e-878d-4e5b-b829-f8b1a1d4dae6.png">


