### PR TITLE
FEAT: Toolbar Branch Picker

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		2847019E27FDDF7600F87B6B /* OutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2847019D27FDDF7600F87B6B /* OutlineView.swift */; };
 		285FEC7027FE4B9800E57D53 /* OutlineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285FEC6F27FE4B9800E57D53 /* OutlineTableViewCell.swift */; };
 		286471AB27ED51FD0039369D /* ProjectNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286471AA27ED51FD0039369D /* ProjectNavigator.swift */; };
+		2864BAAC28117B3F002DBD1A /* ShellClient in Frameworks */ = {isa = PBXBuildFile; productRef = 2864BAAB28117B3F002DBD1A /* ShellClient */; };
+		2864BAAE28117D7C002DBD1A /* TerminalEmulator in Frameworks */ = {isa = PBXBuildFile; productRef = 2864BAAD28117D7C002DBD1A /* TerminalEmulator */; };
 		287776E927E34BC700D46668 /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776E827E34BC700D46668 /* TabBar.swift */; };
 		287776EF27E3515300D46668 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287776EE27E3515300D46668 /* TabBarItem.swift */; };
 		28B0A19827E385C300B73177 /* NavigatorSidebarToolbarTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B0A19727E385C300B73177 /* NavigatorSidebarToolbarTop.swift */; };
@@ -183,7 +185,9 @@
 				0483E34D27FCC46600354AC0 /* ExtensionsStore in Frameworks */,
 				64B64EDE27F7B79400C400F1 /* About in Frameworks */,
 				04C3256B28034FC800C8DA2D /* CodeEditKit in Frameworks */,
+				2864BAAC28117B3F002DBD1A /* ShellClient in Frameworks */,
 				20C4319A28058B9E00964DD5 /* GitAccounts in Frameworks */,
+				2864BAAE28117D7C002DBD1A /* TerminalEmulator in Frameworks */,
 				5C403B8F27E20F8000788241 /* WorkspaceClient in Frameworks */,
 				5CAD1B972806B57D0059A74E /* Breadcrumbs in Frameworks */,
 				2803257127F3CF1F009C7DC2 /* AppPreferences in Frameworks */,
@@ -477,6 +481,8 @@
 				2004A3822808468600FD9696 /* Feedback */,
 				2040F0B0280AE96100411B6F /* CodeEditUtils */,
 				2816F593280CF50500DD548B /* CodeEditSymbols */,
+				2864BAAB28117B3F002DBD1A /* ShellClient */,
+				2864BAAD28117D7C002DBD1A /* TerminalEmulator */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -1007,7 +1013,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9VS2VKC5LQ;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1030,7 +1036,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9VS2VKC5LQ;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1140,6 +1146,14 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */;
 			productName = CodeEditSymbols;
+		};
+		2864BAAB28117B3F002DBD1A /* ShellClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ShellClient;
+		};
+		2864BAAD28117D7C002DBD1A /* TerminalEmulator */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TerminalEmulator;
 		};
 		28CE5E9F27E6493D0065D29C /* StatusBar */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit.xcodeproj/xcshareddata/xcschemes/CodeEdit.xcscheme
+++ b/CodeEdit.xcodeproj/xcshareddata/xcschemes/CodeEdit.xcscheme
@@ -62,9 +62,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "GitClientTests"
-               BuildableName = "GitClientTests"
-               BlueprintName = "GitClientTests"
+               BlueprintIdentifier = "WelcomeModuleTests"
+               BuildableName = "WelcomeModuleTests"
+               BlueprintName = "WelcomeModuleTests"
                ReferencedContainer = "container:CodeEditModules">
             </BuildableReference>
          </TestableReference>
@@ -72,9 +72,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "WelcomeModuleTests"
-               BuildableName = "WelcomeModuleTests"
-               BlueprintName = "WelcomeModuleTests"
+               BlueprintIdentifier = "GitClientTests"
+               BuildableName = "GitClientTests"
+               BlueprintName = "GitClientTests"
                ReferencedContainer = "container:CodeEditModules">
             </BuildableReference>
          </TestableReference>

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import CodeFile
 import CodeEditUI
 import QuickOpen
+import GitClient
 
 final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
 
@@ -70,6 +71,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         let toolbar = NSToolbar(identifier: UUID().uuidString)
         toolbar.delegate = self
         toolbar.displayMode = .labelOnly
+        self.window?.titleVisibility = .hidden
         self.window?.toolbarStyle = .unifiedCompact
         // Set titlebar background as transparent by default in order to style the toolbar background.
         self.window?.titlebarAppearsTransparent = true
