### PR TITLE
Optimize Native Tab Bar Style, Fix Bugs, and Add Accessory Icons.

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		D7E201B227E8D50000CB86D0 /* FindNavigatorModeSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E201B127E8D50000CB86D0 /* FindNavigatorModeSelector.swift */; };
 		D7E201BD27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E201BC27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift */; };
 		D7F72DEB27EA3574000C3064 /* Search in Frameworks */ = {isa = PBXBuildFile; productRef = D7F72DEA27EA3574000C3064 /* Search */; };
+		DE6405A62817734700881FDF /* TabBarNative.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6405A52817734700881FDF /* TabBarNative.swift */; };
 		DE6F77872813625500D00A76 /* TabBarDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F77862813625500D00A76 /* TabBarDivider.swift */; };
 /* End PBXBuildFile section */
 
@@ -180,6 +181,7 @@
 		D7E201B127E8D50000CB86D0 /* FindNavigatorModeSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorModeSelector.swift; sourceTree = "<group>"; };
 		D7E201B327E9989900CB86D0 /* FindNavigatorResultList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorResultList.swift; sourceTree = "<group>"; };
 		D7E201BC27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorResultFileItem.swift; sourceTree = "<group>"; };
+		DE6405A52817734700881FDF /* TabBarNative.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarNative.swift; sourceTree = "<group>"; };
 		DE6F77862813625500D00A76 /* TabBarDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarDivider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -357,6 +359,7 @@
 				287776E827E34BC700D46668 /* TabBar.swift */,
 				287776EE27E3515300D46668 /* TabBarItem.swift */,
 				DE6F77862813625500D00A76 /* TabBarDivider.swift */,
+				DE6405A52817734700881FDF /* TabBarNative.swift */,
 			);
 			path = TabBar;
 			sourceTree = "<group>";
@@ -712,6 +715,7 @@
 				20EBB503280C327C00F3A5DA /* HistoryInspector.swift in Sources */,
 				2072FA1A280D872600C7F8D4 /* LineEndings.swift in Sources */,
 				20EBB507280C32D300F3A5DA /* QuickHelpInspector.swift in Sources */,
+				DE6405A62817734700881FDF /* TabBarNative.swift in Sources */,
 				04C3255C2801F86900C8DA2D /* OutlineMenu.swift in Sources */,
 				04540D5E27DD08C300E91B77 /* WorkspaceView.swift in Sources */,
 				DE6F77872813625500D00A76 /* TabBarDivider.swift in Sources */,

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		D7E201B227E8D50000CB86D0 /* FindNavigatorModeSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E201B127E8D50000CB86D0 /* FindNavigatorModeSelector.swift */; };
 		D7E201BD27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E201BC27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift */; };
 		D7F72DEB27EA3574000C3064 /* Search in Frameworks */ = {isa = PBXBuildFile; productRef = D7F72DEA27EA3574000C3064 /* Search */; };
+		DE513F52281B672D002260B9 /* TabBarAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE513F51281B672D002260B9 /* TabBarAccessory.swift */; };
 		DE6405A62817734700881FDF /* TabBarNative.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6405A52817734700881FDF /* TabBarNative.swift */; };
 		DE6F77872813625500D00A76 /* TabBarDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F77862813625500D00A76 /* TabBarDivider.swift */; };
 /* End PBXBuildFile section */
@@ -181,6 +182,7 @@
 		D7E201B127E8D50000CB86D0 /* FindNavigatorModeSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorModeSelector.swift; sourceTree = "<group>"; };
 		D7E201B327E9989900CB86D0 /* FindNavigatorResultList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorResultList.swift; sourceTree = "<group>"; };
 		D7E201BC27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorResultFileItem.swift; sourceTree = "<group>"; };
+		DE513F51281B672D002260B9 /* TabBarAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarAccessory.swift; sourceTree = "<group>"; };
 		DE6405A52817734700881FDF /* TabBarNative.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarNative.swift; sourceTree = "<group>"; };
 		DE6F77862813625500D00A76 /* TabBarDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarDivider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -360,6 +362,7 @@
 				287776EE27E3515300D46668 /* TabBarItem.swift */,
 				DE6F77862813625500D00A76 /* TabBarDivider.swift */,
 				DE6405A52817734700881FDF /* TabBarNative.swift */,
+				DE513F51281B672D002260B9 /* TabBarAccessory.swift */,
 			);
 			path = TabBar;
 			sourceTree = "<group>";
@@ -696,6 +699,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2072FA13280D74ED00C7F8D4 /* HistoryInspectorModel.swift in Sources */,
+				DE513F52281B672D002260B9 /* TabBarAccessory.swift in Sources */,
 				2813F93927ECC4C300E305E4 /* NavigatorSidebar.swift in Sources */,
 				20EBB50D280C383700F3A5DA /* LanguageType.swift in Sources */,
 				2813F93827ECC4AA00E305E4 /* FindNavigatorResultList.swift in Sources */,

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		D7E201BD27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E201BC27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift */; };
 		D7F72DEB27EA3574000C3064 /* Search in Frameworks */ = {isa = PBXBuildFile; productRef = D7F72DEA27EA3574000C3064 /* Search */; };
 		DE513F52281B672D002260B9 /* TabBarAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE513F51281B672D002260B9 /* TabBarAccessory.swift */; };
