### PR TITLE
UI: fixed sidebar dock icon size

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>0be7d7ad4347c1a4cb5e6256ba0140a8a3b62b68</string>
+	<string>f7744c7884e6264d7ab70cc45a32b246fa94d66c</string>
 </dict>
 </plist>

--- a/CodeEdit/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
+++ b/CodeEdit/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
@@ -52,6 +52,7 @@ struct NavigatorSidebarToolbarTop: View {
         var activeState: ControlActiveState
         func makeBody(configuration: Configuration) -> some View {
             configuration.label
+                .font(.system(size: 12, weight: id == selection ? .semibold : .regular))
                 .symbolVariant(id == selection ? .fill : .none)
                 .foregroundColor(id == selection ? .accentColor : configuration.isPressed ? .primary : .secondary)
                 .frame(width: 25, height: 25, alignment: .center)


### PR DESCRIPTION
# Description

Made the dock icon size smaller to match Xcode.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #444 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

![Group 9](https://user-images.githubusercontent.com/9460130/163377898-a660c2f2-fb6b-440e-9c07-7087a70b2665.png)