### PR TITLE
`AboutView`: Code Clean-Up

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>c453151a5f6abe7c04aca41583ae7f8e8c444d0d</string>
+	<string>7dbca499d2ae5e4a6d674c6cb498a862e930f4c3</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>6ab4826637e37aabf1a14ba3596bf34dbb791047</string>
+	<string>c453151a5f6abe7c04aca41583ae7f8e8c444d0d</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/About/src/AboutView.swift
+++ b/CodeEditModules/Modules/About/src/AboutView.swift
@@ -23,70 +23,85 @@ public struct AboutView: View {
     private var commitHash: String {
         Bundle
             .main
-            .object(forInfoDictionaryKey: "GitHash") as? String ?? ""
+            .object(forInfoDictionaryKey: "GitHash") as? String ?? "No Hash"
+    }
+
+    private var shortCommitHash: String {
+        if commitHash.count > 7 {
+            return String(commitHash[...commitHash.index(commitHash.startIndex, offsetBy: 7)])
+        }
+        return commitHash
     }
 
     public var body: some View {
         HStack(spacing: 0) {
-            Spacer().frame(width: 32)
-            Image(nsImage: NSApp.applicationIconImage)
-                .resizable()
-                .frame(width: 128, height: 128)
-            Spacer().frame(width: 32)
+            logo
             VStack(alignment: .leading, spacing: 0) {
-                HStack(spacing: 0) {
-                    Spacer().frame(width: 6)
-                    VStack(alignment: .leading, spacing: 0) {
-                        Text("CodeEdit").font(.system(size: 38, weight: .regular))
-                        Text("Version \(appVersion) (\(appBuild))")
-                            .textSelection(.enabled)
-                            .foregroundColor(.secondary)
-                            .font(.system(size: 13, weight: .light))
-                        Spacer().frame(height: 5)
-                        HStack(spacing: 2.0) {
-                            Text("Commit:")
-                            Text(self.hoveringOnCommitHash ?
-                                    commitHash :
-                                    String(commitHash[...commitHash.index(commitHash.startIndex, offsetBy: 7)]))
-                                .textSelection(.enabled)
-                                .onHover { _ in
-                                    self.hoveringOnCommitHash.toggle()
-                                }
-                                .animation(.easeInOut, value: self.hoveringOnCommitHash)
-                        }.foregroundColor(.secondary)
-                            .font(.system(size: 10, weight: .light))
-                        Spacer().frame(height: 36)
-                        Text("Copyright © 2022 CodeEdit")
-                            .foregroundColor(.secondary)
-                            .font(.system(size: 9, weight: .light))
-                            .lineSpacing(0.2)
-                        Spacer().frame(height: 5)
-                        Text("MIT License")
-                            .foregroundColor(.secondary)
-                            .font(.system(size: 9, weight: .light))
-                            .lineSpacing(0.2)
-                    }
-                    Spacer().frame(width: 32)
-                }
+                topMetaData
                 Spacer()
-                HStack(spacing: 0) {
-                    Spacer().frame(width: 6)
-                    Button(action: {
-                        AcknowledgementsView().showWindow(width: 300, height: 400)
-                    }, label: {
-                        Text("Acknowledgments")
-                            .frame(width: 136, height: 20)
-                    })
-                    Spacer().frame(width: 12)
-                    Button(action: {
-                        openURL(URL(string: "https://github.com/CodeEditApp/CodeEdit/blob/main/LICENSE.md")!)
-                    }, label: {
-                        Text("License Agreement")
-                            .frame(width: 136, height: 20)
-                    })
-                    Spacer().frame(width: 16)
-                }.frame(maxWidth: .infinity)
-                Spacer().frame(height: 20)
+                bottomMetaData
+                actionButtons
+            }
+            .padding([.trailing, .bottom])
+        }
+    }
+
+    // MARK: Sub-Views
+
+    private var logo: some View {
+        Image(nsImage: NSApp.applicationIconImage)
+            .resizable()
+            .frame(width: 128, height: 128)
+            .padding(32)
+    }
+
+    private var topMetaData: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("CodeEdit").font(.system(size: 38, weight: .regular))
+            Text("Version \(appVersion) (\(appBuild))")
+                .textSelection(.enabled)
+                .foregroundColor(.secondary)
+                .font(.system(size: 13, weight: .light))
+            HStack(spacing: 2.0) {
+                Text("Commit:")
+                Text(self.hoveringOnCommitHash ?
+                     commitHash : shortCommitHash)
+                .textSelection(.enabled)
+                .onHover { hovering in
+                    self.hoveringOnCommitHash = hovering
+                }
+                .animation(.easeInOut, value: self.hoveringOnCommitHash)
+            }
+            .foregroundColor(.secondary)
+            .font(.system(size: 10, weight: .light))
+        }
+    }
+
+    private var bottomMetaData: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("Copyright © 2022 CodeEdit")
+            Text("MIT License")
+        }
+        .foregroundColor(.secondary)
+        .font(.system(size: 9, weight: .light))
+        .padding(.bottom, 10)
+    }
+
+    private var actionButtons: some View {
+        HStack {
+            Button {
+                AcknowledgementsView().showWindow(width: 300, height: 400)
+            } label: {
+                Text("Acknowledgments")
+                    .frame(maxWidth: .infinity)
+            }
+            Button {
+                guard let url = URL(string: "https://github.com/CodeEditApp/CodeEdit/blob/main/LICENSE.md")
+                else { return }
+                openURL(url)
+            } label: {
+                Text("License Agreement")
+                    .frame(maxWidth: .infinity)
             }
         }
     }
