### PR TITLE
Added hover, push, and inactive states for mini tabs.

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>0e233f2a4d0484e716dd44d05fdf52fc9584d567</string>
+	<string>32192e1c71f66c04a0072aca5f853315ea51199a</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/CodeEditUI/src/PressActionsModifier.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/PressActionsModifier.swift
@@ -1,0 +1,32 @@
+//
+//  Created by Gabriel Theodoropoulos on 1/11/20.
+//
+
+import SwiftUI
+
+struct PressActions: ViewModifier {
+    var onPress: () -> Void
+    var onRelease: () -> Void
+    func body(content: Content) -> some View {
+        content
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged({ _ in
+                        onPress()
+                    })
+                    .onEnded({ _ in
+                        onRelease()
+                    })
+            )
+    }
+}
+
+extension View {
+    func pressAction(onPress: @escaping (() -> Void), onRelease: @escaping (() -> Void)) -> some View {
+        modifier(PressActions(onPress: {
+            onPress()
+        }, onRelease: {
+            onRelease()
+        }))
+    }
+}

--- a/CodeEditModules/Modules/CodeEditUI/src/SegmentedControl.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/SegmentedControl.swift
@@ -9,10 +9,6 @@ import SwiftUI
 
 /// A view that creates a segmented control from an array of text labels.
 public struct SegmentedControl: View {
-
-    @Environment(\.colorScheme)
-    private var colorScheme
-
     /// A view that creates a segmented control from an array of text labels.
     /// - Parameters:
     ///   - selection: The index of the current selected item.
@@ -36,29 +32,72 @@ public struct SegmentedControl: View {
     private let color: Color
 
     public var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 8) {
             ForEach(options.indices, id: \.self) { index in
-                Text(options[index])
-                    .font(.subheadline)
-                    .foregroundColor(preselectedIndex == index
-                                     ? colorScheme == .dark ? .white : .accentColor
-                                     : .primary)
-                    .frame(height: 16)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
-                    .background {
-                        Rectangle()
-                            .fill(color)
-                            .cornerRadius(5)
-                            .padding(2)
-                            .opacity(preselectedIndex == index ? 0.75 : 0.01)
-                    }
-                    .onTapGesture {
+                SegmentedControlItem(
+                    label: options[index],
+                    active: preselectedIndex == index,
+                    action: {
                         preselectedIndex = index
-                    }
+                    },
+                    color: color
+                )
+
             }
         }
         .frame(height: 20)
+    }
+}
+
+struct SegmentedControlItem: View {
+    @Environment(\.colorScheme)
+    private var colorScheme
+
+    @Environment(\.controlActiveState)
+    private var activeState
+
+    @State
+    var isHovering: Bool = false
+
+    @State
+    var isPressing: Bool = false
+
+    let label: String
+
+    let active: Bool
+
+    let action: () -> Void
+
+    let color: Color
+
+    public var body: some View {
+        Text(label)
+            .font(.subheadline)
+            .foregroundColor(active
+                             ? colorScheme == .dark ? .white : .accentColor
+                             : .primary)
+            .opacity(activeState != .inactive ? 1 : active ? 0.5 : 0.3)
+            .frame(height: 20)
+            .padding(.horizontal, 7.5)
+            .background(
+                active
+                ? color.opacity(isPressing ? 1 : activeState != .inactive ? 0.75 : 0.5)
+                : Color(nsColor: colorScheme == .dark ? .white : .black)
+                    .opacity(isPressing ? 0.10 : isHovering ? 0.05 : 0)
+            )
+            .cornerRadius(5)
+            .onTapGesture {
+                action()
+            }
+            .onHover { hover in
+                isHovering = hover
+            }
+            .pressAction {
+                isPressing = true
+            } onRelease: {
+                isPressing = false
+            }
+
     }
 }
 


### PR DESCRIPTION
# Description

This PR adds hover, push, and inactive states for mini tabs.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #550 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/806104/165230014-ab6988f6-a7be-4d7f-939b-80b834daa8f6.mov