@@ -82,6 +84,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         return [
             .toggleFirstSidebarItem,
             .sidebarTrackingSeparator,
+            .branchPicker,
             .flexibleSpace,
             .flexibleSpace,
             .toggleLastSidebarItem
@@ -94,10 +97,12 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
             .sidebarTrackingSeparator,
             .flexibleSpace,
             .itemListTrackingSeparator,
-            .toggleLastSidebarItem
+            .toggleLastSidebarItem,
+            .branchPicker
         ]
     }
 
+    // swiftlint:disable:next function_body_length
     func toolbar(
         _ toolbar: NSToolbar,
         itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
@@ -142,6 +147,12 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
             )?.withSymbolConfiguration(.init(scale: .large))
 
             return toolbarItem
+        case .branchPicker:
+            let toolbarItem = NSToolbarItem(itemIdentifier: .branchPicker)
+            let view = NSHostingView(rootView: BranchPickerToolbarItem(workspace?.workspaceClient))
+            toolbarItem.view = view
+
+            return toolbarItem
         default:
             return NSToolbarItem(itemIdentifier: itemIdentifier)
         }
@@ -160,9 +171,9 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         guard let lastSplitView = splitViewController.splitViewItems.last else { return }
         lastSplitView.animator().isCollapsed.toggle()
         if lastSplitView.animator().isCollapsed {
-            window?.toolbar?.removeItem(at: 3)
+            window?.toolbar?.removeItem(at: 4)
         } else {
-            window?.toolbar?.insertItem(withItemIdentifier: .itemListTrackingSeparator, at: 3)
+            window?.toolbar?.insertItem(withItemIdentifier: .itemListTrackingSeparator, at: 4)
         }
     }
 
@@ -209,4 +220,5 @@ private extension NSToolbarItem.Identifier {
     static let toggleFirstSidebarItem: NSToolbarItem.Identifier = NSToolbarItem.Identifier("ToggleFirstSidebarItem")
     static let toggleLastSidebarItem: NSToolbarItem.Identifier = NSToolbarItem.Identifier("ToggleLastSidebarItem")
     static let itemListTrackingSeparator = NSToolbarItem.Identifier("ItemListTrackingSeparator")
+    static let branchPicker: NSToolbarItem.Identifier = NSToolbarItem.Identifier("BranchPicker")
 }

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>824bdb5b5280edbe1318bfb0f56c38b7595f0bb3</string>
+	<string>56c0ddc4889f2879245a0cac1c5642238d0f0be0</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>56c0ddc4889f2879245a0cac1c5642238d0f0be0</string>
+	<string>64ed59bd61774f68f2596c99d00704caf16a7be2</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/CodeEditUI/src/BranchPickerToolbarItem.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/BranchPickerToolbarItem.swift
@@ -1,0 +1,85 @@
+//
+//  BranchPickerToolbarItem.swift
+//  CodeEdit
+//
+//  Created by Lukas Pistrol on 21.04.22.
+//
+
+import SwiftUI
+import CodeEditSymbols
+import WorkspaceClient
+import GitClient
+
+public struct BranchPickerToolbarItem: View {
+
+    private var workspace: WorkspaceClient?
+    private var gitClient: GitClient?
+
+    public init(_ workspace: WorkspaceClient?) {
+        self.workspace = workspace
+        if let folderURL = workspace?.folderURL() {
+            self.gitClient = GitClient.default(
+                directoryURL: folderURL,
+                shellClient: .live
+            )
+        }
+    }
+
+    @State
+    private var isHovering: Bool = false
+
+    @State
+    private var displayPopover: Bool = false
+
+    public var body: some View {
+        HStack(alignment: .center) {
+            Image.checkout
+                .imageScale(.large)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                    .frame(height: 16)
+                    .help(title)
+                if let currentBranch = currentBranch {
+                    ZStack(alignment: .trailing) {
+                        Text(currentBranch)
+                            .padding(.trailing)
+                        if isHovering {
+                            Image(systemName: "chevron.down")
+                        }
+                    }
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .frame(height: 11)
+                }
+            }
+        }
+        .onTapGesture {
+            displayPopover.toggle()
+        }
+        .onHover { active in
+            isHovering = active
+        }
+        .popover(isPresented: $displayPopover, arrowEdge: .bottom) {
+            PopoverView()
+        }
+    }
+
+    private var title: String {
+        workspace?.folderURL()?.lastPathComponent ?? "Empty"
+    }
+
+    private var currentBranch: String? {
+        try? gitClient?.getCurrentBranchName()
+    }
+
+    private struct PopoverView: View {
+        var body: some View {
+            VStack {
+                Text("Current Branch:")
+            }
+            .padding()
+        }
+    }
+}

