### PR TITLE
Fix Tab Color Issue in Native Style

### DIFF
--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -87,6 +87,8 @@ struct TabBar: View {
                     NSVisualEffectView.Material.titlebar,
                     blendingMode: NSVisualEffectView.BlendingMode.withinWindow
                 )
+                .background(Color(nsColor: .controlBackgroundColor))
+                .edgesIgnoringSafeArea(.top)
             }
         }
         .padding(.leading, -1)

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -259,7 +259,7 @@ struct TabBarItem: View {
                     .animation(.easeInOut(duration: 0.08), value: isHovering)
             } else {
                 EffectView(
-                    material: NSVisualEffectView.Material.titlebar,
+                    NSVisualEffectView.Material.titlebar,
                     blendingMode: NSVisualEffectView.BlendingMode.withinWindow
                 )
                 .background(

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -26,8 +26,10 @@ struct TabDivider: View {
             .padding(.vertical, prefs.preferences.general.tabBarStyle == .xcode ? 8 : 0)
             .foregroundColor(
                 prefs.preferences.general.tabBarStyle == .xcode
-                ? Color(nsColor: colorScheme == .dark ? .white : .black).opacity(0.12)
-                : Color(nsColor: .separatorColor).opacity(colorScheme == .dark ? 0.4 : 1.0)
+                ? Color(nsColor: colorScheme == .dark ? .white : .black)
+                    .opacity(0.12)
+                : Color(nsColor: colorScheme == .dark ? .white : .black)
+                    .opacity(colorScheme == .dark ? 0.08 : 0.12)
             )
     }
 }
@@ -48,8 +50,10 @@ struct NativeTabShadow: View {
             .padding(.vertical, prefs.preferences.general.tabBarStyle == .xcode ? 8 : 0)
             .foregroundColor(
                 prefs.preferences.general.tabBarStyle == .xcode
-                ? Color(nsColor: colorScheme == .dark ? .white : .black).opacity(0.12)
-                : Color(nsColor: .separatorColor).opacity(colorScheme == .dark ? 0.3 : 1.0)
+                ? Color(nsColor: colorScheme == .dark ? .white : .black)
+                    .opacity(0.12)
+                : Color(nsColor: colorScheme == .dark ? .black : .black)
+                    .opacity(colorScheme == .dark ? 0.45 : 0.15)
             )
     }
 }
@@ -254,31 +258,29 @@ struct TabBarItem: View {
                     )
                     .animation(.easeInOut(duration: 0.08), value: isHovering)
             } else {
-                if isActive {
-                    EffectView(
-                        // Use `windowBackground` material to fit the material of transparent titlebar
-                        // in order to make it native-styled.
-                        NSVisualEffectView.Material.windowBackground,
-                        blendingMode: NSVisualEffectView.BlendingMode.withinWindow
-                    )
-                } else {
-                    EffectView(
-                        NSVisualEffectView.Material.titlebar,
-                        blendingMode: NSVisualEffectView.BlendingMode.withinWindow
-                    )
-                    .overlay(
-                        Color(nsColor: .black)
-                            .opacity(colorScheme == .dark ? 0.50 : 0.05)
-                            .padding(.top, 1)
-                            .padding(.horizontal, 1)
-                    )
-                    .overlay(
-                        Color(nsColor: colorScheme == .dark ? .white : .black)
-                            .opacity(isHovering ? 0.05 : 0.0)
-                            .animation(.easeInOut(duration: 0.10), value: isHovering)
-                            .padding(.top, 1)
-                            .padding(.horizontal, 1)
-                    )
+                EffectView(
+                    material: NSVisualEffectView.Material.titlebar,
+                    blendingMode: NSVisualEffectView.BlendingMode.withinWindow
+                )
+                .background(
+                    // This background is used to avoid color-split between title bar and tab bar.
+                    // The material will tint the color hind, which will result in a color-split.
+                    Color(nsColor: .controlBackgroundColor)
+                )
+                .overlay {
+                    if !isActive {
+                        ZStack {
+                            Color(nsColor: .black)
+                                .opacity(colorScheme == .dark ? 0.50 : 0.05)
+                                .padding(.top, 1)
+                                .padding(.horizontal, 1)
+                            Color(nsColor: colorScheme == .dark ? .white : .black)
+                                .opacity(isHovering ? 0.05 : 0.0)
+                                .animation(.easeInOut(duration: 0.10), value: isHovering)
+                                .padding(.top, 1)
+                                .padding(.horizontal, 1)
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description

I just rebuilt the entire tab view with system material. It should now look as same as Finder in both light and dark mode.

# Related Issue

* #480

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/36816148/163950751-ad05bb10-ca6f-49d1-a2c6-63b33a7666d0.mp4
