### PR TITLE
Add ability to load Language Servers as extensions (bundles)

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>2c0117e07080912ae7d8aa0e23b8b635868113f8</string>
+	<string>bfe2e04d16ea76737fdaf2a6167e0952d9067a87</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>2d44f050802ae0058b149cac764295ba3a7a6352</string>
+	<string>df5126734cd5f8c976187eba5d43204046775769</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>bfe2e04d16ea76737fdaf2a6167e0952d9067a87</string>
+	<string>cba30ade536c314a5b8ef6450831e3778330fa68</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>c7fee3a29a4477ce93e6e892af08e32078fa19ac</string>
+	<string>2c0117e07080912ae7d8aa0e23b8b635868113f8</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>cba30ade536c314a5b8ef6450831e3778330fa68</string>
+	<string>2d44f050802ae0058b149cac764295ba3a7a6352</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/ExtensionsStore/src/ExtensionsManager.swift
+++ b/CodeEditModules/Modules/ExtensionsStore/src/ExtensionsManager.swift
@@ -74,7 +74,8 @@ public final class ExtensionsManager {
 
         loadedLanguageServers.filter { elem in
             return elem.key.workspace == url
-        }.forEach { (key: PluginWorkspaceKey, _) in
+        }.forEach { (key: PluginWorkspaceKey, client: LSPClient) in
+            client.close()
             loadedLanguageServers.removeValue(forKey: key)
         }
     }
@@ -118,7 +119,9 @@ public final class ExtensionsManager {
                 return nil
             }
 
-            return LSPClient(lspURL, workspace: workspaceURL)
+            return try LSPClient(lspURL,
+                                 workspace: workspaceURL,
+                                 arguments: loadedBundles[id]?.infoDictionary?["CELSPArguments"] as? [String])
         }
 
         guard let bundle = try loadBundle(id: id, withExtension: "celsp") else {
@@ -133,7 +136,9 @@ public final class ExtensionsManager {
             return nil
         }
 
-        return LSPClient(lspURL, workspace: workspaceURL)
+        return try LSPClient(lspURL,
+                             workspace: workspaceURL,
+                             arguments: loadedBundles[id]?.infoDictionary?["CELSPArguments"] as? [String])
     }
 
     /// Preloads all extensions' bundles to `loadedBundles`
@@ -269,8 +274,9 @@ public final class ExtensionsManager {
 
         loadedLanguageServers.filter { elem in
             return elem.key.releaseID == entry.release
-        }.forEach { (key: PluginWorkspaceKey, _) in
-            loadedPlugins.removeValue(forKey: key)
+        }.forEach { (key: PluginWorkspaceKey, client: LSPClient) in
+            client.close()
+            loadedLanguageServers.removeValue(forKey: key)
         }
     }
 

--- a/CodeEditModules/Modules/ExtensionsStore/src/ExtensionsManager.swift
+++ b/CodeEditModules/Modules/ExtensionsStore/src/ExtensionsManager.swift
@@ -212,6 +212,7 @@ public final class ExtensionsManager {
             )
             .appendingPathComponent("\(release.id.uuidString).tar")
 
