### PR TITLE
[WIP] Resolved issues in search-results #534

### DIFF
--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -246,6 +246,7 @@ extension WorkspaceDocument {
     final class SearchState: ObservableObject {
         var workspace: WorkspaceDocument
         @Published var searchResult: [SearchResultModel] = []
+        @Published var searchText: String = ""
 
         init(_ workspace: WorkspaceDocument) {
             self.workspace = workspace

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>b65f8ea34ec3259bd783ecb0a4cc49356436e84a</string>
+	<string>336cf02a09f4a525d854af6a49d0d897a45af63f</string>
 </dict>
 </plist>

--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigator.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigator.swift
@@ -13,9 +13,6 @@ struct FindNavigator: View {
     @ObservedObject
     var state: WorkspaceDocument.SearchState
 
-    @State
-    private var searchText: String = ""
-
     private var foundFilesCount: Int {
         state.searchResult.filter {!$0.hasKeywordInfo}.count
     }
@@ -28,7 +25,7 @@ struct FindNavigator: View {
         VStack {
             VStack {
                 FindNavigatorModeSelector()
-                FindNavigatorSearchBar(state: state, title: "", text: $searchText)
+                FindNavigatorSearchBar(state: state, title: "", text: $state.searchText)
                 HStack {
                     Spacer()
                 }
@@ -45,7 +42,7 @@ struct FindNavigator: View {
             FindNavigatorResultList(state: state)
         }
         .onSubmit {
-            state.search(searchText)
+            state.search(state.searchText)
         }
     }
 }


### PR DESCRIPTION
# Dev note 🛠

I started working on this issue and found out that after clicking on a search result we open whole file (instead of file with desired line of code). 
I found it hard to fix all of color issues without a little bit of hacking (🪝 ).

Current implementation of `FindNavigatorResultList` doesn't catch selection events within the same file so I'm considering refactoring it something similar to `ProjectNavigator` - OutlineGroup. WDYT?

# Description

## Changes
* Fixed issues with colors in search results
* Fixed: text in the search field is removed from the input field when you switch panels.
* Refactored `FindNavigatorResultFileItem` - extracted large parts to separate subviews


<!--- REQUIRED: Describe what changed in detail -->

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #534 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [ ] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

### Light Mode
| Before  | After |
| ------------- | ------------- |
| <img width="267" alt="CleanShot 2022-04-25 at 22 35 48@2x" src="https://user-images.githubusercontent.com/31246956/165170800-db15ad3d-c735-4295-9a21-a8e8c14f357a.png"> | <img width="264" alt="CleanShot 2022-04-25 at 22 19 28@2x" src="https://user-images.githubusercontent.com/31246956/165170835-9ea209a9-24d4-41f9-8f25-aa01276a3e37.png"> |

### Dark Mode
| Before  | After |
| ------------- | ------------- |
| <img width="265" alt="CleanShot 2022-04-25 at 22 35 58@2x" src="https://user-images.githubusercontent.com/31246956/165172026-6bce3125-15fe-45c7-98bf-b7869a178620.png"> | <img width="260" alt="CleanShot 2022-04-25 at 22 19 11@2x" src="https://user-images.githubusercontent.com/31246956/165172046-bab6eb2b-07a4-47ee-9e52-9c8f189ac04a.png"> |




<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