@@ -143,5 +158,12 @@ final class PlaceholderWindowController: NSWindowController {
         }
         window?.animator().alphaValue = 0.0
         NSAnimationContext.endGrouping()
+    }
+}
+
+struct About_Previews: PreviewProvider {
+    static var previews: some View {
+        AboutView()
+            .frame(width: 530, height: 220)
     }
 }

--- a/CodeEditModules/Modules/About/src/AboutView.swift
+++ b/CodeEditModules/Modules/About/src/AboutView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import CodeEditUtils
 import Acknowledgements
 
 public struct AboutView: View {
@@ -9,21 +10,15 @@ public struct AboutView: View {
     public init() {}
 
     private var appVersion: String {
-        Bundle
-            .main
-            .object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+        Bundle.versionString ?? "No Version"
     }
 
     private var appBuild: String {
-        Bundle
-            .main
-            .object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
+        Bundle.buildString ?? "No Build"
     }
 
     private var commitHash: String {
-        Bundle
-            .main
-            .object(forInfoDictionaryKey: "GitHash") as? String ?? "No Hash"
+        Bundle.commitHash ?? "No Hash"
     }
 
     private var shortCommitHash: String {

--- a/CodeEditModules/Modules/CodeEditUtils/src/Extensions/Bundle+Info.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/src/Extensions/Bundle+Info.swift
@@ -1,0 +1,26 @@
+//
+//  Bundle+Info.swift
+//  CodeEdit
+//
+//  Created by Lukas Pistrol on 01.05.22.
+//
+
+import Foundation
+
+public extension Bundle {
+
+    /// Returns the main bundle's version string if available (e.g. 1.0.0)
+    static var versionString: String? {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+
+    /// Returns the main bundle's build string if available (e.g. 123)
+    static var buildString: String? {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+    }
+
+    /// Returns the main bundle's commitHash string if available (e.g. 7dbca499d2ae5e4a6d674c6cb498a862e930f4c3)
+    static var commitHash: String? {
+        Bundle.main.object(forInfoDictionaryKey: "GitHash") as? String
+    }
+}

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -249,7 +249,8 @@ let package = Package(
         .target(
             name: "About",
             dependencies: [
-                "Acknowledgements"
+                "Acknowledgements",
+                "CodeEditUtils"
             ],
             path: "Modules/About/src"
         ),


### PR DESCRIPTION
# Description

Cleaning up some code:

- Get rid of excessive use of `Spacer()`
- Split up `var body` into sub-views
- Handling `out-of-bounds` error when no commit hash is provided (e.g. in Previews)

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="642" alt="Screen Shot 2022-05-01 at 19 42 16" src="https://user-images.githubusercontent.com/9460130/166157935-1de14831-d72c-444a-abfa-077d0ed4b052.png">

