### PR TITLE
Fix Divider Color Issue in Xcode-styled Tab Bar

### DIFF
--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -47,11 +47,12 @@ struct NativeTabShadow: View {
     var body: some View {
         Rectangle()
             .foregroundColor(
-                prefs.preferences.general.tabBarStyle == .xcode
-                ? Color(nsColor: colorScheme == .dark ? .white : .black)
-                    .opacity(0.12)
-                : Color(nsColor: colorScheme == .dark ? .black : .black)
-                    .opacity(colorScheme == .dark ? 0.40 : 0.15)
+                Color(nsColor: .black)
+                    .opacity(
+                        prefs.preferences.general.tabBarStyle == .xcode
+                        ? (colorScheme == .dark ? 0.28 : 0.12)
+                        : (colorScheme == .dark ? 0.40 : 0.15)
+                    )
             )
             .frame(height: height)
     }


### PR DESCRIPTION
# Description

Change the color of top divider in Xcode-styled tab bar to the correct one.

# Related Issue

* #497

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [ ] Review requested

# Screenshots

<img width="267" alt="CleanShot 2022-04-19 at 22 04 17@2x" src="https://user-images.githubusercontent.com/36816148/164132172-6dc958c9-c70b-4757-9c32-64347eecb089.png">
