### PR TITLE
Main Menu: Fixed issue where `Command + W` closes the app

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>1dc33901ae5a01968e4e42948acbd62ed582e9d8</string>
+	<string>67a2618bab3900fa3dd96764fb0232183a95fb88</string>
 </dict>
 </plist>

--- a/CodeEdit/MainMenu.xib
+++ b/CodeEdit/MainMenu.xib
@@ -97,11 +97,18 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
-                            <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                            <menuItem title="Close Tab" keyEquivalent="w" id="DVo-aG-piG"/>
+                            <menuItem title="Close Editor" keyEquivalent="W" id="Xhf-Xm-5lk">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Close Window" keyEquivalent="W" id="2tv-fO-t5i"/>
+                            <menuItem title="Close Workspace" keyEquivalent="w" id="aHY-bT-UtW">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" option="YES" command="YES"/>
                                 <connections>
-                                    <action selector="performClose:" target="-1" id="HmO-Ls-i7Q"/>
+                                    <action selector="performClose:" target="-1" id="hDP-mA-SiS"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="oaB-hH-59T"/>
                             <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
                                 <connections>
                                     <action selector="saveDocument:" target="-1" id="kkG-H8-VoM"/>


### PR DESCRIPTION
# Description

As pointed out by @lilingxi01 `Command + W` closes the editor and not the tab which the shortcut should be reserved for.

# Related Issue

Issue: #473

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
