### PR TITLE
moved `HelpButton` to `CodeEditUI` module

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>f7744c7884e6264d7ab70cc45a32b246fa94d66c</string>
+	<string>f26fdfc617cb975246c7698e17a6238d73b28620</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/CodeEditUI/src/HelpButton.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/HelpButton.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// A Button representing a system Help button displaying a question mark symbol.
 public struct HelpButton: View {
     var action : () -> Void
 

--- a/CodeEditModules/Modules/CodeEditUI/src/HelpButton.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/HelpButton.swift
@@ -7,10 +7,14 @@
 
 import SwiftUI
 
-struct HelpButton: View {
+public struct HelpButton: View {
     var action : () -> Void
 
-    var body: some View {
+    public init(action: @escaping () -> Void) {
+        self.action = action
+    }
+
+    public var body: some View {
         Button(action: action, label: {
             ZStack {
                 Circle()
@@ -19,7 +23,6 @@ struct HelpButton: View {
                     .shadow(color: Color(NSColor.separatorColor).opacity(0.3), radius: 0.5)
                     .shadow(color: Color(NSColor.shadowColor).opacity(0.3), radius: 1, y: 0.5)
                     .frame(width: 20, height: 20)
-//                Text("?").font(.system(size: 15, weight: .medium ))
                 Image(systemName: "questionmark")
                     .font(.system(size: 12.5, weight: .medium))
             }


### PR DESCRIPTION
# Description

Moved the `HelpButton` to the `CodeEditUI` module so it can be accessed everywhere in the app.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
