### PR TITLE
Match Tab Bar Divider Colors and Width

### DIFF
--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -28,7 +28,7 @@ struct WorkspaceCodeFileView: View {
                     .safeAreaInset(edge: .top, spacing: 0) {
                         VStack(spacing: 0) {
                             TabBar(windowController: windowController, workspace: workspace)
-                            Divider()
+                            TabBarBottomDivider()
                             BreadcrumbsView(file: item, tappedOpenFile: workspace.openFile(item:))
                         }
                     }

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -70,14 +70,7 @@ struct TabBar: View {
         .overlay {
             // When tab bar style is `xcode`, we put the top divider as an overlay.
             if prefs.preferences.general.tabBarStyle == .xcode {
-                NativeTabShadow()
-                    .frame(height: tabBarHeight, alignment: .top)
-            }
-        }
-        .background {
-            // When tab bar style is `native`, we put the top divider beneath tabs.
-            if prefs.preferences.general.tabBarStyle == .native {
-                NativeTabShadow()
+                TabBarTopDivider()
                     .frame(height: tabBarHeight, alignment: .top)
             }
         }
@@ -85,10 +78,15 @@ struct TabBar: View {
             if prefs.preferences.general.tabBarStyle == .xcode {
                 Color(nsColor: .controlBackgroundColor)
             } else {
-                Color(nsColor: .black)
-                    .opacity(colorScheme == .dark ? 0.50 : 0.05)
-                    // Set padding top to 1 to avoid color-overlapping.
-                    .padding(.top, 1)
+                ZStack {
+                    Color(nsColor: .black)
+                        .opacity(colorScheme == .dark ? 0.50 : 0.05)
+                        // Set padding top to 1 to avoid color-overlapping.
+                        .padding(.top, 1)
+                    // When tab bar style is `native`, we put the top divider beneath tabs.
+                    TabBarTopDivider()
+                        .frame(height: tabBarHeight, alignment: .top)
+                }
             }
         }
         .background {

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -34,15 +34,13 @@ struct TabDivider: View {
     }
 }
 
-/// The top border for inactive tabs when native-styled tab bar is selected.
-struct NativeTabShadow: View {
+/// The top border for tab bar (between tab bar and titlebar).
+struct TabBarTopDivider: View {
     @Environment(\.colorScheme)
     var colorScheme
 
     @StateObject
     private var prefs: AppPreferencesModel = .shared
-
-    let height: CGFloat = 1
 
     var body: some View {
         Rectangle()
@@ -50,11 +48,33 @@ struct NativeTabShadow: View {
                 Color(nsColor: .black)
                     .opacity(
                         prefs.preferences.general.tabBarStyle == .xcode
-                        ? (colorScheme == .dark ? 0.28 : 0.12)
-                        : (colorScheme == .dark ? 0.40 : 0.15)
+                        ? (colorScheme == .dark ? 0.29 : 0.11)
+                        : (colorScheme == .dark ? 0.80 : 0.15)
                     )
             )
-            .frame(height: height)
+            .frame(height: prefs.preferences.general.tabBarStyle == .xcode ? 1.0 : 0.8)
+    }
+}
+
+/// The bottom border for tab bar (between tab bar and breadcrumbs).
+struct TabBarBottomDivider: View {
+    @Environment(\.colorScheme)
+    var colorScheme
+
+    @StateObject
+    private var prefs: AppPreferencesModel = .shared
+
+    var body: some View {
+        Rectangle()
+            .foregroundColor(
+                prefs.preferences.general.tabBarStyle == .xcode
+                ? Color(nsColor: .separatorColor)
+                    .opacity(colorScheme == .dark ? 0.40 : 0.45)
+                : Color(nsColor: .black)
+                    .opacity(colorScheme == .dark ? 0.65 : 0.09)
+
+            )
+            .frame(height: prefs.preferences.general.tabBarStyle == .xcode ? 1.0 : 0.8)
     }
 }
 
@@ -194,7 +214,7 @@ struct TabBarItem: View {
             .overlay {
                 // Only show NativeTabShadow when `tabBarStyle` is native and this tab is not active.
                 if prefs.preferences.general.tabBarStyle == .native && !isActive {
-                    NativeTabShadow()
+                    TabBarTopDivider()
                         .frame(maxHeight: .infinity, alignment: .top)
                 }
             }
@@ -275,10 +295,17 @@ struct TabBarItem: View {
                 .overlay {
                     if !isActive {
                         ZStack {
+                            // Native inactive tab background dim.
                             Color(nsColor: .black)
                                 .opacity(colorScheme == .dark ? 0.50 : 0.05)
+
+                            // Native inactive tab hover state.
                             Color(nsColor: colorScheme == .dark ? .white : .black)
-                                .opacity(isHovering ? 0.05 : 0.0)
+                                .opacity(
+                                    isHovering
+                                    ? (colorScheme == .dark ? 0.08 : 0.05)
+                                    : 0.0
+                                )
                                 .animation(.easeInOut(duration: 0.10), value: isHovering)
                         }
                         .padding(.top, colorScheme == .dark ? 0 : 1)


### PR DESCRIPTION
# Description

* Fix the incorrect color issue of tab bar bottom divider.
* Better match the color and divider width of native tab bar (in both light and dark mode).
* Better match the color of xcode tab bar (in both light and dark mode).
* Refactor divider component name to avoid confusion.

# Related Issue

* #521

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

## Native Tab Style

<img width="651" alt="CleanShot 2022-04-22 at 02 20 39@2x" src="https://user-images.githubusercontent.com/36816148/164615306-57d81a86-8e94-4eb4-81ba-f1329cbdd3f9.png">

<img width="644" alt="CleanShot 2022-04-22 at 02 21 34@2x" src="https://user-images.githubusercontent.com/36816148/164615430-d5a85b8b-98a8-41d0-a94b-8940fa8fa6aa.png">


## Xcode Tab Style

<img width="674" alt="CleanShot 2022-04-22 at 02 22 00@2x" src="https://user-images.githubusercontent.com/36816148/164615487-91aca815-b6f7-4ee7-a01a-26cf284f4084.png">

<img width="655" alt="CleanShot 2022-04-22 at 02 21 48@2x" src="https://user-images.githubusercontent.com/36816148/164615460-54a3d18e-cdb6-4002-84a3-61d27c24cfd7.png">


