### PR TITLE
Fix Tab-switching Keyboard Shortcut Issue

### DIFF
--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -230,21 +230,28 @@ struct TabBarItem: View {
         }
     }
 
-    // I am not using Button for wrapping content because Button will potentially
-    // have conflict with the inner close Button when the style of this Button is
-    // not set to `plain`. And based on the design of CodeEdit, plain style is not
-    // an expected choice, so I eventually come up with this solution for now. It
-    // is possible to make a customized Button (which may solve the clicking conflict,
-    // but I am not sure). I will try that in the future.
     var body: some View {
-        Button(action: switchAction) {
-            content
-        }
-        .buttonStyle(TabBarItemButtonStyle())
-        .keyboardShortcut(
-            workspace.getTabKeyEquivalent(item: item),
-            modifiers: [.command]
+        Button(
+            action: switchAction,
+            label: { content }
         )
+        .buttonStyle(TabBarItemButtonStyle())
+        .overlay {
+            // Using an overlay to contain the keyboard shortcut is simply because
+            // the keyboard shortcut has an unexpected bug when working with custom
+            // buttonStyle. This is an workaround and it should work as expected.
+            Button(
+                action: switchAction,
+                label: { EmptyView() }
+            )
+            .frame(width: 0, height: 0)
+            .padding(0)
+            .opacity(0)
+            .keyboardShortcut(
+                workspace.getTabKeyEquivalent(item: item),
+                modifiers: [.command]
+            )
+        }
         .background {
             if prefs.preferences.general.tabBarStyle == .xcode {
                 Color(nsColor: isActive ? .selectedControlColor : .clear)
@@ -324,7 +331,6 @@ fileprivate extension WorkspaceDocument {
                 Character.init("\(counter + 1)")
             )
         }
-
         return "0"
     }
 }


### PR DESCRIPTION
# Description

The tab-switching shortcut was not really working (may close the target tab). I have come up with a workaround to resolve this issue. It seems like a ButtonStyle compatibility issue at SwiftUI.

I have also added some comments right there so other people can understand why there is an additional hidden overlay (for workaround).

# Related Issue

* #478

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/36816148/164333851-5233b61a-8934-4b96-85f5-45c219d029d9.mp4
