### PR TITLE
Make Tab Bar Style Persistent

### DIFF
--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -71,7 +71,8 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         toolbar.delegate = self
         toolbar.displayMode = .labelOnly
         self.window?.toolbarStyle = .unifiedCompact
-        self.window?.titlebarSeparatorStyle = .automatic
+        // Set titlebar background as transparent by default in order to style the toolbar background.
+        self.window?.titlebarAppearsTransparent = true
         self.window?.toolbar = toolbar
     }
 

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -67,21 +67,39 @@ struct TabBar: View {
             // TODO: Tab bar tools (e.g. split view).
         }
         .frame(height: tabBarHeight)
+        .overlay {
+            // When tab bar style is `xcode`, we put the top divider as an overlay.
+            if prefs.preferences.general.tabBarStyle == .xcode {
+                NativeTabShadow()
+                    .frame(height: tabBarHeight, alignment: .top)
+            }
+        }
         .background {
+            // When tab bar style is `native`, we put the top divider beneath tabs.
             if prefs.preferences.general.tabBarStyle == .native {
                 NativeTabShadow()
                     .frame(height: tabBarHeight, alignment: .top)
-                    .overlay(
-                        Color(nsColor: .black)
-                            .opacity(colorScheme == .dark ? 0.50 : 0.05)
-                            .padding(.top, 1)
-                            .padding(.horizontal, 1)
-                    )
             }
         }
         .background {
             if prefs.preferences.general.tabBarStyle == .xcode {
                 Color(nsColor: .controlBackgroundColor)
+            } else {
+                Color(nsColor: .black)
+                    .opacity(colorScheme == .dark ? 0.50 : 0.05)
+                    // Set padding top to 1 to avoid color-overlapping.
+                    .padding(.top, 1)
+            }
+        }
+        .background {
+            if prefs.preferences.general.tabBarStyle == .xcode {
+                EffectView(
+                    NSVisualEffectView.Material.titlebar,
+                    blendingMode: NSVisualEffectView.BlendingMode.withinWindow
+                )
+                // Set bottom padding to avoid material overlapping in bar.
+                .padding(.bottom, tabBarHeight)
+                .edgesIgnoringSafeArea(.top)
             } else {
                 EffectView(
                     NSVisualEffectView.Material.titlebar,

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -46,15 +46,14 @@ struct NativeTabShadow: View {
 
     var body: some View {
         Rectangle()
-            .frame(height: height)
-            .padding(.vertical, prefs.preferences.general.tabBarStyle == .xcode ? 8 : 0)
             .foregroundColor(
                 prefs.preferences.general.tabBarStyle == .xcode
                 ? Color(nsColor: colorScheme == .dark ? .white : .black)
                     .opacity(0.12)
                 : Color(nsColor: colorScheme == .dark ? .black : .black)
-                    .opacity(colorScheme == .dark ? 0.45 : 0.15)
+                    .opacity(colorScheme == .dark ? 0.40 : 0.15)
             )
+            .frame(height: height)
     }
 }
 
@@ -96,8 +95,6 @@ struct TabBarItem: View {
     @ObservedObject
     var workspace: WorkspaceDocument
 
-    var tabBarHeight: Double = 28.0
-
     var isActive: Bool {
         item.id == workspace.selectionState.selectedId
     }
@@ -121,7 +118,7 @@ struct TabBarItem: View {
                     .font(.system(size: 11.0))
                     .lineLimit(1)
             }
-            .frame(height: tabBarHeight)
+            .frame(maxHeight: .infinity) // To max-out the parent (tab bar) area.
             .padding(.horizontal, prefs.preferences.general.tabBarStyle == .native ? 28 : 23)
             .overlay {
                 ZStack {
@@ -218,7 +215,7 @@ struct TabBarItem: View {
                 : .secondary
             )
         )
-        .frame(height: tabBarHeight)
+        .frame(maxHeight: .infinity) // To max-out the parent (tab bar) area.
         .contentShape(Rectangle())
         .onHover { hover in
             isHovering = hover
@@ -272,14 +269,12 @@ struct TabBarItem: View {
                         ZStack {
                             Color(nsColor: .black)
                                 .opacity(colorScheme == .dark ? 0.50 : 0.05)
-                                .padding(.top, 1)
-                                .padding(.horizontal, 1)
                             Color(nsColor: colorScheme == .dark ? .white : .black)
                                 .opacity(isHovering ? 0.05 : 0.0)
                                 .animation(.easeInOut(duration: 0.10), value: isHovering)
-                                .padding(.top, 1)
-                                .padding(.horizontal, 1)
                         }
+                        .padding(.top, colorScheme == .dark ? 0 : 1)
+                        .padding(.horizontal, 1)
                     }
                 }
             }
@@ -317,14 +312,6 @@ struct TabBarItem: View {
                 }
             }
         }
-        // Update titlebarAppearsTransparent per tabBarStyle.
-        .onChange(of: prefs.preferences.general.tabBarStyle, perform: { _ in
-            if prefs.preferences.general.tabBarStyle == .native {
-                workspace.windowControllers.first?.window?.titlebarAppearsTransparent = true
-            } else {
-                workspace.windowControllers.first?.window?.titlebarAppearsTransparent = false
-            }
-        })
     }
 }
 

--- a/CodeEditModules/Modules/AppPreferences/src/Model/General/GeneralPreferences.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/General/GeneralPreferences.swift
@@ -34,6 +34,7 @@ public extension AppPreferences {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.appAppearance = try container.decodeIfPresent(Appearances.self, forKey: .appAppearance) ?? .system
             self.fileIconStyle = try container.decodeIfPresent(FileIconStyle.self, forKey: .fileIconStyle) ?? .color
+            self.tabBarStyle = try container.decodeIfPresent(TabBarStyle.self, forKey: .tabBarStyle) ?? .xcode
             self.reopenBehavior = try container.decodeIfPresent(ReopenBehavior.self,
                                                                 forKey: .reopenBehavior) ?? .welcome
             self.projectNavigatorSize = try container.decodeIfPresent(ProjectNavigatorSize.self,
@@ -76,7 +77,7 @@ public extension AppPreferences {
 
     /// The style for tab bar
     /// - **native**: Native-styled tab bar (like Finder)
-    /// - **monochrome**: Xcode-liked tab bar
+    /// - **xcode**: Xcode-liked tab bar
     enum TabBarStyle: String, Codable {
         case native
         case xcode

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
@@ -45,10 +45,10 @@ public struct GeneralPreferencesView: View {
             }
             PreferencesSection("Tab Bar Style") {
                 Picker("Tab Bar Style:", selection: $prefs.preferences.general.tabBarStyle) {
-                    Text("Native")
-                        .tag(AppPreferences.TabBarStyle.native)
                     Text("Xcode")
                         .tag(AppPreferences.TabBarStyle.xcode)
+                    Text("Native")
+                        .tag(AppPreferences.TabBarStyle.native)
                 }
                 .pickerStyle(.radioGroup)
             }


### PR DESCRIPTION
# Description

* Add tab bar style into the initialization of app preferences to make it persistent.
* Make `Xcode` style as the first option because it is default-selected.
* Remove the on-the-flight modification of window property and replace it with a new Xcode-styled titlebar background.
* Re-arrange the layer of top divider per style.

# Related Issue

No related issue.

This PR adds some missing functionalities from #461. The tab bar style is not persistent in the implementation of that PR.

# Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/36816148/164117493-edb07f77-9093-43ec-95b3-e1a9e4ee95d1.mp4
