### PR TITLE
History & Branch Selector Popover: fixed selection background colors

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>26487d71bdf8453d840fe2abe6e1849891dc32b6</string>
+	<string>6c20f0cc08a0578fd3ef89c50d24965f5367f5a5</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>6c20f0cc08a0578fd3ef89c50d24965f5367f5a5</string>
+	<string>cf991acd3ad284a20ec08c8d16b27f817335482d</string>
 </dict>
 </plist>

--- a/CodeEdit/InspectorSidebar/Views/Popover/PopoverView.swift
+++ b/CodeEdit/InspectorSidebar/Views/Popover/PopoverView.swift
@@ -67,7 +67,7 @@ struct PopoverView: View {
             .padding(.horizontal, 6)
         }
         .padding(.top)
-        .padding(.bottom, 10)
+        .padding(.bottom, 5)
         .frame(width: 310)
     }
 
@@ -109,9 +109,9 @@ struct PopoverView: View {
             .padding(.horizontal, 10)
             .padding(.vertical, 3)
             .background(
-                isHovering && isEnabled ? Color(nsColor: .selectedContentBackgroundColor) : .clear
+                EffectView.selectionBackground(isHovering && isEnabled)
             )
-            .clipShape(RoundedRectangle(cornerRadius: 3))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
             .onHover { hovering in
                 isHovering = hovering
             }

--- a/CodeEditModules/Modules/CodeEditUI/src/EffectView.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/EffectView.swift
@@ -56,6 +56,9 @@ public struct EffectView: NSViewRepresentable {
         nsView.blendingMode = blendingMode
     }
 
+    /// Returns the system selection style as an ``EffectView`` if the `condition` is met. Otherwise it returns `Color.clear`
+    /// - Parameter condition: The condition of when to apply the background. Defaults to `true`.
+    /// - Returns: A View
     @ViewBuilder
     public static func selectionBackground(_ condition: Bool = true) -> some View {
         if condition {

--- a/CodeEditModules/Modules/CodeEditUI/src/EffectView.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/EffectView.swift
@@ -56,7 +56,9 @@ public struct EffectView: NSViewRepresentable {
         nsView.blendingMode = blendingMode
     }
 
-    /// Returns the system selection style as an ``EffectView`` if the `condition` is met. Otherwise it returns `Color.clear`
+    /// Returns the system selection style as an ``EffectView`` if the `condition` is met.
+    /// Otherwise it returns `Color.clear`
+    /// 
     /// - Parameter condition: The condition of when to apply the background. Defaults to `true`.
     /// - Returns: A View
     @ViewBuilder

--- a/CodeEditModules/Modules/CodeEditUI/src/EffectView.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/EffectView.swift
@@ -16,31 +16,52 @@ import SwiftUI
 public struct EffectView: NSViewRepresentable {
     private let material: NSVisualEffectView.Material
     private let blendingMode: NSVisualEffectView.BlendingMode
+    private let emphasized: Bool
 
-    /// Initializes the `NSVisualEffectView` with a
+    /// Initializes the
+    /// [`NSVisualEffectView`](https://developer.apple.com/documentation/appkit/nsvisualeffectview)
+    /// with a
     /// [`Material`](https://developer.apple.com/documentation/appkit/nsvisualeffectview/material) and
     /// [`BlendingMode`](https://developer.apple.com/documentation/appkit/nsvisualeffectview/blendingmode)
+    ///
+    /// By setting the
+    /// [`emphasized`](https://developer.apple.com/documentation/appkit/nsvisualeffectview/1644721-isemphasized)
+    /// flag the emphasized state of the material will be used if available.
+    ///
     /// - Parameters:
     ///   - material: The material to use. Defaults to `.headerView`.
     ///   - blendingMode: The blending mode to use. Defaults to `.withinWindow`.
+    ///   - emphasized:A Boolean value indicating whether to emphasize the look of the material. Defaults to `false`.
     public init(
         _ material: NSVisualEffectView.Material = .headerView,
-        blendingMode: NSVisualEffectView.BlendingMode = .withinWindow
+        blendingMode: NSVisualEffectView.BlendingMode = .withinWindow,
+        emphasized: Bool = false
     ) {
         self.material = material
         self.blendingMode = blendingMode
+        self.emphasized = emphasized
     }
 
     public func makeNSView(context: Context) -> NSVisualEffectView {
         let view = NSVisualEffectView()
         view.material = material
         view.blendingMode = blendingMode
-        view.state = NSVisualEffectView.State.followsWindowActiveState
+        view.isEmphasized = emphasized
+        view.state = .followsWindowActiveState
         return view
     }
 
     public func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
         nsView.material = material
         nsView.blendingMode = blendingMode
+    }
+
+    @ViewBuilder
+    public static func selectionBackground(_ condition: Bool = true) -> some View {
+        if condition {
+            EffectView(.selection, blendingMode: .withinWindow, emphasized: true)
+        } else {
+            Color.clear
+        }
     }
 }

--- a/CodeEditModules/Modules/CodeEditUI/src/ToolbarBranchPicker.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/ToolbarBranchPicker.swift
@@ -181,11 +181,9 @@ public struct ToolbarBranchPicker: View {
                 .padding(.horizontal)
                 .padding(.vertical, 10)
                 .background(
-                    RoundedRectangle(cornerRadius: 4)
-                        .foregroundColor(
-                            isHovering ? Color(nsColor: .selectedContentBackgroundColor).opacity(0.8) : .clear
-                        )
+                    EffectView.selectionBackground(isHovering)
                 )
+                .clipShape(RoundedRectangle(cornerRadius: 4))
                 .onHover { active in
                     isHovering = active
                 }


### PR DESCRIPTION
# Description

Fixed the selection background colors to match the system style by using `NSVisualEffectView` with the emphasized `.selection` material. This system provided style uses a slightly dimmed color compared to `NSColor.selectedContentBackgroundColor`. 

> Note that this is only a minor difference in color.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="315" alt="Screen Shot 2022-04-22 at 12 29 45" src="https://user-images.githubusercontent.com/9460130/164698599-97298d2f-c2d3-47ef-9fc1-13fe78725600.png">

<img width="343" alt="Screen Shot 2022-04-22 at 12 31 58" src="https://user-images.githubusercontent.com/9460130/164698624-bad3f5ac-d829-4fdc-8e0b-248228222bba.png">

## Difference
> from top to bottom: old CodeEdit, new CodeEdit, Xcode

![Group 1](https://user-images.githubusercontent.com/9460130/164701562-d2fb7f24-6a49-4d63-84f7-8a5cff0fbcc7.png)