### PR TITLE
Keychain: Added wrapper for Keychains and save Git Accounts in Keychain

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		04C3256B28034FC800C8DA2D /* CodeEditKit in Frameworks */ = {isa = PBXBuildFile; productRef = 04C3256A28034FC800C8DA2D /* CodeEditKit */; };
 		04C3256C28034FC800C8DA2D /* CodeEditKit in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 04C3256A28034FC800C8DA2D /* CodeEditKit */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		2004A3832808468600FD9696 /* Feedback in Frameworks */ = {isa = PBXBuildFile; productRef = 2004A3822808468600FD9696 /* Feedback */; };
+		2040F0B1280AE96100411B6F /* CodeEditUtils in Frameworks */ = {isa = PBXBuildFile; productRef = 2040F0B0280AE96100411B6F /* CodeEditUtils */; };
 		20C4319A28058B9E00964DD5 /* GitAccounts in Frameworks */ = {isa = PBXBuildFile; productRef = 20C4319928058B9E00964DD5 /* GitAccounts */; };
 		2803257127F3CF1F009C7DC2 /* AppPreferences in Frameworks */ = {isa = PBXBuildFile; productRef = 2803257027F3CF1F009C7DC2 /* AppPreferences */; };
 		28069DA427F5BCF70016BC47 /* default-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 28069DA327F5BCDD0016BC47 /* default-dark.json */; };
@@ -153,6 +154,7 @@
 				5C403B8F27E20F8000788241 /* WorkspaceClient in Frameworks */,
 				5CAD1B972806B57D0059A74E /* Breadcrumbs in Frameworks */,
 				2803257127F3CF1F009C7DC2 /* AppPreferences in Frameworks */,
+				2040F0B1280AE96100411B6F /* CodeEditUtils in Frameworks */,
 				5CA8776527FC6A95003F5CD5 /* QuickOpen in Frameworks */,
 				D70F5E2C27E4E8CF004EE4B9 /* WelcomeModule in Frameworks */,
 				D7F72DEB27EA3574000C3064 /* Search in Frameworks */,
@@ -391,6 +393,7 @@
 				5CAD1B962806B57D0059A74E /* Breadcrumbs */,
 				28117FCF280768A500649353 /* CodeEditUI */,
 				2004A3822808468600FD9696 /* Feedback */,
+				2040F0B0280AE96100411B6F /* CodeEditUtils */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -1008,6 +1011,10 @@
 		2004A3822808468600FD9696 /* Feedback */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Feedback;
+		};
+		2040F0B0280AE96100411B6F /* CodeEditUtils */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CodeEditUtils;
 		};
 		20C4319928058B9E00964DD5 /* GitAccounts */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>c7fee3a29a4477ce93e6e892af08e32078fa19ac</string>
