### PR TITLE
[WIP] Fix Fullscreen Behavior of Tab Bar

### DIFF
--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -27,7 +27,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         self.workspace = workspace
 
         setupSplitView(with: workspace)
-        setupToolbar(with: workspace)
+        setupToolbar(for: workspace)
     }
 
     @available(*, unavailable)
@@ -67,24 +67,29 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         self.splitViewController = splitVC
     }
 
-    private func setupToolbar(with workspace: WorkspaceDocument) {
+    private func setupToolbar(for workspace: WorkspaceDocument) {
         let toolbar = NSToolbar(identifier: UUID().uuidString)
         toolbar.delegate = self
         toolbar.displayMode = .labelOnly
         toolbar.showsBaselineSeparator = false
         self.window?.titleVisibility = .hidden
         self.window?.toolbarStyle = .unifiedCompact
+
         // Set titlebar background as transparent by default in order to style the toolbar background.
         self.window?.titlebarAppearsTransparent = true
         self.window?.titlebarSeparatorStyle = .none
         self.window?.styleMask.insert(.fullSizeContentView)
 
-        let titlebar = NSTitlebarAccessoryViewController()
-        let hostingView = NSHostingView(rootView: TabBar(windowController: self, workspace: workspace))
-        titlebar.view = hostingView
-        titlebar.fullScreenMinHeight = 28
-        titlebar.layoutAttribute = .bottom
-        self.window?.addTitlebarAccessoryViewController(titlebar)
+        // WIP: New tab bar (embedded into titlebar/toolbar area).
+        let titlebarAccessory = NSTitlebarAccessoryViewController()
+        let tabBarHostingView = NSHostingView(
+            rootView: TabBar(windowController: self, workspace: workspace)
+        )
+        tabBarHostingView.frame.size = tabBarHostingView.fittingSize
+        titlebarAccessory.fullScreenMinHeight = 28
+        titlebarAccessory.layoutAttribute = .bottom
+        titlebarAccessory.view = tabBarHostingView
+        self.window?.addTitlebarAccessoryViewController(titlebarAccessory)
 
         self.window?.toolbar = toolbar
     }

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -27,7 +27,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         self.workspace = workspace
 
         setupSplitView(with: workspace)
-        setupToolbar()
+        setupToolbar(with: workspace)
     }
 
     @available(*, unavailable)
@@ -67,14 +67,25 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         self.splitViewController = splitVC
     }
 
-    private func setupToolbar() {
+    private func setupToolbar(with workspace: WorkspaceDocument) {
         let toolbar = NSToolbar(identifier: UUID().uuidString)
         toolbar.delegate = self
         toolbar.displayMode = .labelOnly
+        toolbar.showsBaselineSeparator = false
         self.window?.titleVisibility = .hidden
         self.window?.toolbarStyle = .unifiedCompact
         // Set titlebar background as transparent by default in order to style the toolbar background.
         self.window?.titlebarAppearsTransparent = true
+        self.window?.titlebarSeparatorStyle = .none
+        self.window?.styleMask.insert(.fullSizeContentView)
+
+        let titlebar = NSTitlebarAccessoryViewController()
+        let hostingView = NSHostingView(rootView: TabBar(windowController: self, workspace: workspace))
+        titlebar.view = hostingView
+        titlebar.fullScreenMinHeight = 28
+        titlebar.layoutAttribute = .bottom
+        self.window?.addTitlebarAccessoryViewController(titlebar)
+
         self.window?.toolbar = toolbar
     }
 

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -27,7 +27,7 @@ struct WorkspaceCodeFileView: View {
                 CodeFileView(codeFile: codeFile)
                     .safeAreaInset(edge: .top, spacing: 0) {
                         VStack(spacing: 0) {
-                            TabBar(windowController: windowController, workspace: workspace)
+//                            TabBar(windowController: windowController, workspace: workspace)
                             TabBarBottomDivider()
                             BreadcrumbsView(file: item, tappedOpenFile: workspace.openFile(item:))
                             Divider()

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -107,6 +107,6 @@ struct TabBar: View {
                 .edgesIgnoringSafeArea(.top)
             }
         }
-        .padding(.leading, -1)
+        .padding(.leading, 1)
     }
 }


### PR DESCRIPTION
# Description

In fullscreen mode, the tab bar is not integrated with the toolbar. So the background color is not matched (because titlebar background has changed) and it has a separated hovering effect.

# Related Issue

* #535

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [ ] My changes generate no new warnings
- [ ] My code builds and runs on my machine
- [ ] I documented my code
- [ ] Review requested

# Screenshots

Temporary solution (imperfect):

https://user-images.githubusercontent.com/36816148/164909716-8f1634df-6741-4661-a3aa-04b2978a4908.mp4

NSTitlebarAccessoryView has a divider between toolbar and the titlebar accessory, and I found no way to remove it:

![CleanShot 2022-04-23 at 10 16 41@2x](https://user-images.githubusercontent.com/36816148/164909770-5d53ff11-2aa6-4cfa-ac70-933d5f118b9e.png)

So I probably need some helps on this (removing this line or using other workaround).


# Related Links

https://developer.apple.com/documentation/appkit/nstitlebaraccessoryviewcontroller