### PR TITLE
Fix: alignment of ignored files in `Source Control` prefs

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>0be7d7ad4347c1a4cb5e6256ba0140a8a3b62b68</string>
+	<string>f7744c7884e6264d7ab70cc45a32b246fa94d66c</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/AppPreferences/src/HelperViews/PreferencesSection.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/HelperViews/PreferencesSection.swift
@@ -34,16 +34,24 @@ public struct PreferencesSection<Content: View>: View {
     private var width: Double
     private var hideLabels: Bool
     private var content: Content
+    private var align: VerticalAlignment
 
-    public init(_ title: String, width: Double = 300, hideLabels: Bool = true, @ViewBuilder content: () -> Content) {
+    public init(
+        _ title: String,
+        width: Double = 300,
+        hideLabels: Bool = true,
+        align: VerticalAlignment = .firstTextBaseline,
+        @ViewBuilder content: () -> Content
+    ) {
         self.title = title
         self.width = width
         self.hideLabels = hideLabels
+        self.align = align
         self.content = content()
     }
 
     public var body: some View {
-        HStack(alignment: .firstTextBaseline) {
+        HStack(alignment: align) {
             Text("\(title):")
                 .frame(width: width, alignment: .trailing)
             if hideLabels {

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/PreferenceAccountsView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/PreferenceAccountsView.swift
@@ -58,7 +58,7 @@ public struct PreferenceAccountsView: View {
 
             PreferencesToolbar {
                 sidebarBottomToolbar
-            }.frame(height: 27)
+            }
         }
         .frame(width: 210)
     }

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/SourceControlPreferences/SourceControlGeneralView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/SourceControlPreferences/SourceControlGeneralView.swift
@@ -57,7 +57,7 @@ struct SourceControlGeneralView: View {
                 } label: {
                     Text("Local Revision on Left Side")
                         .font(.system(size: 11))
-                }.frame(maxWidth: 170)
+                }
             }
 
             PreferencesSection("Source Control Navigator", hideLabels: false) {
@@ -66,7 +66,7 @@ struct SourceControlGeneralView: View {
                 } label: {
                     Text("Sort by Name")
                         .font(.system(size: 11))
-                }.frame(maxWidth: 170)
+                }
             }
 
             PreferencesSection("Default Branch Name", hideLabels: false) {
@@ -74,6 +74,7 @@ struct SourceControlGeneralView: View {
                     .frame(width: 170)
                 Text("Branch names cannot contain spaces, backslashes, or other symbols")
                     .font(.system(size: 12))
+                    .foregroundColor(.secondary)
             }
         }
         .frame(height: 350)

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/SourceControlPreferences/SourceControlGitView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/SourceControlPreferences/SourceControlGitView.swift
@@ -27,26 +27,24 @@ struct SourceControlGitView: View {
                     .frame(width: 280)
             }
 
-            PreferencesSection("Ignored Files", hideLabels: false) {
+            PreferencesSection("Ignored Files", hideLabels: false, align: .top) {
                 VStack(spacing: 1) {
                     List($prefs.preferences.sourceControl.git.ignoredFiles,
                          selection: $ignoredFileSelection) { ignoredFile in
                         IgnoredFileView(ignoredFile: ignoredFile)
                     }
                     .overlay(Group {
-                        Color(NSColor.controlBackgroundColor)
-                    })
-                    .overlay(Group {
                         if prefs.preferences.sourceControl.git.ignoredFiles.isEmpty {
                             Text("No Ignored Files")
+                                .foregroundColor(.secondary)
                         }
                     })
-                    .frame(width: 280, height: 150)
-                    PreferencesToolbar {
+                    .frame(height: 150)
+                    PreferencesToolbar(height: 22) {
                         bottomToolbar
                     }
-                    .frame(width: 280, height: 27)
                 }
+                .frame(width: 280)
                 .padding(1)
                 .background(Rectangle().foregroundColor(Color(NSColor.separatorColor)))
             }
@@ -67,7 +65,7 @@ struct SourceControlGitView: View {
     }
 
     private var bottomToolbar: some View {
-        HStack {
+        HStack(spacing: 12) {
             Button {} label: {
                 Image(systemName: "plus")
             }

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/ThemePreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/ThemePreferencesView.swift
@@ -74,7 +74,6 @@ public struct ThemePreferencesView: View {
             PreferencesToolbar {
                 sidebarBottomToolbar
             }
-            .frame(height: 27)
         }
         .frame(width: 320)
     }


### PR DESCRIPTION
# Description

Fixed the vertical alignment of the `ignored files` list in `Source Control` preferences.

Also removed some redundant `frame` constraints.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="1016" alt="Screen Shot 2022-04-14 at 15 54 36" src="https://user-images.githubusercontent.com/9460130/163406213-398af941-3d38-44f4-bc7a-20dbf6260998.png">