+        // TODO: show progress
         let (source, _) = try await URLSession.shared.download(from: tarball)
 
         if FileManager.default.fileExists(atPath: cacheTar.path) {

--- a/CodeEditModules/Modules/ExtensionsStore/src/ExtensionsManager.swift
+++ b/CodeEditModules/Modules/ExtensionsStore/src/ExtensionsManager.swift
@@ -9,6 +9,7 @@ import Foundation
 import Light_Swift_Untar
 import CodeEditKit
 import GRDB
+import LSP
 
 /// Class which handles all extensions (its bundles, instances for each workspace and so on)
 public final class ExtensionsManager {
@@ -28,6 +29,7 @@ public final class ExtensionsManager {
 
     var loadedBundles: [UUID: Bundle] = [:]
     var loadedPlugins: [PluginWorkspaceKey: ExtensionInterface] = [:]
+    var loadedLanguageServers: [PluginWorkspaceKey: LSPClient] = [:]
 
     init() throws {
         self.codeeditFolder = try FileManager.default
@@ -53,6 +55,11 @@ public final class ExtensionsManager {
                 table.column("loadable", .boolean)
             }
         }
+        migrator.registerMigration("v1.0.1") { database in
+            try database.alter(table: DownloadedPlugin.databaseTableName) { body in
+                body.add(column: "sdk", .text).defaults(to: "swift")
+            }
+        }
         try migrator.migrate(self.dbQueue)
     }
 
@@ -64,6 +71,27 @@ public final class ExtensionsManager {
         }.forEach { (key: PluginWorkspaceKey, _) in
             loadedPlugins.removeValue(forKey: key)
         }
+
+        loadedLanguageServers.filter { elem in
+            return elem.key.workspace == url
+        }.forEach { (key: PluginWorkspaceKey, _) in
+            loadedLanguageServers.removeValue(forKey: key)
+        }
+    }
+
+    private func loadBundle(id: UUID, withExtension ext: String) throws -> Bundle? {
+        guard let bundleURL = try FileManager.default.contentsOfDirectory(
+            at: extensionsFolder.appendingPathComponent(id.uuidString,
+                                                        isDirectory: true),
+            includingPropertiesForKeys: nil,
+            options: .skipsPackageDescendants
+        ).first(where: {$0.pathExtension == ext}) else { return nil }
+
+        guard let bundle = Bundle(url: bundleURL) else { return nil }
+
+        loadedBundles[id] = bundle
+
+        return bundle
     }
 
     private func getExtensionBuilder(id: UUID) throws -> ExtensionBuilder.Type? {
@@ -71,21 +99,41 @@ public final class ExtensionsManager {
             return loadedBundles[id]?.principalClass as? ExtensionBuilder.Type
         }
 
-        guard let bundleURL = try FileManager.default.contentsOfDirectory(
-            at: extensionsFolder.appendingPathComponent(id.uuidString,
-                                                        isDirectory: true),
-            includingPropertiesForKeys: nil,
-            options: .skipsPackageDescendants
-        ).first else { return nil }
-
-        guard bundleURL.pathExtension == "ceext" else { return nil }
-        guard let bundle = Bundle(url: bundleURL) else { return nil }
+        guard let bundle = try loadBundle(id: id, withExtension: "ceext") else {
+            return nil
+        }
 
         guard bundle.load() else { return nil }
 
-        loadedBundles[id] = bundle
-
         return bundle.principalClass as? ExtensionBuilder.Type
+    }
+
+    private func getLSPClient(id: UUID, workspaceURL: URL) throws -> LSPClient? {
+        if loadedBundles.keys.contains(id) {
+            guard let lspFile = loadedBundles[id]?.infoDictionary?["CELSPExecutable"] as? String else {
+                return nil
+            }
+
+            guard let lspURL = loadedBundles[id]?.url(forResource: lspFile, withExtension: nil) else {
+                return nil
+            }
+
+            return LSPClient(lspURL, workspace: workspaceURL)
+        }
+
+        guard let bundle = try loadBundle(id: id, withExtension: "celsp") else {
+            return nil
+        }
+
+        guard let lspFile = bundle.infoDictionary?["CELSPExecutable"] as? String else {
+            return nil
+        }
+
+        guard let lspURL = bundle.url(forResource: lspFile, withExtension: nil) else {
+            return nil
+        }
+
+        return LSPClient(lspURL, workspace: workspaceURL)
     }
 
     /// Preloads all extensions' bundles to `loadedBundles`
@@ -95,27 +143,42 @@ public final class ExtensionsManager {
         }
 
         try plugins.forEach { plugin in
-            _ = try getExtensionBuilder(id: plugin.release)
+            switch plugin.sdk {
+            case .swift:
+                _ = try loadBundle(id: plugin.release, withExtension: "ceext")
+            case .languageServer:
+                _ = try loadBundle(id: plugin.release, withExtension: "celsp")
+            }
         }
     }
 
