### PR TITLE
fix history inspector: `not a git repo`

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>879d0a88d2c1f99b95b80b4a5cd2b3bbb85575b0</string>
+	<string>f08e8c87a1f981d393377e0380d13afa44366974</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/GitClient/src/Live.swift
+++ b/CodeEditModules/Modules/GitClient/src/Live.swift
@@ -68,10 +68,14 @@ public extension GitClient {
             let dateFormatter = DateFormatter()
             dateFormatter.locale = Locale.current
             dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
-            return try shellClient.run(
+            let output = try shellClient.run(
                 // swiftlint:disable:next line_length
                 "cd \(directoryURL.relativePath);git log --pretty=%h¦%H¦%s¦%aN¦%ae¦%cn¦%ce¦%aD¦ \(entriesString) \(fileLocalPath)"
             )
+            if output.contains("fatal: not a git repository") {
+                throw GitClientError.notGitRepository
+            }
+            return output
                 .split(separator: "\n")
                 .map { line -> Commit in
                     let parameters = line.components(separatedBy: "¦")


### PR DESCRIPTION
# Description

Fixes an issue where the history inspector would populate rows with an error message when the open folder is not a git repository.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

## Before:

<img width="1188" alt="Screen Shot 2022-04-20 at 12 25 10" src="https://user-images.githubusercontent.com/9460130/164211501-62ed8095-45b1-499d-b7ad-ef11fd147389.png">

## After:

<img width="1189" alt="Screen Shot 2022-04-20 at 12 24 34" src="https://user-images.githubusercontent.com/9460130/164211484-1fd79296-9199-47c7-8319-2a951ef81c48.png">