### PR TITLE
Fixed `View on GitHub` menu item.

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>f08e8c87a1f981d393377e0380d13afa44366974</string>
+	<string>8c50fd9b940fdc8192952485b10724ff7e8621d0</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>8c50fd9b940fdc8192952485b10724ff7e8621d0</string>
+	<string>1bbb043b08cecf6f7539102c5434423e019edaaa</string>
 </dict>
 </plist>

--- a/CodeEdit/InspectorSidebar/Views/HistoryItem.swift
+++ b/CodeEdit/InspectorSidebar/Views/HistoryItem.swift
@@ -89,15 +89,13 @@ struct HistoryItem: View {
             }
             Group {
                 Divider()
-                Button("View on GitHub...") {
-                    /**
-                     TODO: fetch the users username from git account also check
-                     user has a github account attached to the editor
-                     */
-                    let commitURL = "https://github.com/CodeEditApp/CodeEdit/commit/\(commit.commitHash)"
-                    openCommit(URL(string: commitURL)!)
+                if let commitRemoteURL = commit.commitBaseURL?.absoluteString {
+                    Button("View on Remote...") {
+                        let commitURL = "\(commitRemoteURL)/\(commit.commitHash)"
+                        openCommit(URL(string: commitURL)!)
+                    }
+                    Divider()
                 }
-                Divider()
                 Button("Check Out \(commit.hash)...") {}
                     .disabled(true) // TODO: Implementation Needed
                 Divider()

--- a/CodeEditModules/Modules/GitClient/src/Live.swift
+++ b/CodeEditModules/Modules/GitClient/src/Live.swift
@@ -72,6 +72,9 @@ public extension GitClient {
                 // swiftlint:disable:next line_length
                 "cd \(directoryURL.relativePath);git log --pretty=%h¦%H¦%s¦%aN¦%ae¦%cn¦%ce¦%aD¦ \(entriesString) \(fileLocalPath)"
             )
+            let remote = try shellClient.run("cd \(directoryURL.relativePath);git ls-remote --get-url")
+            let remoteURL = URL(string: remote.trimmingCharacters(in: .whitespacesAndNewlines))
+            print(remote, remoteURL)
             if output.contains("fatal: not a git repository") {
                 throw GitClientError.notGitRepository
             }
@@ -87,6 +90,7 @@ public extension GitClient {
                         authorEmail: parameters[safe: 4] ?? "",
                         commiter: parameters[safe: 5] ?? "",
                         commiterEmail: parameters[safe: 6] ?? "",
+                        remoteURL: remoteURL,
                         date: dateFormatter.date(from: parameters[safe: 7] ?? "") ?? Date()
                     )
                 }

--- a/CodeEditModules/Modules/GitClient/src/Live.swift
+++ b/CodeEditModules/Modules/GitClient/src/Live.swift
@@ -73,7 +73,7 @@ public extension GitClient {
                 "cd \(directoryURL.relativePath);git log --pretty=%h¦%H¦%s¦%aN¦%ae¦%cn¦%ce¦%aD¦ \(entriesString) \(fileLocalPath)"
             )
             let remote = try shellClient.run("cd \(directoryURL.relativePath);git ls-remote --get-url")
-            let remoteURL = URL(string: remote.trimmingCharacters(in: .whitespacesAndNewlines))
+            let remoteURL = URL(string: remote)
             print(remote, remoteURL)
             if output.contains("fatal: not a git repository") {
                 throw GitClientError.notGitRepository

--- a/CodeEditModules/Modules/GitClient/src/Live.swift
+++ b/CodeEditModules/Modules/GitClient/src/Live.swift
@@ -73,8 +73,7 @@ public extension GitClient {
                 "cd \(directoryURL.relativePath);git log --pretty=%h¦%H¦%s¦%aN¦%ae¦%cn¦%ce¦%aD¦ \(entriesString) \(fileLocalPath)"
             )
             let remote = try shellClient.run("cd \(directoryURL.relativePath);git ls-remote --get-url")
-            let remoteURL = URL(string: remote)
-            print(remote, remoteURL)
+            let remoteURL = URL(string: remote.trimmingCharacters(in: .whitespacesAndNewlines))
             if output.contains("fatal: not a git repository") {
                 throw GitClientError.notGitRepository
             }

--- a/CodeEditModules/Modules/GitClient/src/Models/Commit.swift
+++ b/CodeEditModules/Modules/GitClient/src/Models/Commit.swift
@@ -17,5 +17,17 @@ public struct Commit: Equatable, Hashable, Identifiable {
     public let authorEmail: String
     public let commiter: String
     public let commiterEmail: String
+    public let remoteURL: URL?
     public let date: Date
+
+    public var commitBaseURL: URL? {
+        if let remoteURL = remoteURL {
+            if remoteURL.absoluteString.contains("github") {
+                return remoteURL.deletingPathExtension().appendingPathComponent("commit")
+            }
+
+            // TODO: Implement other git clients other than github here
+        }
+        return nil
+    }
 }


### PR DESCRIPTION
# Description

Fetches the remote git url and returns a base url for commits when it is a GitHub URL. Other Git clients still need implementation.

The context menu will only show if the user has a remote configured and the remote is GitHub.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="251" alt="Screen Shot 2022-04-20 at 14 08 08" src="https://user-images.githubusercontent.com/9460130/164227098-4ef83952-1cd7-41e2-89a2-c2007efd9284.png">

