### PR TITLE
Added options to complete braces and type-over completion

### DIFF
--- a/CodeEditModules/Modules/AppPreferences/src/Model/Text Editing/TextEditingPreferences.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/Text Editing/TextEditingPreferences.swift
@@ -17,6 +17,10 @@ public extension AppPreferences {
         /// The font to use in editor.
         public var font: EditorFont = .init()
 
+        public var enableTypeOverCompletion: Bool = true
+
+        public var autocompleteBraces: Bool = true
+
         /// Default initializer
         public init() {}
 
@@ -25,6 +29,10 @@ public extension AppPreferences {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.defaultTabWidth = try container.decodeIfPresent(Int.self, forKey: .defaultTabWidth) ?? 4
             self.font = try container.decodeIfPresent(EditorFont.self, forKey: .font) ?? .init()
+            self.enableTypeOverCompletion = try container.decodeIfPresent(
+                Bool.self, forKey: .enableTypeOverCompletion) ?? true
+            self.autocompleteBraces = try container.decodeIfPresent(Bool.self,
+                                                                    forKey: .autocompleteBraces) ?? true
         }
     }
 

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/TextEditingPreferences/TextEditingPreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/TextEditingPreferences/TextEditingPreferencesView.swift
@@ -42,6 +42,10 @@ public struct TextEditingPreferencesView: View {
             PreferencesSection("Font") {
                 fontSelector
             }
+            PreferencesSection("Code completion") {
+                autocompleteBraces
+                enableTypeOverCompletion
+            }
         }
     }
 
@@ -59,6 +63,20 @@ public struct TextEditingPreferencesView: View {
                 "\(prefs.preferences.textEditing.font.name) \(prefs.preferences.textEditing.font.size)",
                 name: $prefs.preferences.textEditing.font.name, size: $prefs.preferences.textEditing.font.size
             )
+        }
+    }
+
+    private var autocompleteBraces: some View {
+        HStack {
+            Toggle("Autocomplete braces", isOn: $prefs.preferences.textEditing.autocompleteBraces)
+            Text("Automatically insert closing braces (\"}\")")
+        }
+    }
+
+    private var enableTypeOverCompletion: some View {
+        HStack {
+            Toggle("Enable type-over completion", isOn: $prefs.preferences.textEditing.enableTypeOverCompletion)
+            Text("Enable type-over completion")
         }
     }
 }

--- a/CodeEditModules/Modules/CodeFile/src/TextView/CodeEditorTextView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/TextView/CodeEditorTextView.swift
@@ -73,15 +73,32 @@ public class CodeEditorTextView: NSTextView {
         "{": "}",
         "[": "]",
         "\"": "\"",
+        "\'": "\'"
     ]
+
+    /// Autocompletes if symbol is auto pair
+    private func autocompleteSymbols(_ symbol: String) {
+        guard let end = autoPairs[symbol]
+        else { return }
+
+        if prefs.preferences.textEditing.autocompleteBraces && symbol == "{" {
+            super.insertText(end, replacementRange: selectedRange())
+            super.moveBackward(self)
+            return
+        }
+
+        guard prefs.preferences.textEditing.enableTypeOverCompletion, symbol != "{"
+        else { return }
+
+        super.insertText(end, replacementRange: selectedRange())
+        super.moveBackward(self)
+    }
 
     public override func insertText(_ string: Any, replacementRange: NSRange) {
         super.insertText(string, replacementRange: replacementRange)
-        guard let string = string as? String,
-              let end = autoPairs[string]
+        guard let string = string as? String
         else { return }
-        super.insertText(end, replacementRange: selectedRange())
-        super.moveBackward(self)
+        self.autocompleteSymbols(string)
     }
 
     public override func insertTab(_ sender: Any?) {


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->
Added option to autocomplete braces and (), "", '' and []. This matches the functionality in XCode. New tab added in settings to do this. New method added in CodeEditorTextView to deal with this.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #244 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<img width="904" alt="image" src="https://user-images.githubusercontent.com/44317715/163481297-86811f70-ae16-4557-8540-234214bbb7b4.png">


<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