--- a/CodeEditModules/Modules/CodeEditUI/src/BranchPickerToolbarItem.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/BranchPickerToolbarItem.swift
@@ -10,6 +10,7 @@ import CodeEditSymbols
 import WorkspaceClient
 import GitClient
 
+/// A view that displays a branch selector when tapped. This is designed to live in the toolbar of a window.
 public struct BranchPickerToolbarItem: View {
 
     private var workspace: WorkspaceClient?
@@ -75,6 +76,11 @@ public struct BranchPickerToolbarItem: View {
         workspace?.folderURL()?.lastPathComponent ?? "Empty"
     }
 
+    // MARK: Popover View
+
+    /// A popover view that appears once the branch picker is tapped.
+    ///
+    /// It displays the currently checked-out branch and all other local branches.
     private struct PopoverView: View {
 
         var gitClient: GitClient?
@@ -86,14 +92,14 @@ public struct BranchPickerToolbarItem: View {
                 if let currentBranch = currentBranch {
                     VStack(alignment: .leading, spacing: 0) {
                         headerLabel("Current Branch")
-                        BranchView(name: currentBranch, active: true) {}
+                        BranchCell(name: currentBranch, active: true) {}
                     }
                 }
                 if !branchNames.isEmpty {
                     VStack(alignment: .leading, spacing: 0) {
                         headerLabel("Branches")
                         ForEach(branchNames, id: \.self) { branch in
-                            BranchView(name: branch) {
+                            BranchCell(name: branch) {
                                 try? gitClient?.checkoutBranch(branch)
                                 currentBranch = try? gitClient?.getCurrentBranchName()
                             }
@@ -113,7 +119,10 @@ public struct BranchPickerToolbarItem: View {
                 .padding(.vertical, 5)
         }
 
-        struct BranchView: View {
+        // MARK: Branch Cell
+
+        /// A Button Cell that represents a branch in the branch picker
+        struct BranchCell: View {
             @Environment(\.dismiss) private var dismiss
 
             var name: String

--- a/CodeEditModules/Modules/GitClient/Tests/GitClientTests.swift
+++ b/CodeEditModules/Modules/GitClient/Tests/GitClientTests.swift
@@ -5,9 +5,9 @@
 //  Created by Marco Carnevali on 27/03/22.
 //
 
+import XCTest
 @testable import GitClient
 import ShellClient
-import XCTest
 
 final class GitClientTests: XCTestCase {
     // FIXME: Update GitClient.getCommitHistory implementation on date or this test case

--- a/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
@@ -53,10 +53,6 @@ public struct StatusBarView: View {
                         .padding(.horizontal, 7)
                     SegmentedControl($model.selectedTab, options: StatusBarTab.allOptions)
                 }
-                if model.selectedBranch != nil {
-                    StatusBarBranchPicker(model: model)
-                    StatusBarPullButton(model: model)
-                }
                 Spacer()
                 StatusBarCursorLocationLabel(model: model)
                 StatusBarIndentSelector(model: model)

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -256,6 +256,9 @@ let package = Package(
         ),
         .target(
             name: "CodeEditUI",
+            dependencies: [
+                "CodeEditSymbols"
+            ],
             path: "Modules/CodeEditUI/src"
         ),
         .testTarget(

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -257,7 +257,9 @@ let package = Package(
         .target(
             name: "CodeEditUI",
             dependencies: [
-                "CodeEditSymbols"
+                "CodeEditSymbols",
+                "WorkspaceClient",
+                "GitClient"
             ],
             path: "Modules/CodeEditUI/src"
         ),
@@ -265,6 +267,8 @@ let package = Package(
             name: "CodeEditUITests",
             dependencies: [
                 "CodeEditUI",
+                "WorkspaceClient",
+                "GitClient",
                 "SnapshotTesting",
             ],
             path: "Modules/CodeEditUI/Tests"


### PR DESCRIPTION
# Description

A very basic implementation of the toolbar branch selector.

When clicking on the item in the toolbar, a popup appears which lists the current branch and all other local branches. When clicking on a local branch this branch will get checked out.

This PR also fixes the `too many arguments` error that would appear in the branch selector when the project path contains spaces.

I also removed the status bar branch picker according to the Sigma concept.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #447 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="1112" alt="Screen Shot 2022-04-21 at 13 40 39" src="https://user-images.githubusercontent.com/9460130/164453942-e098ff4a-8076-44bc-ab51-6795ba5c1054.png">

