### PR TITLE
`CodeEditUtils`: added opacity to hex color inits

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>1431c7387b276943e30e20e8d75f51535326c4c7</string>
+	<string>e9dde109e0f3d77916baa023857e0ddc079aa805</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/CodeEditUtils/Tests/UnitTests_Extensions.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/Tests/UnitTests_Extensions.swift
@@ -42,6 +42,20 @@ final class CodeEditUtilsExtensionsUnitTests: XCTestCase {
         XCTAssertEqual(colorInt, color.hex)
     }
 
+    func testColorConversionAlphaValue() throws {
+        let alpha = 0.25
+        let color = Color(hex: "#123456", alpha: alpha)
+
+        XCTAssertEqual(alpha, color.alphaComponent)
+    }
+
+    func testNSColorConversionAlphaValue() throws {
+        let alpha = 0.25
+        let color = NSColor(hex: "#123456", alpha: alpha)
+
+        XCTAssertEqual(alpha, color.alphaComponent)
+    }
+
     // MARK: - DATE + FORMATTED
 
     func testRelativeDateStringMinutes() throws {

--- a/CodeEditModules/Modules/CodeEditUtils/src/Extensions/Color+HEX.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/src/Extensions/Color+HEX.swift
@@ -9,20 +9,26 @@ import SwiftUI
 
 public extension Color {
 
-    /// Initializes a `Color` from a HEX String (e.g.: #112233)
-    init(hex: String) {
+    /// Initializes a `Color` from a HEX String (e.g.: `#1D2E3F`) and an optional alpha value.
+    /// - Parameters:
+    ///   - hex: A String of a HEX representation of a color (format: `#1D2E3F`)
+    ///   - alpha: A Double indicating the alpha value from `0.0` to `1.0`
+    init(hex: String, alpha: Double = 1.0) {
         let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
         var int: UInt64 = 0
         Scanner(string: hex).scanHexInt64(&int)
-        self.init(hex: Int(int))
+        self.init(hex: Int(int), alpha: alpha)
     }
 
-    /// Initializes a `Color` from an Int (e.g.: 0x112233)
-    init(hex: Int) {
+    /// Initializes a `Color` from an Int (e.g.: `0x1D2E3F`)and an optional alpha value.
+    /// - Parameters:
+    ///   - hex: An Int of a HEX representation of a color (format: `0x1D2E3F`)
+    ///   - alpha: A Double indicating the alpha value from `0.0` to `1.0`
+    init(hex: Int, alpha: Double = 1.0) {
         let red = (hex >> 16) & 0xFF
         let green = (hex >> 8) & 0xFF
         let blue = hex & 0xFF
-        self.init(.sRGB, red: Double(red) / 255, green: Double(green) / 255, blue: Double(blue) / 255, opacity: 1)
+        self.init(.sRGB, red: Double(red) / 255, green: Double(green) / 255, blue: Double(blue) / 255, opacity: alpha)
     }
 
     /// Returns an Int representing the `Color` in hex format (e.g.: 0x112233)
@@ -42,24 +48,35 @@ public extension Color {
 
         return "#" + String(format: "%06x", color)
     }
+
+    /// The alpha (opacity) component of the Color (0.0 - 1.0)
+    var alphaComponent: Double {
+        return NSColor(self).alphaComponent
+    }
 }
 
 public extension NSColor {
 
-    /// Initializes a `NSColor` from a HEX String (e.g.: #112233)
-    convenience init(hex: String) {
+    /// Initializes a `NSColor` from a HEX String (e.g.: `#1D2E3F`) and an optional alpha value.
+    /// - Parameters:
+    ///   - hex: A String of a HEX representation of a color (format: `#1D2E3F`)
+    ///   - alpha: A Double indicating the alpha value from `0.0` to `1.0`
+    convenience init(hex: String, alpha: Double = 1.0) {
         let hex = hex.trimmingCharacters(in: .alphanumerics.inverted)
         var int: UInt64 = 0
         Scanner(string: hex).scanHexInt64(&int)
-        self.init(hex: Int(int))
+        self.init(hex: Int(int), alpha: alpha)
     }
 
-    /// Initializes a `NSColor` from an Int (e.g.: 0x112233)
-    convenience init(hex: Int) {
+    /// Initializes a `NSColor` from an Int  (e.g.: `0x1D2E3F`)and an optional alpha value.
+    /// - Parameters:
+    ///   - hex: An Int of a HEX representation of a color (format: `0x1D2E3F`)
+    ///   - alpha: A Double indicating the alpha value from `0.0` to `1.0`
+    convenience init(hex: Int, alpha: Double = 1.0) {
         let red = (hex >> 16) & 0xFF
         let green = (hex >> 8) & 0xFF
         let blue = hex & 0xFF
-        self.init(srgbRed: Double(red) / 255, green: Double(green) / 255, blue: Double(blue) / 255, alpha: 1)
+        self.init(srgbRed: Double(red) / 255, green: Double(green) / 255, blue: Double(blue) / 255, alpha: alpha)
     }
 
     /// Returns an Int representing the `NSColor` in hex format (e.g.: 0x112233)


### PR DESCRIPTION
# Description

added opacity to hex `Color` and `NSColor` inits.

## Usage in code:

```swift
let color1 = NSColor(hex: "#123456", alpha: 0.1)
let color2 = NSColor(hex: 0x123456, alpha: 0.1)

let color3 = Color(hex: "#123456", alpha: 0.1)
let color4 = Color(hex: 0x123456, alpha: 0.1)
```

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested