### PR TITLE
Fix Tab Bar Item Clicking Area Obstruction Issue

### DIFF
--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -124,16 +124,36 @@ struct TabBarItem: View {
             .overlay {
                 ZStack {
                     if isActive {
-                        // Create a hidden button, if the tab is selected
-                        // and hide the button in the ZStack.
-                        Button(action: closeAction) {
-                            Text("").hidden()
-                        }
+                        // Close Tab Shortcut:
+                        // Using an invisible button to contain the keyboard shortcut is simply
+                        // because the keyboard shortcut has an unexpected bug when working with
+                        // custom buttonStyle. This is an workaround and it works as expected.
+                        Button(
+                            action: closeAction,
+                            label: { EmptyView() }
+                        )
                         .frame(width: 0, height: 0)
                         .padding(0)
                         .opacity(0)
                         .keyboardShortcut("w", modifiers: [.command])
                     }
+                    // Switch Tab Shortcut:
+                    // Using an invisible button to contain the keyboard shortcut is simply
+                    // because the keyboard shortcut has an unexpected bug when working with
+                    // custom buttonStyle. This is an workaround and it works as expected.
+                    Button(
+                        action: switchAction,
+                        label: { EmptyView() }
+                    )
+                    .frame(width: 0, height: 0)
+                    .padding(0)
+                    .opacity(0)
+                    .keyboardShortcut(
+                        workspace.getTabKeyEquivalent(item: item),
+                        modifiers: [.command]
+                    )
+                    .background(.blue)
+                    // Close button.
                     Button(action: closeAction) {
                         if prefs.preferences.general.tabBarStyle == .xcode {
                             Image(systemName: "xmark")
@@ -236,22 +256,6 @@ struct TabBarItem: View {
             label: { content }
         )
         .buttonStyle(TabBarItemButtonStyle())
-        .overlay {
-            // Using an overlay to contain the keyboard shortcut is simply because
-            // the keyboard shortcut has an unexpected bug when working with custom
-            // buttonStyle. This is an workaround and it should work as expected.
-            Button(
-                action: switchAction,
-                label: { EmptyView() }
-            )
-            .frame(width: 0, height: 0)
-            .padding(0)
-            .opacity(0)
-            .keyboardShortcut(
-                workspace.getTabKeyEquivalent(item: item),
-                modifiers: [.command]
-            )
-        }
         .background {
             if prefs.preferences.general.tabBarStyle == .xcode {
                 Color(nsColor: isActive ? .selectedControlColor : .clear)


### PR DESCRIPTION
# Description

* Fix the clicking area obstruction issue by re-ordering the invisible button for keyboard shortcut.
* For now, after resolving the main issue, a tiny area around close button is still not clickable. But that area is very small (I barely click in there), so this problem might not need to be resolved immediately.

# Related Issue

* #522

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/36816148/164620206-4aa5b194-c867-459e-a97d-c808de93875c.mp4