+		DE513F54281DE5D0002260B9 /* TabBarXcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE513F53281DE5D0002260B9 /* TabBarXcode.swift */; };
 		DE6405A62817734700881FDF /* TabBarNative.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6405A52817734700881FDF /* TabBarNative.swift */; };
 		DE6F77872813625500D00A76 /* TabBarDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F77862813625500D00A76 /* TabBarDivider.swift */; };
 		FD6A3D3D2817C13B008BCF11 /* Package.resolved in Resources */ = {isa = PBXBuildFile; fileRef = FD6A3D3C2817C13B008BCF11 /* Package.resolved */; };
@@ -184,9 +185,10 @@
 		D7E201B327E9989900CB86D0 /* FindNavigatorResultList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorResultList.swift; sourceTree = "<group>"; };
 		D7E201BC27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorResultFileItem.swift; sourceTree = "<group>"; };
 		DE513F51281B672D002260B9 /* TabBarAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarAccessory.swift; sourceTree = "<group>"; };
+		DE513F53281DE5D0002260B9 /* TabBarXcode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarXcode.swift; sourceTree = "<group>"; };
 		DE6405A52817734700881FDF /* TabBarNative.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarNative.swift; sourceTree = "<group>"; };
 		DE6F77862813625500D00A76 /* TabBarDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarDivider.swift; sourceTree = "<group>"; };
-		FD6A3D3C2817C13B008BCF11 /* Package.resolved */ = {isa = PBXFileReference; lastKnownFileType = file; path = Package.resolved; sourceTree = SOURCE_ROOT; };
+		FD6A3D3C2817C13B008BCF11 /* Package.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Package.resolved; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -365,6 +367,7 @@
 				DE6F77862813625500D00A76 /* TabBarDivider.swift */,
 				DE6405A52817734700881FDF /* TabBarNative.swift */,
 				DE513F51281B672D002260B9 /* TabBarAccessory.swift */,
+				DE513F53281DE5D0002260B9 /* TabBarXcode.swift */,
 			);
 			path = TabBar;
 			sourceTree = "<group>";
@@ -724,6 +727,7 @@
 				2072FA13280D74ED00C7F8D4 /* HistoryInspectorModel.swift in Sources */,
 				DE513F52281B672D002260B9 /* TabBarAccessory.swift in Sources */,
 				2813F93927ECC4C300E305E4 /* NavigatorSidebar.swift in Sources */,
+				DE513F54281DE5D0002260B9 /* TabBarXcode.swift in Sources */,
 				20EBB50D280C383700F3A5DA /* LanguageType.swift in Sources */,
 				2813F93827ECC4AA00E305E4 /* FindNavigatorResultList.swift in Sources */,
 				0483E35027FDB17700354AC0 /* ExtensionNavigator.swift in Sources */,

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -17,33 +17,40 @@ struct WorkspaceCodeFileView: View {
 
     @ViewBuilder
     var codeView: some View {
-        if let item = workspace.selectionState.openFileItems.first(where: { file in
-            if file.id == workspace.selectionState.selectedId {
-                print("Item loaded is: ", file.url)
-            }
-            return file.id == workspace.selectionState.selectedId
-        }) {
-            if let codeFile = workspace.selectionState.openedCodeFiles[item] {
-                CodeFileView(codeFile: codeFile)
-                    .safeAreaInset(edge: .top, spacing: 0) {
-                        VStack(spacing: 0) {
-                            TabBar(windowController: windowController, workspace: workspace)
-                            TabBarBottomDivider()
-                            BreadcrumbsView(file: item, tappedOpenFile: workspace.openFile(item:))
-                            Divider()
+        ZStack {
+            if let item = workspace.selectionState.openFileItems.first(where: { file in
+                if file.id == workspace.selectionState.selectedId {
+                    print("Item loaded is: ", file.url)
+                }
+                return file.id == workspace.selectionState.selectedId
+            }) {
+                if let codeFile = workspace.selectionState.openedCodeFiles[item] {
+                    CodeFileView(codeFile: codeFile)
+                        .safeAreaInset(edge: .top, spacing: 0) {
+                            VStack(spacing: 0) {
+                                BreadcrumbsView(file: item, tappedOpenFile: workspace.openFile(item:))
+                                Divider()
+                            }
                         }
-                    }
+                } else {
+                    Text("CodeEdit cannot open this file because its file type is not supported.")
+                        .frame(minHeight: 0)
+                        .clipped()
+                }
             } else {
-                Text("CodeEdit cannot open this file because its file type is not supported.")
+                Text("No Editor")
+                    .font(.system(size: 17))
+                    .foregroundColor(.secondary)
                     .frame(minHeight: 0)
                     .clipped()
             }
-        } else {
-            Text("No Editor")
-                .font(.system(size: 17))
-                .foregroundColor(.secondary)
-                .frame(minHeight: 0)
-                .clipped()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .safeAreaInset(edge: .top, spacing: 0) {
+            VStack(spacing: 0) {
+                TabBar(windowController: windowController, workspace: workspace)
+                TabBarBottomDivider()
+            }
         }
     }
 

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -49,10 +49,15 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
 
         if selectionState.openFileItems.isEmpty {
             selectionState.selectedId = nil
-        } else if idx == 0 {
-            selectionState.selectedId = selectionState.openFileItems.first?.id
+        } else if selectionState.selectedId == closedFileItem.id {
+            // If the closed item is the selected one, then select another tab.
+            if idx == 0 {
+                selectionState.selectedId = selectionState.openFileItems.first?.id
+            } else {
+                selectionState.selectedId = selectionState.openFileItems[idx - 1].id
+            }
         } else {
-            selectionState.selectedId = selectionState.openFileItems[idx - 1].id
+            // If the closed item is not the selected one, then do nothing.
         }
     }
     func closeFileTabs<Items>(items: Items) where Items: Collection, Items.Element == WorkspaceClient.FileItem {

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -90,13 +90,15 @@ struct TabBar: View {
                                     windowController: windowController,
                                     workspace: workspace
                                 )
+                                .transition(.slide)
                             }
                         }
                         // This padding is to hide dividers at two ends under the accessory view divider.
                         .padding(.horizontal, prefs.preferences.general.tabBarStyle == .native ? -1 : 0)
-                        // On view appeared, compute the initial expected width for tabs.
                         .onAppear {
+                            // On view appeared, compute the initial expected width for tabs.
                             updateExpectedTabWidth(proxy: geometryProxy)
+                            // On first tab appeared, jump to the corresponding position.
                             scrollReader.scrollTo(workspace.selectionState.selectedId)
                         }
                         // When selected tab is changed, scroll to it if possible.
@@ -109,7 +111,7 @@ struct TabBar: View {
                             // Only update the expected width when user is not hovering over tabs.
                             // This should give users a better experience on closing multiple tabs continuously.
                             if !isHoveringOverTabs {
-                                withAnimation(.easeOut(duration: 0.20)) {
+                                withAnimation(.easeOut(duration: 0.15)) {
                                     updateExpectedTabWidth(proxy: geometryProxy)
                                 }
                             }
@@ -122,13 +124,17 @@ struct TabBar: View {
                         .onHover { isHovering in
                             isHoveringOverTabs = isHovering
                             if !isHovering {
-                                withAnimation(.easeOut(duration: 0.20)) {
+                                withAnimation(.easeOut(duration: 0.15)) {
                                     updateExpectedTabWidth(proxy: geometryProxy)
                                 }
                             }
                         }
                     }
                 }
+                // When there is no opened file, hide the scroll view, but keep the background.
+                .opacity(workspace.selectionState.openFileItems.isEmpty ? 0.0 : 1.0)
+                // To fill up the parent space of tab bar.
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background {
                     TabBarNativeInactiveBackground()
                 }

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -94,14 +94,17 @@ struct TabBar: View {
                         }
                         // This padding is to hide dividers at two ends under the accessory view divider.
                         .padding(.horizontal, prefs.preferences.general.tabBarStyle == .native ? -1 : 0)
+                        // On view appeared, compute the initial expected width for tabs.
                         .onAppear {
                             updateExpectedTabWidth(proxy: geometryProxy)
                             scrollReader.scrollTo(workspace.selectionState.selectedId)
                         }
+                        // When selected tab is changed, scroll to it if possible.
                         .onChange(of: workspace.selectionState.selectedId) { targetId in
                             guard let selectedId = targetId else { return }
                             scrollReader.scrollTo(selectedId)
                         }
+                        // When tabs are changing, re-compute the expected tab width.
                         .onChange(of: workspace.selectionState.openFileItems.count) { _ in
                             // Only update the expected width when user is not hovering over tabs.
                             // This should give users a better experience on closing multiple tabs continuously.
@@ -111,12 +114,13 @@ struct TabBar: View {
                                 }
                             }
                         }
+                        // When window size changes, re-compute the expected tab width.
                         .onChange(of: geometryProxy.size.width) { _ in
                             updateExpectedTabWidth(proxy: geometryProxy)
                         }
+                        // When user is not hovering anymore, re-compute the expected tab width immediately.
                         .onHover { isHovering in
                             isHoveringOverTabs = isHovering
-                            // When user is not hovering anymore, update the expected width immediately.
                             if !isHovering {
                                 withAnimation(.easeOut(duration: 0.20)) {
                                     updateExpectedTabWidth(proxy: geometryProxy)

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -11,6 +11,10 @@ import AppPreferences
 import CodeEditUI
 
 struct TabBar: View {
+    /// The height of tab bar.
+    /// I am not making it a private variable because it may need to be used in outside views.
+    static let height = 28.0
+
     @Environment(\.colorScheme)
     private var colorScheme
 
@@ -21,8 +25,6 @@ struct TabBar: View {
 
     @ObservedObject
     private var workspace: WorkspaceDocument
-
-    private let tabBarHeight = 28.0
 
     @StateObject
     private var prefs: AppPreferencesModel = .shared
@@ -90,7 +92,7 @@ struct TabBar: View {
                                     windowController: windowController,
                                     workspace: workspace
                                 )
-                                .transition(.slide)
+                                .frame(height: TabBar.height)
                             }
                         }
                         // This padding is to hide dividers at two ends under the accessory view divider.
@@ -129,14 +131,17 @@ struct TabBar: View {
                                 }
                             }
                         }
+                        .frame(height: TabBar.height)
                     }
                 }
                 // When there is no opened file, hide the scroll view, but keep the background.
                 .opacity(workspace.selectionState.openFileItems.isEmpty ? 0.0 : 1.0)
                 // To fill up the parent space of tab bar.
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .frame(maxWidth: .infinity)
                 .background {
-                    TabBarNativeInactiveBackground()
+                    if prefs.preferences.general.tabBarStyle == .native {
+                        TabBarNativeInactiveBackground()
+                    }
                 }
             }
             // Tab bar tools (e.g. split view).
@@ -169,7 +174,7 @@ struct TabBar: View {
                 }
             }
         }
