### PR TITLE
Fix color not found

### DIFF
--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/AccountSelectionDialog.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/AccountSelectionDialog.swift
@@ -18,7 +18,7 @@ struct AccountSelectionDialog: View {
         Providers(name: "GitLab Self-Hosted", id: "gitlabSelfHosted")
     ]
 
-    @State var providerSelection: Providers.ID?
+    @State var providerSelection: Providers.ID? = "github"
     @State var openGitLogin = false
 
     @Binding var dismissDialog: Bool
@@ -30,7 +30,10 @@ struct AccountSelectionDialog: View {
 
             List(gitProviders, selection: $providerSelection) {
                 AccountListItem(gitClientName: $0.name)
-            }.background(Color(NSColor.controlBackgroundColor))
+            }
+            .background(Color(NSColor.controlBackgroundColor))
+            .padding(1)
+            .background(Rectangle().foregroundColor(Color(NSColor.separatorColor)))
 
             HStack {
                 Button("Cancel") {
@@ -46,7 +49,6 @@ struct AccountSelectionDialog: View {
                 .buttonStyle(.borderedProminent)
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
-            .padding(.trailing, 20)
         }
         .padding(20)
         .frame(width: 400, height: 285)

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Github/GithubLoginView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Github/GithubLoginView.swift
@@ -66,12 +66,9 @@ struct GithubLoginView: View {
                     }
                 }.padding(.top, 2)
             }
-            .background(Rectangle().foregroundColor(Color("Logins")))
             .frame(maxWidth: .infinity)
             .padding(.bottom, 10)
             .padding(.top, 10)
-            .background(RoundedRectangle(cornerRadius: 4)
-                .stroke(Color("Stroke"), lineWidth: 1))
 
             HStack {
                 HStack {


### PR DESCRIPTION
# Description

In the latest version no colors are found.
At the moment as requested by @nanashili  I remove them.

`[SwiftUI] No color named 'Logins' found in asset catalog for main bundle`
`[SwiftUI] No color named 'Stroke' found in asset catalog for main bundle`

Added the ability to have a default choice in account creation and fix various ui dialogs.

<!--- REQUIRED: Describe what changed in detail -->

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="419" alt="Schermata 2022-04-14 alle 10 10 51" src="https://user-images.githubusercontent.com/20476002/163342665-31633f56-93c0-4a1d-b048-3e66d296bf4e.png">

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