+	<string>2c0117e07080912ae7d8aa0e23b8b635868113f8</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Github/GithubEnterpriseLoginView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Github/GithubEnterpriseLoginView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import GitAccounts
+import CodeEditUtils
 
 struct GithubEnterpriseLoginView: View {
 
@@ -20,6 +21,8 @@ struct GithubEnterpriseLoginView: View {
 
     @StateObject
     private var prefs: AppPreferencesModel = .shared
+
+    private let keychain = CodeEditKeychain()
 
     var body: some View {
         VStack {
@@ -80,7 +83,6 @@ struct GithubEnterpriseLoginView: View {
         GithubAccount(config).me { response in
             switch response {
             case .success(let user):
-                print(user.login as Any)
                 if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased()}) {
                     print("Account with the username already exists!")
                 } else {
@@ -94,7 +96,7 @@ struct GithubEnterpriseLoginView: View {
                                               gitCloningProtocol: true,
                                               gitSSHKey: "",
                                               isTokenValid: true))
-
+                    keychain.set(accountToken, forKey: accountName)
                     dismissDialog = false
                 }
             case .failure(let error):

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Github/GithubLoginView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Github/GithubLoginView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import GitAccounts
+import CodeEditUtils
 
 struct GithubLoginView: View {
 
@@ -14,6 +15,8 @@ struct GithubLoginView: View {
     @State var accountToken = ""
 
     @Environment(\.openURL) var createToken
+
+    private let keychain = CodeEditKeychain()
 
     @Binding var dismissDialog: Bool
 
@@ -105,7 +108,6 @@ struct GithubLoginView: View {
         GithubAccount(config).me { response in
             switch response {
             case .success(let user):
-                print(user.login as Any)
                 if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased()}) {
                     print("Account with the username already exists!")
                 } else {
@@ -119,7 +121,7 @@ struct GithubLoginView: View {
                                               gitCloningProtocol: true,
                                               gitSSHKey: "",
                                               isTokenValid: true))
-
+                    keychain.set(accountToken, forKey: accountName)
                     dismissDialog = false
                 }
             case .failure(let error):

--- a/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/CodeEditKeychain.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/CodeEditKeychain.swift
@@ -1,0 +1,286 @@
+//
+//  CodeEditKeychain.swift
+//  
+//
+//  Created by Nanashi Li on 2022/04/14.
+//
+
+import Foundation
+import Security
+
+open class CodeEditKeychain {
+
+    var lastQueryParameters: [String: Any]? // Used by the unit tests
+
+    /// Contains result code from the last operation. Value is noErr (0) for a successful result.
+    open var lastResultCode: OSStatus = noErr
+
+    var keyPrefix = "" // Can be useful in test.
+
+    /**
+     Specify an access group that will be used to access keychain items.
+     Access groups can be used to share keychain items between applications.
+     When access group value is nil all application access groups are being accessed.
+     Access group name is used by all functions: set, get, delete and clear.
+     */
+    open var accessGroup: String?
+
+    private let lock = NSLock()
+
+    public init() { }
+
+    /**
+     - parameter keyPrefix: a prefix that is added before the key in get/set methods.
+     Note that `clear` method still clears everything from the Keychain.
+     */
+    public init(keyPrefix: String) {
+        self.keyPrefix = keyPrefix
+    }
+
+    /**
+     Stores the text value in the keychain item under the given key.
+     - parameter key: Key under which the text value is stored in the keychain.
+     - parameter value: Text string to be written to the keychain.
+     - parameter withAccess: Value that indicates when your app needs access to the text in the keychain item.
+     By default the .AccessibleWhenUnlocked option is used that permits the data to be accessed only
+     while the device is unlocked by the user.
+     - returns: True if the text was successfully written to the keychain.
+     */
+    @discardableResult
+    open func set(_ value: String, forKey key: String,
+                  withAccess access: CodeEditKeychainAccessOptions? = nil) -> Bool {
+
+        if let value = value.data(using: String.Encoding.utf8) {
+            return set(value, forKey: key, withAccess: access)
+        }
+        return false
+    }
+
+    /**
+     Stores the data in the keychain item under the given key.
+     - parameter key: Key under which the data is stored in the keychain.
+     - parameter value: Data to be written to the keychain.
+     - parameter withAccess: Value that indicates when your app needs access to the text in the keychain item.
+     By default the .AccessibleWhenUnlocked option is used that permits the data to be accessed
+     only while the device is unlocked by the user.
+     - returns: True if the text was successfully written to the keychain.
+     */
+    @discardableResult
+    open func set(_ value: Data, forKey key: String,
+                  withAccess access: CodeEditKeychainAccessOptions? = nil) -> Bool {
+
+        // The lock prevents the code to be run simultaneously
+        // from multiple threads which may result in crashing
+        lock.lock()
+        defer { lock.unlock() }
+
+        deleteNoLock(key) // Delete any existing key before saving it
+        let accessible = access?.value ?? CodeEditKeychainAccessOptions.defaultOption.value
+
+        let prefixedKey = keyWithPrefix(key)
+
+        var query: [String: Any] = [
+            CodeEditKeychainConstants.klass: kSecClassGenericPassword,
+            CodeEditKeychainConstants.attrAccount: prefixedKey,
+            CodeEditKeychainConstants.valueData: value,
+            CodeEditKeychainConstants.accessible: accessible
+        ]
+
+        query = addAccessGroupWhenPresent(query)
+        lastQueryParameters = query
+
+        lastResultCode = SecItemAdd(query as CFDictionary, nil)
+
+        return lastResultCode == noErr
+    }
+
+    /**
+     Stores the boolean value in the keychain item under the given key.
+     - parameter key: Key under which the value is stored in the keychain.
+     - parameter value: Boolean to be written to the keychain.
+     - parameter withAccess: Value that indicates when your app needs access to the value in the keychain item.
+     By default the .AccessibleWhenUnlocked option is used that permits the data to be accessed
+     only while the device is unlocked by the user.
+     - returns: True if the value was successfully written to the keychain.
+     */
+    @discardableResult
+    open func set(_ value: Bool, forKey key: String,
+                  withAccess access: CodeEditKeychainAccessOptions? = nil) -> Bool {
+
+        let bytes: [UInt8] = value ? [1] : [0]
+        let data = Data(bytes)
+
+        return set(data, forKey: key, withAccess: access)
+    }
+
+    /**
+     Retrieves the text value from the keychain that corresponds to the given key.
+     - parameter key: The key that is used to read the keychain item.
+     - returns: The text value from the keychain. Returns nil if unable to read the item.
+     */
+    open func get(_ key: String) -> String? {
+        if let data = getData(key) {
+
+            if let currentString = String(data: data, encoding: .utf8) {
+                return currentString
+            }
+
+            lastResultCode = -67853 // errSecInvalidEncoding
+        }
+
+        return nil
+    }
+
+    /**
+     Retrieves the data from the keychain that corresponds to the given key.
+     - parameter key: The key that is used to read the keychain item.
+     - parameter asReference: If true, returns the data as reference (needed for things like NEVPNProtocol).
+     - returns: The text value from the keychain. Returns nil if unable to read the item.
+     */
+    open func getData(_ key: String, asReference: Bool = false) -> Data? {
+        // The lock prevents the code to be run simultaneously
+        // from multiple threads which may result in crashing
+        lock.lock()
+        defer { lock.unlock() }
+
+        let prefixedKey = keyWithPrefix(key)
+
+        var query: [String: Any] = [
+            CodeEditKeychainConstants.klass: kSecClassGenericPassword,
+            CodeEditKeychainConstants.attrAccount: prefixedKey,
+            CodeEditKeychainConstants.matchLimit: kSecMatchLimitOne
+        ]
+
+        if asReference {
+            query[CodeEditKeychainConstants.returnReference] = kCFBooleanTrue
+        } else {
+            query[CodeEditKeychainConstants.returnData] =  kCFBooleanTrue
+        }
+
+        query = addAccessGroupWhenPresent(query)
+        lastQueryParameters = query
+
+        var result: AnyObject?
+
+        lastResultCode = withUnsafeMutablePointer(to: &result) {
+            SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
+        }
+
+        if lastResultCode == noErr {
+            return result as? Data
+        }
+
+        return nil
+    }
+
+    /**
+     Retrieves the boolean value from the keychain that corresponds to the given key.
+     - parameter key: The key that is used to read the keychain item.
+     - returns: The boolean value from the keychain. Returns nil if unable to read the item.
+     */
+    open func getBool(_ key: String) -> Bool? {
+        guard let data = getData(key) else { return nil }
+        guard let firstBit = data.first else { return nil }
+        return firstBit == 1
+    }
+
+    /**
+     Deletes the single keychain item specified by the key.
+     - parameter key: The key that is used to delete the keychain item.
+     - returns: True if the item was successfully deleted.
+     */
+    @discardableResult
+    open func delete(_ key: String) -> Bool {
+        // The lock prevents the code to be run simultaneously
+        // from multiple threads which may result in crashing
+        lock.lock()
+        defer { lock.unlock() }
+
+        return deleteNoLock(key)
+    }
+
+    /**
+     Return all keys from keychain
+     - returns: An string array with all keys from the keychain.
+     */
+    public var allKeys: [String] {
+        var query: [String: Any] = [
+            CodeEditKeychainConstants.klass: kSecClassGenericPassword,
+            CodeEditKeychainConstants.returnData: true,
+            CodeEditKeychainConstants.returnAttributes: true,
+            CodeEditKeychainConstants.returnReference: true,
+            CodeEditKeychainConstants.matchLimit: CodeEditKeychainConstants.secMatchLimitAll
+        ]
+
+        query = addAccessGroupWhenPresent(query)
+
+        var result: AnyObject?
+
+        let lastResultCode = withUnsafeMutablePointer(to: &result) {
+            SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
+        }
+
+        if lastResultCode == noErr {
+            return (result as? [[String: Any]])?.compactMap {
+                $0[CodeEditKeychainConstants.attrAccount] as? String } ?? []
+        }
+
+        return []
+    }
+
+    /**
+     Same as `delete` but is only accessed internally, since it is not thread safe.
+     - parameter key: The key that is used to delete the keychain item.
+     - returns: True if the item was successfully deleted.
+     */
+    @discardableResult
+    func deleteNoLock(_ key: String) -> Bool {
+        let prefixedKey = keyWithPrefix(key)
+
+        var query: [String: Any] = [
+            CodeEditKeychainConstants.klass: kSecClassGenericPassword,
+            CodeEditKeychainConstants.attrAccount: prefixedKey
+        ]
+
+        query = addAccessGroupWhenPresent(query)
+        lastQueryParameters = query
+
+        lastResultCode = SecItemDelete(query as CFDictionary)
+
+        return lastResultCode == noErr
+    }
+
+    /**
+     Deletes all Keychain items used by the app.
+     Note that this method deletes all items regardless of the prefix settings used for initializing the class.
+     - returns: True if the keychain items were successfully deleted.
+     */
+    @discardableResult
+    open func clear() -> Bool {
+        // The lock prevents the code to be run simultaneously
+        // from multiple threads which may result in crashing
+        lock.lock()
+        defer { lock.unlock() }
+
+        var query: [String: Any] = [ kSecClass as String: kSecClassGenericPassword ]
+        query = addAccessGroupWhenPresent(query)
+        lastQueryParameters = query
+
+        lastResultCode = SecItemDelete(query as CFDictionary)
+
+        return lastResultCode == noErr
+    }
+
+    /// Returns the key with currently set prefix.
+    func keyWithPrefix(_ key: String) -> String {
+        return "\(keyPrefix)\(key)"
+    }
+
+    func addAccessGroupWhenPresent(_ items: [String: Any]) -> [String: Any] {
+        guard let accessGroup = accessGroup else { return items }
+
+        var result: [String: Any] = items
+        result[CodeEditKeychainConstants.accessGroup] = accessGroup
+        return result
+    }
+}

--- a/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/CodeEditKeychainConstants.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/CodeEditKeychainConstants.swift
@@ -1,0 +1,53 @@
+//
+//  CodeEditKeychainConstants.swift
+//  
+//
+//  Created by Nanashi Li on 2022/04/14.
+//
+
+import Foundation
+import Security
+
+/// Constants used by the library
+public struct CodeEditKeychainConstants {
+    /// Specifies a Keychain access group. Used for sharing Keychain items between apps.
+    public static var accessGroup: String { return toString(kSecAttrAccessGroup) }
+
+    /**
+     A value that indicates when your app needs access to the data in a keychain item.
+     The default value is AccessibleWhenUnlocked.
+     For a list of possible values, see CodeEditKeychainAccessOptions.
+     */
+    public static var accessible: String { return toString(kSecAttrAccessible) }
+
+    /// Used for specifying a String key when setting/getting a Keychain value.
+    public static var attrAccount: String { return toString(kSecAttrAccount) }
+
+    /// Used for specifying synchronization of keychain items between devices.
+    public static var attrSynchronizable: String { return toString(kSecAttrSynchronizable) }
+
+    /// An item class key used to construct a Keychain search dictionary.
+    public static var klass: String { return toString(kSecClass) }
+
+    /// Specifies the number of values returned from the keychain. The library only supports single values.
+    public static var matchLimit: String { return toString(kSecMatchLimit) }
+
+    /// A return data type used to get the data from the Keychain.
+    public static var returnData: String { return toString(kSecReturnData) }
+
+    /// Used for specifying a value when setting a Keychain value.
+    public static var valueData: String { return toString(kSecValueData) }
+
+    /// Used for returning a reference to the data from the keychain
+    public static var returnReference: String { return toString(kSecReturnPersistentRef) }
+
+    /// A key whose value is a Boolean indicating whether or not to return item attributes
+    public static var returnAttributes: String { return toString(kSecReturnAttributes) }
+
+    /// A value that corresponds to matching an unlimited number of items
+    public static var secMatchLimitAll: String { return toString(kSecMatchLimitAll) }
+
+    static func toString(_ value: CFString) -> String {
+        return value as String
+    }
+}

--- a/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/Documentation.docc/Documentation.md
+++ b/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/Documentation.docc/Documentation.md
@@ -1,0 +1,66 @@
+#  What is Keychain?
+
+Keychain is the password management system in macOS, developed by Apple. It was introduced with Mac OS 8.6, and has been included in all subsequent versions of the operating system, now known as macOS. A Keychain can contain various types of data: passwords, private keys, certificates, and secure notes. 
+
+## Notice:
+This build of CodeEditKeychain could change at anytime if bugs or breaking changes are found in the module. 
+
+## Usage
+
+### String
+
+```swift
+let keychain = CodeEditKeychain()
+keychain.set("hello world", forKey: "my key")
+keychain.get("my key")
+```
+
+### Boolean
+
+```swift
+let keychain = CodeEditKeychain()
+keychain.set(true, forKey: "my key")
+keychain.getBool("my key")
+```
+
+### Data
+
+```swift
+let keychain = CodeEditKeychain()
+keychain.set(dataObject, forKey: "my key")
+keychain.getData("my key")
+```
+### Removing Keys
+
+```swift
+let keychain = CodeEditKeychain()
+keychain.delete("my key")
+```
+
+### Return All Keys
+
+```swift
+let keychain = CodeEditKeychain()
+keychain.allKeys // Returns the names of all keys
+```
+
+### Check if operation was successful
+
+One can verify if `set`, `delete` and `clear` methods finished successfully by checking their return values. Those methods return `true` on success and `false` on error.
+
+```swift
+if keychain.set("hello world", forKey: "my key") {
+  // Keychain item is saved successfully
+} else {
+  // Report error
+}
+```
+
+### Setting key prefix
+
+One can pass a `keyPrefix` argument when initializing a `CodeEditKeychain` object. The string passed in `keyPrefix` argument will be used as a prefix to **all the keys** used in `set`, `get`, `getData` and `delete` methods. Adding a prefix to the keychain keys can be useful in unit tests. This prevents the tests from changing the Keychain keys that are used when the app is launched manually.
+
+```swift
+let keychain = CodeEditKeychain(keyPrefix: "myTestKey_")
+keychain.set("hello world", forKey: "hello") // Value will be stored under "myTestKey_hello" key
+```

--- a/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/KeychainSwiftAccessOptions.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/KeychainSwiftAccessOptions.swift
@@ -1,0 +1,94 @@
+//
+//  CodeEditKeychainAccessOptions.swift
+//  
+//
+//  Created by Nanashi Li on 2022/04/14.
+//
+
+import Security
+
+/**
+ These options are used to determine when a keychain item should be readable.
+ The default value is AccessibleWhenUnlocked.
+ */
+public enum CodeEditKeychainAccessOptions {
+
+    /**
+     The data in the keychain item can be accessed only while the device is unlocked by the user.
+
+     This is recommended for items that need to be accessible only while the application is in the foreground.
+     Items with this attribute migrate to a new device when using encrypted backups.
+
+     This is the default value for keychain items added without explicitly setting an accessibility constant.
+     */
+    case accessibleWhenUnlocked
+
+    /**
+     The data in the keychain item can be accessed only while the device is unlocked by the user.
+
+     This is recommended for items that need to be accessible only while the application is in the foreground.
+     Items with this attribute do not migrate to a new device.
+     Thus, after restoring from a backup of a different device, these items will not be present.
+     */
+    case accessibleWhenUnlockedThisDeviceOnly
+
+    /**
+     The data in the keychain item cannot be accessed after a restart until the device has
+     been unlocked once by the user.
+
+     After the first unlock, the data remains accessible until the next restart.
+     This is recommended for items that need to be accessed by background applications.
+     Items with this attribute migrate to a new device when using encrypted backups.
+     */
+    case accessibleAfterFirstUnlock
+
+    /**
+     The data in the keychain item cannot be accessed after a restart until the device has
+     been unlocked once by the user.
+
+     After the first unlock, the data remains accessible until the next restart.
+     This is recommended for items that need to be accessed by background applications.
+     Items with this attribute do not migrate to a new device.
+     Thus, after restoring from a backup of a different device, these items will not be present.
+     */
+    case accessibleAfterFirstUnlockThisDeviceOnly
+
+    /**
+     The data in the keychain can only be accessed when the device is unlocked.
+     Only available if a passcode is set on the device.
+
+     This is recommended for items that only need to be accessible while the application is in the foreground.
+     Items with this attribute never migrate to a new device.
+     After a backup is restored to a new device, these items are missing.
+     No items can be stored in this class on devices without a passcode.
+     Disabling the device passcode causes all items in this class to be deleted.
+     */
+    case accessibleWhenPasscodeSetThisDeviceOnly
+
+    static var defaultOption: CodeEditKeychainAccessOptions {
+        return .accessibleWhenUnlocked
+    }
+
+    var value: String {
+        switch self {
+        case .accessibleWhenUnlocked:
+            return toString(kSecAttrAccessibleWhenUnlocked)
+
+        case .accessibleWhenUnlockedThisDeviceOnly:
+            return toString(kSecAttrAccessibleWhenUnlockedThisDeviceOnly)
+
+        case .accessibleAfterFirstUnlock:
+            return toString(kSecAttrAccessibleAfterFirstUnlock)
+
+        case .accessibleAfterFirstUnlockThisDeviceOnly:
+            return toString(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
+
+        case .accessibleWhenPasscodeSetThisDeviceOnly:
+            return toString(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly)
+        }
+    }
+
+    func toString(_ value: CFString) -> String {
+        return CodeEditKeychainConstants.toString(value)
+    }
+}

--- a/CodeEditModules/Modules/Feedback/src/Model/FeedbackModel.swift
+++ b/CodeEditModules/Modules/Feedback/src/Model/FeedbackModel.swift
@@ -7,11 +7,22 @@
 
 import SwiftUI
 import GitAccounts
+import AppPreferences
+import CodeEditUtils
 
 public class FeedbackModel: ObservableObject {
 
     public static let shared: FeedbackModel = .init()
 
+    private var prefs: AppPreferencesModel = .shared
+    private let keychain = CodeEditKeychain()
+
+    @Environment(\.openURL) var openIssueURL
+
+    @Published
+    var isSubmitted: Bool = false
+    @Published
+    var failedToSubmit: Bool = false
     @Published
     var feedbackTitle: String = ""
     @Published
@@ -128,13 +139,15 @@ public class FeedbackModel: ObservableObject {
         """
     }
 
-    /// Still need to add support for saving tokens in the keychain
     public func createIssue(title: String,
                             description: String,
                             steps: String?,
                             expectation: String?,
                             actuallyHappened: String?) {
-        let config = GithubTokenConfiguration("") // TODO: Token needs to fetched from keychain
+        let gitAccounts = prefs.preferences.accounts.sourceControlAccounts.gitAccount
+        let firstGitAccount = gitAccounts.first
+
+        let config = GithubTokenConfiguration(keychain.get(firstGitAccount!.gitAccountName))
         GithubAccount(config).postIssue(owner: "CodeEditApp",
                                   repository: "CodeEdit",
                                   title: "\(getFeebackTypeTitle()) \(title)",

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -77,6 +77,10 @@ let package = Package(
             name: "Feedback",
             targets: ["Feedback"]
         ),
+        .library(
+            name: "CodeEditUtils",
+            targets: ["CodeEditUtils"]
+        ),
     ],
     dependencies: [
         .package(
@@ -217,7 +221,8 @@ let package = Package(
             dependencies: [
                 "Preferences",
                 "CodeEditUI",
-                "GitAccounts"
+                "GitAccounts",
+                "CodeEditUtils",
             ],
             path: "Modules/AppPreferences/src"
         ),
@@ -264,9 +269,14 @@ let package = Package(
             dependencies: [
                 "GitAccounts",
                 "CodeEditUI",
-                "AppPreferences"
+                "AppPreferences",
+                "CodeEditUtils",
             ],
             path: "Modules/Feedback/src"
+        ),
+        .target(
+            name: "CodeEditUtils",
+            path: "Modules/CodeEditUtils/src"
         ),
     ]
 )


### PR DESCRIPTION
# Description

This PR adds support for adding git accounts into they keychain system and also fetching it. The Keychain system for CodeEdit is build in custom wrapper format to reduce the amount of code when using the keychain to store tokens etc...

By building the wrapper we make it easier for any developer who contributes to the project and needs to use the keychain to store info much more simpler than what it would have been before.

# Checklist
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
