### PR TITLE
Fixed the strange behavior of sidebar openings

### DIFF
--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -44,6 +44,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         )
         navigator.titlebarSeparatorStyle = .none
         navigator.minimumThickness = 260
+        navigator.collapseBehavior = .useConstraints
         splitVC.addSplitViewItem(navigator)
 
         let workspaceView = WorkspaceView(windowController: self, workspace: workspace)
@@ -61,7 +62,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         inspector.minimumThickness = 260
         inspector.maximumThickness = 260
         inspector.isCollapsed = true
-        inspector.collapseBehavior = .preferResizingSiblingsWithFixedSplitView
+        inspector.collapseBehavior = .useConstraints
         splitVC.addSplitViewItem(inspector)
 
         self.splitViewController = splitVC
@@ -170,7 +171,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
     @objc func toggleLastPanel() {
         guard let lastSplitView = splitViewController.splitViewItems.last else { return }
         lastSplitView.animator().isCollapsed.toggle()
-        if lastSplitView.animator().isCollapsed {
+        if lastSplitView.isCollapsed {
             window?.toolbar?.removeItem(at: 4)
         } else {
             window?.toolbar?.insertItem(withItemIdentifier: .itemListTrackingSeparator, at: 4)

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>6869e20b040c34383cfa356e48f1ec92a3334a03</string>
+	<string>912701dcded1113023d2753fb89d2e37b4a7a5ff</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixed upstream bug #538

# Description

Changed the split view items behaviour to `useConstraints`, it keeps the window size fixed the workspace expand

# Related Issue

- #538 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots
https://youtu.be/C5n2kTcWtNw
