### PR TITLE
Status Bar fixes

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>9fccda47a128d367f38efa59b8a84e5cb25ec9dd</string>
+	<string>77abafe85e98d065022f9af76460e0ffbc170107</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>5593ad9a1f15ecfe6dfda914110cb6bf463aa63f</string>
+	<string>9fccda47a128d367f38efa59b8a84e5cb25ec9dd</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
+++ b/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
@@ -29,7 +29,7 @@ public class StatusBarModel: ObservableObject {
     /// - **1**: Debugger
     /// - **2**: Output
     @Published
-    public var selectedTab: Int = 1
+    public var selectedTab: Int = 0
 
     // TODO: Implement logic for updating values
     /// Returns number of errors during comilation

--- a/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
@@ -52,6 +52,7 @@ public struct StatusBarView: View {
                         .frame(maxHeight: 12)
                         .padding(.horizontal, 7)
                     SegmentedControl($model.selectedTab, options: StatusBarTab.allOptions)
+                        .opacity(model.isExpanded ? 1 : 0)
                 }
                 Spacer()
                 StatusBarCursorLocationLabel(model: model)

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarDrawer.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarDrawer.swift
@@ -30,11 +30,8 @@ internal struct StatusBarDrawer: View {
     }
 
     internal var body: some View {
-        ZStack(alignment: .bottom) {
+        VStack(spacing: 0) {
             TerminalEmulatorView(url: model.workspaceURL)
-                .frame(minHeight: 0,
-                       idealHeight: height,
-                       maxHeight: height)
             HStack(alignment: .center, spacing: 10) {
                 FilterTextField(title: "Filter", text: $searchText)
                     .frame(maxWidth: 300)
@@ -44,8 +41,12 @@ internal struct StatusBarDrawer: View {
                 StatusBarSplitTerminalButton(model: model)
                 StatusBarMaximizeButton(model: model)
             }
-            .padding(.all, 10)
+            .padding(10)
             .frame(maxHeight: 34)
+            .background(.bar)
         }
+        .frame(minHeight: 0,
+               idealHeight: height,
+               maxHeight: height)
     }
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarEncodingSelector.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarEncodingSelector.swift
@@ -19,8 +19,7 @@ internal struct StatusBarEncodingSelector: View {
         Menu {
             // UTF 8, ASCII, ...
         } label: {
-            StatusBarMenuLabel(text: "UTF 8")
-                .font(model.toolbarFont)
+            StatusBarMenuLabel("UTF 8", model: model)
         }
         .menuIndicator(.hidden)
         .menuStyle(.borderlessButton)

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarIndentSelector.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarIndentSelector.swift
@@ -39,8 +39,7 @@ internal struct StatusBarIndentSelector: View {
                 }
             }
         } label: {
-            StatusBarMenuLabel(text: "\(prefs.preferences.textEditing.defaultTabWidth) Spaces")
-                .font(model.toolbarFont)
+            StatusBarMenuLabel("\(prefs.preferences.textEditing.defaultTabWidth) Spaces", model: model)
         }
         .menuIndicator(.hidden)
         .menuStyle(.borderlessButton)

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarLineEndSelector.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarLineEndSelector.swift
@@ -19,9 +19,7 @@ internal struct StatusBarLineEndSelector: View {
         Menu {
             // LF, CRLF
         } label: {
-            StatusBarMenuLabel(text: "LF")
-                .font(model.toolbarFont)
-        }
+            StatusBarMenuLabel("LF", model: model)        }
         .menuIndicator(.hidden)
         .menuStyle(.borderlessButton)
         .fixedSize()

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarMenuLabel.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarMenuLabel.swift
@@ -1,11 +1,22 @@
 import SwiftUI
+import CodeEditSymbols
 
 /// A view that displays Text with custom chevron up/down symbol
 internal struct StatusBarMenuLabel: View {
-    internal let text: String
+    private let text: String
+
+    @ObservedObject
+    private var model: StatusBarModel
+
+    internal init(_ text: String, model: StatusBarModel) {
+        self.text = text
+        self.model = model
+    }
 
     internal var body: some View {
-        Text(text + " ") +
+        Text(text + "  ")
+            .font(model.toolbarFont) +
         Text(Image.customChevronUpChevronDown)
+            .font(model.toolbarFont)
     }
 }

--- a/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView.swift
+++ b/CodeEditModules/Modules/TerminalEmulator/src/TerminalEmulatorView.swift
@@ -180,7 +180,17 @@ public struct TerminalEmulatorView: NSViewRepresentable {
             terminal.optionAsMetaKey = optionAsMeta
         }
         terminal.appearance = colorAppearance
+        scroller?.isHidden = true
         TerminalEmulatorView.lastTerminal[url.path] = terminal
+    }
+
+    private var scroller: NSScroller? {
+        for subView in terminal.subviews {
+            if let scroller = subView as? NSScroller {
+                return scroller
+            }
+        }
+        return nil
     }
 
     public func updateNSView(_ view: LocalProcessTerminalView, context: Context) {


### PR DESCRIPTION
# Description

- The initial selected Tab in the status bar now is `Terminal`
- Hide Mini-Tabs when not expanded,
- Terminal: hide square in bottom right corner,
- Add background to drawer filter area

Also fixed the picker font size:
<img width="300" alt="Screen Shot 2022-04-26 at 11 49 26" src="https://user-images.githubusercontent.com/9460130/165273317-83d83b69-3b6d-4506-ac0e-5306f76380ef.png">


# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #491 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

## Hidden Mini-Tabs when collapsed
<img width="1112" alt="Screen Shot 2022-04-26 at 11 19 23" src="https://user-images.githubusercontent.com/9460130/165268646-17783a05-f48d-43cb-8bc2-2b473aea8806.png">

## Background for Filter Area
<img width="1112" alt="Screen Shot 2022-04-26 at 11 19 10" src="https://user-images.githubusercontent.com/9460130/165268803-48e706c4-d6f9-46e3-bd4c-b9dd633b27f4.png">
<img width="1112" alt="Screen Shot 2022-04-26 at 11 31 29" src="https://user-images.githubusercontent.com/9460130/165269647-618d763e-03f0-4d51-b661-0f51f39c8f5f.png">
<img width="1112" alt="Screen Shot 2022-04-26 at 11 18 55" src="https://user-images.githubusercontent.com/9460130/165269742-d5745b85-1cf7-4643-bde4-349380142bde.png">


