### PR TITLE
Implemented additional syntax for accessing custom images from `CodeEditSymbols`

### DIFF
--- a/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/CodeEditApp/CodeEditSymbols",
         "state": {
           "branch": "main",
-          "revision": "fe91b1e31a3562b958edf20c210c65284402dbed",
+          "revision": "51ab9b4e7e6434ce8e2c74b04a6ba2591b972bb1",
           "version": null
         }
       },
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/groue/GRDB.swift.git",
         "state": {
           "branch": null,
-          "revision": "15c06e037430c8a2dc570f9199dd7bf8caa21195",
-          "version": "5.22.2"
+          "revision": "4472d3a60ec4cc383503eba5072ce17f781b9ddc",
+          "version": "5.23.0"
         }
       },
       {

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -239,7 +239,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             Preferences.Pane(
                 identifier: Preferences.PaneIdentifier("SourceControl"),
                 title: "Source Control",
-                toolbarIcon: NSImage.symbol(named: "vault")
+                toolbarIcon: NSImage.vault
             ) {
                 PreferenceSourceControlView()
             },


### PR DESCRIPTION
# Description

Access custom `CodeEditSymbols` with:

```swift
let nsImage = NSImage.vault
let nsImageFill = NSImage.vault_fill

let image = Image.vault
let imageFill = Image.vault_fill
```

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
