### PR TITLE
fix `breakpoint.fill` symbol scaling issue

### DIFF
--- a/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/CodeEditApp/CodeEditSymbols",
         "state": {
           "branch": "main",
-          "revision": "7d37a9b2d07cc135da905c74795f45f25ce0bb23",
+          "revision": "9a33d8e9899f36136b1e1e138b8101080927ae80",
           "version": null
         }
       },

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>eae9468edc68ad3d1ea159e9f5e1a01ba401fb1e</string>
+	<string>165e2e479e3ce3ef70177a9bcaefb7cda423a384</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Description

Fixed scaling issues of `breakpoint.fill` to match size of `breakpoint` symbol.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