-    /// Loads extensions' bundles which were not loaded before and creates `ExtensionInterface` instances
-    /// with `ExtensionAPI` created using specified initializer
-    /// - Parameter apiInitializer: function which creates `ExtensionAPI` instance based on plugin's ID
-    public func load(_ apiInitializer: (String) -> ExtensionAPI) throws {
+    /// Loads extensions' bundles which were not loaded before and passes `ExtensionAPI` as a whole class
+    /// or workspace's URL
+    /// - Parameter apiBuilder: function which creates `ExtensionAPI` instance based on plugin's ID
+    public func load(_ apiBuilder: (String) -> ExtensionAPI) throws {
         let plugins = try self.dbQueue.read { database in
-            try DownloadedPlugin.filter(Column("loadable") == true).fetchAll(database)
+            try DownloadedPlugin
+                .filter(Column("loadable") == true)
+                .fetchAll(database)
         }
 
         try plugins.forEach { plugin in
-            guard let builder = try getExtensionBuilder(id: plugin.release) else {
-                return
-            }
-
-            let api = apiInitializer(plugin.plugin.uuidString)
-
+            let api = apiBuilder(plugin.plugin.uuidString)
             let key = PluginWorkspaceKey(releaseID: plugin.release, workspace: api.workspaceURL)
-            loadedPlugins[key] = builder.init().build(withAPI: api)
+
+            switch plugin.sdk {
+            case .swift:
+                guard let builder = try getExtensionBuilder(id: plugin.release) else {
+                    return
+                }
+
+                loadedPlugins[key] = builder.init().build(withAPI: api)
+            case .languageServer:
+                guard let client = try getLSPClient(id: plugin.release, workspaceURL: api.workspaceURL) else {
+                    return
+                }
+                loadedLanguageServers[key] = client
+            }
         }
     }
 
@@ -168,7 +231,7 @@ public final class ExtensionsManager {
         // save to db
 
         try await dbQueue.write { database in
-            try DownloadedPlugin(plugin: plugin.id, release: release.id, loadable: true)
+            try DownloadedPlugin(plugin: plugin.id, release: release.id, loadable: true, sdk: plugin.sdk)
                 .insert(database)
         }
     }
@@ -199,6 +262,12 @@ public final class ExtensionsManager {
         loadedBundles.removeValue(forKey: entry.release)
 
         loadedPlugins.filter { elem in
+            return elem.key.releaseID == entry.release
+        }.forEach { (key: PluginWorkspaceKey, _) in
+            loadedPlugins.removeValue(forKey: key)
+        }
+
+        loadedLanguageServers.filter { elem in
             return elem.key.releaseID == entry.release
         }.forEach { (key: PluginWorkspaceKey, _) in
             loadedPlugins.removeValue(forKey: key)

--- a/CodeEditModules/Modules/ExtensionsStore/src/Models/DownloadedPlugin.swift
+++ b/CodeEditModules/Modules/ExtensionsStore/src/Models/DownloadedPlugin.swift
@@ -15,4 +15,5 @@ public struct DownloadedPlugin: Codable, FetchableRecord, PersistableRecord, Tab
     public var plugin: UUID
     public var release: UUID
     public var loadable: Bool
+    public var sdk: Plugin.SDK
 }

--- a/CodeEditModules/Modules/ExtensionsStore/src/Models/Plugin.swift
+++ b/CodeEditModules/Modules/ExtensionsStore/src/Models/Plugin.swift
@@ -18,6 +18,7 @@ public struct Plugin: Codable, Identifiable, Hashable {
 
     public enum SDK: String, Codable, Hashable {
         case swift
+        case languageServer = "language_server"
     }
 
     public enum ReleaseManagement: String, Codable, Hashable {

--- a/CodeEditModules/Modules/LSP/src/LSPClient.swift
+++ b/CodeEditModules/Modules/LSP/src/LSPClient.swift
@@ -20,6 +20,7 @@ public class LSPClient {
     ///   - arguments: Additional arguments from `CELSPArguments` in `Info.plist` of the Language Server bundle
     public init(_ executable: URL, workspace: URL, arguments: [String]?) throws {
         self.executable = executable
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: self.executable.path)
         self.workspace = workspace
         self.process = try Process.run(executable, arguments: arguments ?? ["--stdio"], terminationHandler: nil)
     }

--- a/CodeEditModules/Modules/LSP/src/LSPClient.swift
+++ b/CodeEditModules/Modules/LSP/src/LSPClient.swift
@@ -7,17 +7,24 @@
 
 import Foundation
 
+/// A LSP client to handle Language Server process
 public class LSPClient {
     var exec: URL
     var workspace: URL
     var process: Process
 
-    public init(_ exec: URL, workspace: URL, arguments: [String]?) throws {
-        self.exec = exec
+    /// Initialize new LSP client
+    /// - Parameters:
+    ///   - executable: Executable of the Language Server to be run
+    ///   - workspace: Workspace's URL
+    ///   - arguments: Additional arguments from `CELSPArguments` in `Info.plist` of the Language Server bundle
+    public init(_ executable: URL, workspace: URL, arguments: [String]?) throws {
+        self.exec = executable
         self.workspace = workspace
-        self.process = try Process.run(exec, arguments: arguments ?? ["--stdio"], terminationHandler: nil)
+        self.process = try Process.run(executable, arguments: arguments ?? ["--stdio"], terminationHandler: nil)
     }
 
+    /// Close the process
     public func close() {
         self.process.terminate()
     }

--- a/CodeEditModules/Modules/LSP/src/LSPClient.swift
+++ b/CodeEditModules/Modules/LSP/src/LSPClient.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// A LSP client to handle Language Server process
 public class LSPClient {
-    var exec: URL
+    var executable: URL
     var workspace: URL
     var process: Process
 
@@ -19,7 +19,7 @@ public class LSPClient {
     ///   - workspace: Workspace's URL
     ///   - arguments: Additional arguments from `CELSPArguments` in `Info.plist` of the Language Server bundle
     public init(_ executable: URL, workspace: URL, arguments: [String]?) throws {
-        self.exec = executable
+        self.executable = executable
         self.workspace = workspace
         self.process = try Process.run(executable, arguments: arguments ?? ["--stdio"], terminationHandler: nil)
     }

--- a/CodeEditModules/Modules/LSP/src/LSPClient.swift
+++ b/CodeEditModules/Modules/LSP/src/LSPClient.swift
@@ -1,0 +1,18 @@
+//
+//  LSPClient.swift
+//  
+//
+//  Created by Pavel Kasila on 16.04.22.
+//
+
+import Foundation
+
+public class LSPClient {
+    var exec: URL
+    var workspace: URL
+
+    public init(_ exec: URL, workspace: URL) {
+        self.exec = exec
+        self.workspace = workspace
+    }
+}

--- a/CodeEditModules/Modules/LSP/src/LSPClient.swift
+++ b/CodeEditModules/Modules/LSP/src/LSPClient.swift
@@ -10,9 +10,15 @@ import Foundation
 public class LSPClient {
     var exec: URL
     var workspace: URL
+    var process: Process
 
-    public init(_ exec: URL, workspace: URL) {
+    public init(_ exec: URL, workspace: URL, arguments: [String]?) throws {
         self.exec = exec
         self.workspace = workspace
+        self.process = try Process.run(exec, arguments: arguments ?? ["--stdio"], terminationHandler: nil)
+    }
+
+    public func close() {
+        self.process.terminate()
     }
 }

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -247,7 +247,8 @@ let package = Package(
             dependencies: [
                 "CodeEditKit",
                 "Light-Swift-Untar",
-                .productItem(name: "GRDB", package: "GRDB.swift", condition: nil)
+                .productItem(name: "GRDB", package: "GRDB.swift", condition: nil),
+                "LSP"
             ],
             path: "Modules/ExtensionsStore/src"
         ),
@@ -267,6 +268,10 @@ let package = Package(
                 "AppPreferences"
             ],
             path: "Modules/Feedback/src"
+        ),
+        .target(
+            name: "LSP",
+            path: "Modules/LSP/src"
         ),
     ]
 )


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->
Now `ExtensionsManager` supports `language_server` extensions. Also, there is a `LSPClient` class added to handle Language Server Process (through stdio). Currently, it doesn't do anything except running Language Server in the background.

## Language Server Extension Bundle
Almost the same as in #416, but there are some minor changes in the process.

1. Plugin's SDK should be set to `language_server` while registering a plugin in the Extension Store
2. Extension should contain Language Server executable inside
3. Extension's `Info.plist` should contain the following properties
3.1. `CELSPExecutable` (`String`) which is the Language Server's executable file name
3.2. `CELSPFileExtensions` (`Array`) which contains file extensions to be handled by Language Server
3.3. `CELSPArguments` (`Array`, _optional_: defaults to `["--stdio"]`) which contains arguments to be passed to Language Server to be run

Language Server Extension example is available in the [`pkasila/HTMLLanguageServer`](https://github.com/pkasila/HTMLLanguageServer) repository (based on `vscode-html-languageserver`)

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #12
* #86
* #183 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
