### PR TITLE
Line Gutter & Accounts: Put the correct font and width size, also added vault icons

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>1dc33901ae5a01968e4e42948acbd62ed582e9d8</string>
+	<string>a92000d5c11fc51f2ca07ca8158d6081463cea85</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>a92000d5c11fc51f2ca07ca8158d6081463cea85</string>
+	<string>de5c59b262cc4639e25037bb23880d3355b904e2</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/AccountListItem.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/AccountListItem.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import CodeEditSymbols
 
 struct AccountListItem: View {
 
@@ -13,7 +14,7 @@ struct AccountListItem: View {
 
     var body: some View {
         HStack {
-            Image("vault.fill")
+            Image(symbol: "vault.fill")
                 .resizable()
                 .frame(width: 28.0, height: 28.0)
             Text(gitClientName)

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/AccountListItem.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/AccountListItem.swift
@@ -13,7 +13,7 @@ struct AccountListItem: View {
 
     var body: some View {
         HStack {
-            Image(systemName: "xmark.square.fill")
+            Image("vault.fill")
                 .resizable()
                 .frame(width: 28.0, height: 28.0)
             Text(gitClientName)

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/GitAccountItem.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/GitAccountItem.swift
@@ -14,7 +14,7 @@ struct GitAccountItem: View {
 
     var body: some View {
         HStack {
-            Image(systemName: "xmark.square.fill")
+            Image("vault.fill")
                 .resizable()
                 .frame(width: 24.0, height: 24.0)
 

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/GitAccountItem.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/GitAccountItem.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import CodeEditSymbols
 
 struct GitAccountItem: View {
 
@@ -14,7 +15,7 @@ struct GitAccountItem: View {
 
     var body: some View {
         HStack {
-            Image("vault.fill")
+            Image(symbol: "vault.fill")
                 .resizable()
                 .frame(width: 24.0, height: 24.0)
 

--- a/CodeEditModules/Modules/CodeFile/src/CodeEditor.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeEditor.swift
@@ -63,8 +63,8 @@ struct CodeEditor: NSViewRepresentable {
         scrollView.documentView = textView
         scrollView.verticalRulerView = LineGutter(
             scrollView: scrollView,
-            width: 45,
-            font: .monospacedDigitSystemFont(ofSize: 11, weight: .regular),
+            width: 37,
+            font: NSFont(name: "SF Mono", size: 11) ?? .monospacedSystemFont(ofSize: 11, weight: .regular),
             textColor: .secondaryLabelColor,
             backgroundColor: .clear
         )

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -228,6 +228,7 @@ let package = Package(
                 "CodeEditUI",
                 "GitAccounts",
                 "CodeEditUtils",
+                "CodeEditSymbols",
             ],
             path: "Modules/AppPreferences/src"
         ),


### PR DESCRIPTION
# Description

The Line Gutter had incorrect font attached to it and the width was way more than that of Xcode.

Also added the vault icons to the appropriate sections 

# Checklist
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