-        .frame(height: tabBarHeight)
+        .frame(height: TabBar.height)
         .overlay(alignment: .top) {
             // When tab bar style is `xcode`, we put the top divider as an overlay.
             if prefs.preferences.general.tabBarStyle == .xcode {
@@ -188,7 +193,7 @@ struct TabBar: View {
                     blendingMode: NSVisualEffectView.BlendingMode.withinWindow
                 )
                 // Set bottom padding to avoid material overlapping in bar.
-                .padding(.bottom, tabBarHeight)
+                .padding(.bottom, TabBar.height)
                 .edgesIgnoringSafeArea(.top)
             } else {
                 TabBarNativeMaterial()

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -14,7 +14,8 @@ struct TabBar: View {
     @Environment(\.colorScheme)
     private var colorScheme
 
-    @Environment(\.controlActiveState) private var activeState
+    @Environment(\.controlActiveState)
+    private var activeState
 
     private let windowController: NSWindowController
 
@@ -25,6 +26,7 @@ struct TabBar: View {
 
     @StateObject
     private var prefs: AppPreferencesModel = .shared
+
     // TabBar(windowController: windowController, workspace: workspace)
     init(windowController: NSWindowController, workspace: WorkspaceDocument) {
         self.windowController = windowController
@@ -36,7 +38,8 @@ struct TabBar: View {
 
     /// This state is used to detect if the mouse is hovering over tabs.
     /// If it is true, then we do not update the expected tab width immediately.
-    @State var isHoveringOverTabs: Bool = false
+    @State
+    var isHoveringOverTabs: Bool = false
 
     private func updateExpectedTabWidth(proxy: GeometryProxy) {
         expectedTabWidth = max(
@@ -87,6 +90,7 @@ struct TabBar: View {
                                 )
                             }
                         }
+                        // This padding is to hide dividers at two ends under the accessory view divider.
                         .padding(.horizontal, prefs.preferences.general.tabBarStyle == .native ? -1 : 0)
                         .onAppear {
                             updateExpectedTabWidth(proxy: geometryProxy)

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -183,7 +183,7 @@ struct TabBar: View {
         }
         .background {
             if prefs.preferences.general.tabBarStyle == .xcode {
-                Color(nsColor: .controlBackgroundColor)
+                TabBarXcodeBackground()
             }
         }
         .background {

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -96,7 +96,7 @@ struct TabBar: View {
                             updateExpectedTabWidth(proxy: geometryProxy)
                             value.scrollTo(self.workspace.selectionState.selectedId)
                         }
-                        .onChange(of: workspace.selectionState.openFileItems.count) { tabCount in
+                        .onChange(of: workspace.selectionState.openFileItems.count) { _ in
                             // Only update the expected width when user is not hovering over tabs.
                             // This should give users a better experience on closing multiple tabs continuously.
                             if !isHoveringOverTabs {
@@ -105,7 +105,7 @@ struct TabBar: View {
                                 }
                             }
                         }
-                        .onChange(of: geometryProxy.size.width) { newWidth in
+                        .onChange(of: geometryProxy.size.width) { _ in
                             updateExpectedTabWidth(proxy: geometryProxy)
                         }
                         .onHover { isHovering in

--- a/CodeEdit/TabBar/TabBarAccessory.swift
+++ b/CodeEdit/TabBar/TabBarAccessory.swift
@@ -1,0 +1,78 @@
+//
+//  TabBarAccessory.swift
+//  CodeEdit
+//
+//  Created by Lingxi Li on 4/28/22.
+//
+
+import SwiftUI
+
+/// Accessory icon's view for tab bar.
+struct TabBarAccessoryIcon: View {
+    /// Unifies icon font for tab bar accessories.
+    static private let iconFont = Font.system(size: 14, weight: .regular, design: .default)
+
+    private let icon: Image
+    private let action: () -> Void
+
+    init(icon: Image, action: @escaping () -> Void) {
+        self.icon = icon
+        self.action = action
+    }
+
+    var body: some View {
+        Button(
+            action: action,
+            label: { icon.font(TabBarAccessoryIcon.iconFont) }
+        )
+    }
+}
+
+/// Tab bar accessory area background for native tab bar style.
+struct TabBarAccessoryNativeBackground: View {
+    enum DividerPosition {
+        case none
+        case leading
+        case trailing
+    }
+
+    /// Divider alignment
+    private let dividerPosition: Self.DividerPosition
+
+    init(dividerAt: Self.DividerPosition) {
+        self.dividerPosition = dividerAt
+    }
+
+    private func getAlignment() -> Alignment {
+        switch self.dividerPosition {
+        case .leading:
+            return .leading
+        case .trailing:
+            return .trailing
+        default:
+            return .leading
+        }
+    }
+
+    private func getPaddingDirection() -> Edge.Set {
+        switch self.dividerPosition {
+        case .leading:
+            return .leading
+        case .trailing:
+            return .trailing
+        default:
+            return .leading
+        }
+    }
+
+    var body: some View {
+        ZStack(alignment: getAlignment()) {
+            TabBarNativeInactiveBackgroundColor()
+                .padding(getPaddingDirection(), dividerPosition == .none ? 0 : 1)
+            TabDivider()
+                .opacity(dividerPosition == .none ? 0 : 1)
+            TabBarTopDivider()
+                .frame(maxHeight: .infinity, alignment: .top)
+        }
+    }
+}

--- a/CodeEdit/TabBar/TabBarDivider.swift
+++ b/CodeEdit/TabBar/TabBarDivider.swift
@@ -27,8 +27,8 @@ struct TabDivider: View {
                 prefs.preferences.general.tabBarStyle == .xcode
                 ? Color(nsColor: colorScheme == .dark ? .white : .black)
                     .opacity(0.12)
-                : Color(nsColor: colorScheme == .dark ? .white : .black)
-                    .opacity(colorScheme == .dark ? 0.08 : 0.12)
+                : Color(nsColor: colorScheme == .dark ? .controlColor : .black)
+                    .opacity(colorScheme == .dark ? 0.40 : 0.13)
             )
     }
 }

--- a/CodeEdit/TabBar/TabBarDivider.swift
+++ b/CodeEdit/TabBar/TabBarDivider.swift
@@ -71,7 +71,7 @@ struct TabBarBottomDivider: View {
             .foregroundColor(
                 prefs.preferences.general.tabBarStyle == .xcode
                 ? Color(nsColor: .separatorColor)
-                    .opacity(colorScheme == .dark ? 0.40 : 0.45)
+                    .opacity(colorScheme == .dark ? 0.80 : 0.50)
                 : Color(nsColor: .black)
                     .opacity(colorScheme == .dark ? 0.65 : 0.13)
 

--- a/CodeEdit/TabBar/TabBarDivider.swift
+++ b/CodeEdit/TabBar/TabBarDivider.swift
@@ -73,7 +73,7 @@ struct TabBarBottomDivider: View {
                 ? Color(nsColor: .separatorColor)
                     .opacity(colorScheme == .dark ? 0.40 : 0.45)
                 : Color(nsColor: .black)
-                    .opacity(colorScheme == .dark ? 0.65 : 0.09)
+                    .opacity(colorScheme == .dark ? 0.65 : 0.13)
 
             )
             .frame(height: prefs.preferences.general.tabBarStyle == .xcode ? 1.0 : 0.8)

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -284,7 +284,6 @@ struct TabBarItem: View {
                 : nil
             )
         )
-        .clipped()
         .onAppear {
             withAnimation(.easeOut(duration: 0.20)) {
                 isAppeared = true

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -254,14 +254,10 @@ struct TabBarItem: View {
                     )
                     .animation(.easeInOut(duration: 0.08), value: isHovering)
             } else {
-                EffectView(
-                    NSVisualEffectView.Material.titlebar,
-                    blendingMode: NSVisualEffectView.BlendingMode.withinWindow
-                )
-                .background(Color(nsColor: .controlBackgroundColor))
+                TabBarNativeMaterial()
                 ZStack {
                     // Native inactive tab background dim.
-                    TabBarNativeBackgroundInactiveColor()
+                    TabBarNativeInactiveBackgroundColor()
                     // Native inactive tab hover state.
                     Color(nsColor: colorScheme == .dark ? .white : .black)
                         .opacity(isHovering ? (colorScheme == .dark ? 0.08 : 0.05) : 0.0)

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -10,12 +10,17 @@ import WorkspaceClient
 import AppPreferences
 import CodeEditUI
 
+// Disable the rule because this view is fairly complicated and I have already modularize some parts.
+// swiftlint:disable type_body_length
 struct TabBarItem: View {
     @Environment(\.colorScheme)
     private var colorScheme
 
     @Environment(\.controlActiveState)
     private var activeState
+
+    @Environment(\.isFullscreen)
+    private var isFullscreen
 
     @StateObject
     private var prefs: AppPreferencesModel = .shared
@@ -159,7 +164,8 @@ struct TabBarItem: View {
                     .foregroundColor(isPressingClose ? .primary : .secondary)
                     .background(
                         colorScheme == .dark
-                        ? Color(nsColor: .white).opacity(isPressingClose ? 0.32 : isHoveringClose ? 0.18 : 0)
+                        ? Color(nsColor: .white)
+                            .opacity(isPressingClose ? 0.32 : isHoveringClose ? 0.18 : 0)
                         : (
                             prefs.preferences.general.tabBarStyle == .xcode
                             ? Color(nsColor: isActive ? .controlAccentColor : .black)
@@ -255,7 +261,11 @@ struct TabBarItem: View {
                     )
                     .animation(.easeInOut(duration: 0.08), value: isHovering)
             } else {
-                TabBarNativeMaterial()
+                if isFullscreen && isActive {
+                    TabBarNativeActiveMaterial()
+                } else {
+                    TabBarNativeMaterial()
+                }
                 ZStack {
                     // Native inactive tab background dim.
                     TabBarNativeInactiveBackgroundColor()
@@ -311,6 +321,7 @@ struct TabBarItem: View {
         }
     }
 }
+// swiftlint:enable type_body_length
 
 fileprivate extension WorkspaceDocument {
     func getTabKeyEquivalent(item: WorkspaceClient.FileItem) -> KeyEquivalent {

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -250,18 +250,26 @@ struct TabBarItem: View {
         .buttonStyle(TabBarItemButtonStyle())
         .background {
             if prefs.preferences.general.tabBarStyle == .xcode {
-                Color(nsColor: isActive ? .selectedControlColor : .clear)
-                    .opacity(
-                        colorScheme == .dark
-                        ? (activeState != .inactive ? 0.70 : 0.50)
-                        : (activeState != .inactive ? 0.50 : 0.35)
-                    )
-                    .background(
-                        // This layer of background is to hide dividers of other tab bar items
-                        // because the original background above is translucent (by opacity).
-                        TabBarXcodeBackground()
-                    )
-                    .animation(.easeInOut(duration: 0.08), value: isHovering)
+                ZStack {
+                    // This layer of background is to hide dividers of other tab bar items
+                    // because the original background above is translucent (by opacity).
+                    TabBarXcodeBackground()
+                    if isActive {
+                        Color(nsColor: .controlAccentColor)
+                            .saturation(
+                                colorScheme == .dark
+                                ? (activeState != .inactive ? 0.60 : 0.75)
+                                : (activeState != .inactive ? 0.90 : 0.75)
+                            )
+                            .opacity(
+                                colorScheme == .dark
+                                ? (activeState != .inactive ? 0.50 : 0.35)
+                                : (activeState != .inactive ? 0.19 : 0.13)
+                            )
+                            .hueRotation(.degrees(-5))
+                    }
+                }
+                .animation(.easeInOut(duration: 0.08), value: isHovering)
             } else {
                 if isFullscreen && isActive {
                     TabBarNativeActiveMaterial()

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -259,7 +259,7 @@ struct TabBarItem: View {
                             .saturation(
                                 colorScheme == .dark
                                 ? (activeState != .inactive ? 0.60 : 0.75)
-                                : (activeState != .inactive ? 0.90 : 0.75)
+                                : (activeState != .inactive ? 0.90 : 0.85)
                             )
                             .opacity(
                                 colorScheme == .dark

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -264,7 +264,7 @@ struct TabBarItem: View {
                             .opacity(
                                 colorScheme == .dark
                                 ? (activeState != .inactive ? 0.50 : 0.35)
-                                : (activeState != .inactive ? 0.19 : 0.13)
+                                : (activeState != .inactive ? 0.18 : 0.12)
                             )
                             .hueRotation(.degrees(-5))
                     }

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -79,7 +79,7 @@ struct TabBarItem: View {
         HStack(spacing: 0.0) {
             TabDivider()
                 .opacity(isActive && prefs.preferences.general.tabBarStyle == .xcode ? 0.0 : 1.0)
-                .padding(.top, isActive && prefs.preferences.general.tabBarStyle == .native ? 2 : 0)
+                .padding(.top, isActive && prefs.preferences.general.tabBarStyle == .native ? 1.22 : 0)
             // Tab content (icon and text).
             HStack(alignment: .center, spacing: 5) {
                 Image(systemName: item.systemImage)
@@ -200,7 +200,7 @@ struct TabBarItem: View {
             )
             TabDivider()
                 .opacity(isActive && prefs.preferences.general.tabBarStyle == .xcode ? 0.0 : 1.0)
-                .padding(.top, isActive && prefs.preferences.general.tabBarStyle == .native ? 2 : 0)
+                .padding(.top, isActive && prefs.preferences.general.tabBarStyle == .native ? 1.22 : 0)
         }
         .overlay(alignment: .top) {
             // Only show NativeTabShadow when `tabBarStyle` is native and this tab is not active.

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -259,7 +259,7 @@ struct TabBarItem: View {
                     .background(
                         // This layer of background is to hide dividers of other tab bar items
                         // because the original background above is translucent (by opacity).
-                        Color(nsColor: .controlBackgroundColor)
+                        TabBarXcodeBackground()
                     )
                     .animation(.easeInOut(duration: 0.08), value: isHovering)
             } else {

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -79,6 +79,7 @@ struct TabBarItem: View {
         HStack(spacing: 0.0) {
             TabDivider()
                 .opacity(isActive && prefs.preferences.general.tabBarStyle == .xcode ? 0.0 : 1.0)
+                .padding(.top, isActive && prefs.preferences.general.tabBarStyle == .native ? 2 : 0)
             // Tab content (icon and text).
             HStack(alignment: .center, spacing: 5) {
                 Image(systemName: item.systemImage)
@@ -199,6 +200,7 @@ struct TabBarItem: View {
             )
             TabDivider()
                 .opacity(isActive && prefs.preferences.general.tabBarStyle == .xcode ? 0.0 : 1.0)
+                .padding(.top, isActive && prefs.preferences.general.tabBarStyle == .native ? 2 : 0)
         }
         .overlay(alignment: .top) {
             // Only show NativeTabShadow when `tabBarStyle` is native and this tab is not active.
@@ -275,7 +277,7 @@ struct TabBarItem: View {
             y: 0
         )
         .opacity(isAppeared ? 1.0 : 0.0)
-        .zIndex(isActive ? 1 : 0)
+        .zIndex(isActive ? (prefs.preferences.general.tabBarStyle == .native ? -1 : 1) : 0)
         .frame(
             width: (
                 // Constrain the width of tab bar item for native tab style only.

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -62,7 +62,9 @@ struct TabBarItem: View {
         if prefs.preferences.general.tabBarStyle == .native {
             isAppeared = false
         }
-        withAnimation(.easeOut(duration: 0.20)) {
+        withAnimation(
+            .easeOut(duration: prefs.preferences.general.tabBarStyle == .native ? 0.15 : 0.20)
+        ) {
             workspace.closeFileTab(item: item)
         }
     }
@@ -297,7 +299,9 @@ struct TabBarItem: View {
             )
         )
         .onAppear {
-            withAnimation(.easeOut(duration: 0.20)) {
+            withAnimation(
+                .easeOut(duration: prefs.preferences.general.tabBarStyle == .native ? 0.15 : 0.20)
+            ) {
                 isAppeared = true
             }
         }

--- a/CodeEdit/TabBar/TabBarNative.swift
+++ b/CodeEdit/TabBar/TabBarNative.swift
@@ -1,0 +1,39 @@
+//
+//  TabBarNative.swift
+//  CodeEdit
+//
+//  This file contains some support views to make native tab bar style come true.
+//
+//  Created by Lingxi Li on 4/25/22.
+//
+
+import SwiftUI
+import AppPreferences
+import WorkspaceClient
+import CodeEditUI
+
+struct TabBarNativeBackgroundInactive: View {
+    @Environment(\.colorScheme)
+    var colorScheme
+
+    @Environment(\.controlActiveState)
+    private var activeState
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            TabBarNativeBackgroundInactiveColor()
+            // When tab bar style is `native`, we put the top divider beneath tabs.
+            TabBarTopDivider()
+        }
+    }
+}
+
+struct TabBarNativeBackgroundInactiveColor: View {
+    @Environment(\.colorScheme)
+    var colorScheme
+
+    var body: some View {
+        Color(nsColor: .black)
+            .opacity(colorScheme == .dark ? 0.45 : 0.05)
+    }
+}

--- a/CodeEdit/TabBar/TabBarNative.swift
+++ b/CodeEdit/TabBar/TabBarNative.swift
@@ -12,13 +12,8 @@ import AppPreferences
 import WorkspaceClient
 import CodeEditUI
 
+/// Native style background view (including color and shadow divider) for tab bar.
 struct TabBarNativeInactiveBackground: View {
-    @Environment(\.colorScheme)
-    var colorScheme
-
-    @Environment(\.controlActiveState)
-    private var activeState
-
     var body: some View {
         ZStack(alignment: .top) {
             TabBarNativeInactiveBackgroundColor()
@@ -28,9 +23,10 @@ struct TabBarNativeInactiveBackground: View {
     }
 }
 
+/// Native style background color for tab bar.
 struct TabBarNativeInactiveBackgroundColor: View {
     @Environment(\.colorScheme)
-    var colorScheme
+    private var colorScheme
 
     var body: some View {
         Color(nsColor: .black)
@@ -38,6 +34,7 @@ struct TabBarNativeInactiveBackgroundColor: View {
     }
 }
 
+/// Native style background material for tab bar.
 struct TabBarNativeMaterial: View {
     var body: some View {
         EffectView(

--- a/CodeEdit/TabBar/TabBarNative.swift
+++ b/CodeEdit/TabBar/TabBarNative.swift
@@ -12,7 +12,7 @@ import AppPreferences
 import WorkspaceClient
 import CodeEditUI
 
-struct TabBarNativeBackgroundInactive: View {
+struct TabBarNativeInactiveBackground: View {
     @Environment(\.colorScheme)
     var colorScheme
 
@@ -21,19 +21,29 @@ struct TabBarNativeBackgroundInactive: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            TabBarNativeBackgroundInactiveColor()
+            TabBarNativeInactiveBackgroundColor()
             // When tab bar style is `native`, we put the top divider beneath tabs.
             TabBarTopDivider()
         }
     }
 }
 
-struct TabBarNativeBackgroundInactiveColor: View {
+struct TabBarNativeInactiveBackgroundColor: View {
     @Environment(\.colorScheme)
     var colorScheme
 
     var body: some View {
         Color(nsColor: .black)
             .opacity(colorScheme == .dark ? 0.45 : 0.05)
+    }
+}
+
+struct TabBarNativeMaterial: View {
+    var body: some View {
+        EffectView(
+            NSVisualEffectView.Material.titlebar,
+            blendingMode: NSVisualEffectView.BlendingMode.withinWindow
+        )
+        .background(Color(nsColor: .controlBackgroundColor))
     }
 }

--- a/CodeEdit/TabBar/TabBarNative.swift
+++ b/CodeEdit/TabBar/TabBarNative.swift
@@ -34,6 +34,31 @@ struct TabBarNativeInactiveBackgroundColor: View {
     }
 }
 
+/// Native style background material for active tab bar in fullscreen.
+/// This view is only used in fullscreen (to match the material of toolbar).
+struct TabBarNativeActiveMaterial: View {
+    @Environment(\.colorScheme)
+    private var colorScheme
+
+    var body: some View {
+        EffectView(
+            NSVisualEffectView.Material.headerView,
+            blendingMode: NSVisualEffectView.BlendingMode.withinWindow
+        )
+        .background(
+            // This layer of background is for matching the native toolbar background
+            // in dark mode and in fullscreen.
+            // There is no exactly matched material available.
+            // If you have a better solution, feel free to replace!!
+            Color(nsColor: colorScheme == .dark ? .selectedContentBackgroundColor : .clear)
+                .opacity(0.003)
+        )
+        .background(
+            Color(nsColor: colorScheme == .dark ? .windowBackgroundColor : .controlBackgroundColor)
+        )
+    }
+}
+
 /// Native style background material for tab bar.
 struct TabBarNativeMaterial: View {
     var body: some View {

--- a/CodeEdit/TabBar/TabBarXcode.swift
+++ b/CodeEdit/TabBar/TabBarXcode.swift
@@ -1,0 +1,24 @@
+//
+//  TabBarXcode.swift
+//  CodeEdit
+//
+//  Created by Lingxi Li on 4/30/22.
+//
+
+import SwiftUI
+import CodeEditUI
+
+/// This is the Xcode style background material for tab bar and breadcrumbs.
+struct TabBarXcodeBackground: View {
+    @Environment(\.colorScheme)
+    private var colorScheme
+
+    var body: some View {
+        EffectView(
+            colorScheme == .dark
+            ? NSVisualEffectView.Material.windowBackground
+            : NSVisualEffectView.Material.contentBackground,
+            blendingMode: NSVisualEffectView.BlendingMode.withinWindow
+        )
+    }
+}

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import WorkspaceClient
 import StatusBar
+import AppKit
 
 struct WorkspaceView: View {
     init(windowController: NSWindowController, workspace: WorkspaceDocument) {
@@ -34,6 +35,17 @@ struct WorkspaceView: View {
     @State
     var showInspector = true
 
+    /// The fullscreen state of the NSWindow.
+    /// This will be passed into all child views as an environment variable.
+    @State
+    var isFullscreen = false
+
+    @State
+    private var enterFullscreenObserver: Any?
+
+    @State
+    private var leaveFullscreenObserver: Any?
+
     var body: some View {
         ZStack {
             if workspace.workspaceClient != nil, let model = workspace.statusBarModel {
@@ -56,11 +68,50 @@ struct WorkspaceView: View {
                 windowController.window?.subtitle = ""
             }
         }
+        .onAppear {
+            // There may be other methods to monitor the full-screen state.
+            // But I cannot find a better one for now because I need to pass this into the SwiftUI.
+            // And it should always be updated.
+            enterFullscreenObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didEnterFullScreenNotification,
+                object: nil,
+                queue: .current,
+                using: { _ in self.isFullscreen = true }
+            )
+            leaveFullscreenObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.willExitFullScreenNotification,
+                object: nil,
+                queue: .current,
+                using: { _ in self.isFullscreen = false }
+            )
+        }
+        .onDisappear {
+            // Unregister the observer when view is going to be disappeared.
+            if enterFullscreenObserver != nil {
+                NotificationCenter.default.removeObserver(enterFullscreenObserver!)
+            }
+            if leaveFullscreenObserver != nil {
+                NotificationCenter.default.removeObserver(leaveFullscreenObserver!)
+            }
+        }
+        // Send the environment to all subviews.
+        .environment(\.isFullscreen, self.isFullscreen)
     }
 }
 
 struct WorkspaceView_Previews: PreviewProvider {
     static var previews: some View {
         WorkspaceView(windowController: NSWindowController(), workspace: .init())
+    }
+}
+
+private struct WorkspaceFullscreenStateEnvironmentKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
+extension EnvironmentValues {
+    var isFullscreen: Bool {
+        get { self[WorkspaceFullscreenStateEnvironmentKey.self] }
+        set { self[WorkspaceFullscreenStateEnvironmentKey.self] = newValue }
     }
 }

--- a/CodeEditModules/Modules/Breadcrumbs/src/BreadcrumbsView.swift
+++ b/CodeEditModules/Modules/Breadcrumbs/src/BreadcrumbsView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import WorkspaceClient
+import CodeEditUI
 
 public struct BreadcrumbsView: View {
     @Environment(\.colorScheme)
@@ -42,7 +43,14 @@ public struct BreadcrumbsView: View {
             .padding(.horizontal, 10)
         }
         .frame(height: 28, alignment: .center)
-        .background(Color(nsColor: .controlBackgroundColor))
+        .background {
+            EffectView(
+                colorScheme == .dark
+                ? NSVisualEffectView.Material.windowBackground
+                : NSVisualEffectView.Material.contentBackground,
+                blendingMode: NSVisualEffectView.BlendingMode.withinWindow
+            )
+        }
         .onAppear {
             fileInfo(self.file)
         }


### PR DESCRIPTION
# Description

* [x] Optimize the native tab bar style to make it feel more like Finder.
* [x] Add right side accessory icon placeholders.
* [x] Fix fullscreen native tab bar color issue.
* [x] Fix the toolbar background (and missing tab bar) issue while there is no file opened.
* [x] Add missing tinted background color at tab bar and breadcrumb.
* [x] Fix active tab background color in Xcode style.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #532
* #535 
* #546

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

## New Native Tab Bar Style

https://user-images.githubusercontent.com/36816148/165642886-80c62332-f936-440a-8d1e-5265c689a596.mp4
