### PR TITLE
Expand or collapse folder on double click

### DIFF
--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -55,6 +55,7 @@ final class OutlineViewController: NSViewController {
         self.outlineView.headerView = nil
         self.outlineView.menu = OutlineMenu(sender: self.outlineView)
         self.outlineView.menu?.delegate = self
+        self.outlineView.doubleAction = #selector(onItemDoubleClicked)
 
         let column = NSTableColumn(identifier: .init(rawValue: "Cell"))
         column.title = "Cell"
@@ -85,7 +86,17 @@ final class OutlineViewController: NSViewController {
         }
 
         select(by: itemID, from: content)
+    }
+    
+    /// Expand or collapse the folder on double click
+    @objc
+    private func onItemDoubleClicked() {
+        guard let item = outlineView.item(atRow: outlineView.clickedRow) as? Item else { return }
 
+        if item.children != nil {
+            let isExpanded = outlineView.isItemExpanded(item)
+            isExpanded ? outlineView.collapseItem(item) : outlineView.expandItem(item)
+        }
     }
 
     /// Get the appropriate color for the items icon depending on the users preferences.


### PR DESCRIPTION
# Description

Expand or collapse folder on double click to mirror the Xcode behaviour. 
Right now folders can be expanded only by clicking on the chevron. 

# Checklist

<!--- Add things that are not yet implemented above -->
- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] I documented my code
- [X] Review requested

# Screenshots

https://user-images.githubusercontent.com/8146514/164223080-2b19fee1-1ddb-4c3c-8ece-b926ed2e101e.mov


