### PR TITLE
Editor View: Updated Font for Line Numbers

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>1e75a9d778d0032d5f1aaf918bfc06cfe8baba25</string>
+	<string>0e233f2a4d0484e716dd44d05fdf52fc9584d567</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>cf991acd3ad284a20ec08c8d16b27f817335482d</string>
+	<string>1e75a9d778d0032d5f1aaf918bfc06cfe8baba25</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/CodeFile/src/CodeEditor.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeEditor.swift
@@ -69,7 +69,6 @@ struct CodeEditor: NSViewRepresentable {
         scrollView.verticalRulerView = LineGutter(
             scrollView: scrollView,
             width: 37,
-            // font: NSFont(name: "SF Mono", size: 11) ?? .monospacedSystemFont(ofSize: 11, weight: .regular),
             font: lineGutterFont,
             textColor: .tertiaryLabelColor,
             backgroundColor: .clear

--- a/CodeEditModules/Modules/CodeFile/src/CodeEditor.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeEditor.swift
@@ -57,6 +57,7 @@ struct CodeEditor: NSViewRepresentable {
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         textView.minSize = NSSize(width: 0, height: scrollView.contentSize.height)
         textView.delegate = context.coordinator
+        textView.usesFontPanel = false
 
         scrollView.drawsBackground = true
         scrollView.borderType = .noBorder
@@ -68,8 +69,9 @@ struct CodeEditor: NSViewRepresentable {
         scrollView.verticalRulerView = LineGutter(
             scrollView: scrollView,
             width: 37,
-            font: NSFont(name: "SF Mono", size: 11) ?? .monospacedSystemFont(ofSize: 11, weight: .regular),
-            textColor: .secondaryLabelColor,
+            // font: NSFont(name: "SF Mono", size: 11) ?? .monospacedSystemFont(ofSize: 11, weight: .regular),
+            font: lineGutterFont,
+            textColor: .tertiaryLabelColor,
             backgroundColor: .clear
         )
         scrollView.rulersVisible = true
@@ -78,13 +80,37 @@ struct CodeEditor: NSViewRepresentable {
         return scrollView
     }
 
+    private var lineGutterFont: NSFont {
+        let fontSize: Double = 10
+
+        // TODO: calculate the font size depending on the editors font size.
+
+        let font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .medium)
+
+        let alt0NoSlash: [NSFontDescriptor.FeatureKey: Int] = [
+            .selectorIdentifier: 6,
+            .typeIdentifier: kStylisticAlternativesType,
+        ]
+
+        let alt1NoSerif: [NSFontDescriptor.FeatureKey: Int] = [
+            .selectorIdentifier: 8,
+            .typeIdentifier: kStylisticAlternativesType,
+        ]
+
+        let descriptor = font.fontDescriptor.addingAttributes([.featureSettings: [alt0NoSlash, alt1NoSerif]])
+
+        return NSFont(descriptor: descriptor, size: 0) ?? font
+    }
+
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? CodeEditorTextView else {
             return
         }
-        if let rulerView = scrollView.verticalRulerView as? LineGutter,
-           content.wrappedValue != textView.string {
-            rulerView.invalidateLineIndices()
+        if let rulerView = scrollView.verticalRulerView as? LineGutter {
+            if content.wrappedValue != textView.string {
+                rulerView.invalidateLineIndices()
+            }
+            rulerView.font = lineGutterFont
         }
         updateTextView(textView)
     }

--- a/CodeEditModules/Modules/CodeFile/src/LineGutter/LineGutter.swift
+++ b/CodeEditModules/Modules/CodeFile/src/LineGutter/LineGutter.swift
@@ -56,7 +56,11 @@ final class LineGutter: NSRulerView {
 
     private let rulerMargin: CGFloat = 5
     private let rulerWidth: CGFloat
-    private let font: NSFont
+    public var font: NSFont {
+        didSet {
+            needsDisplay = true
+        }
+    }
     public var textColor: NSColor
     public var backgroundColor: NSColor
 
@@ -236,6 +240,8 @@ final class LineGutter: NSRulerView {
     func textAttributes() -> [NSAttributedString.Key: AnyObject] {
         [
             NSAttributedString.Key.font: self.font,
+            NSAttributedString.Key.kern: NSNumber(value: 0),
+            NSAttributedString.Key.tracking: NSNumber(value: 0),
             NSAttributedString.Key.foregroundColor: self.textColor
         ]
     }


### PR DESCRIPTION
# Description

To be exact: Now we're using `SF Mono Medium` with `Stylistic Alternate Characters` for the digits `1` and `0`.

This is done by adding these `font descriptor attributes`:

```swift
let alt0NoSlash: [NSFontDescriptor.FeatureKey: Int] = [
    .selectorIdentifier: 6,
    .typeIdentifier: kStylisticAlternativesType,
]

let alt1NoSerif: [NSFontDescriptor.FeatureKey: Int] = [
    .selectorIdentifier: 8,
    .typeIdentifier: kStylisticAlternativesType,
]

let descriptor = font.fontDescriptor.addingAttributes([
    .featureSettings: [alt0NoSlash, alt1NoSerif]
])
```

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

## Overview

<img width="1112" alt="Screen Shot 2022-04-23 at 16 46 00" src="https://user-images.githubusercontent.com/9460130/164911183-0d96a198-3559-4f67-a44f-59f2595eccd8.png">

## Line Numbers

<img alt="Screen Shot 2022-04-23 at 16 45 17" src="https://user-images.githubusercontent.com/9460130/164911188-b816d247-7445-4bc6-84c4-28f2f8d8f2a8.png">

