### PR TITLE
Fix Background Color Issue in Empty State

### DIFF
--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -10,10 +10,16 @@ import CodeFile
 import WorkspaceClient
 import StatusBar
 import Breadcrumbs
+import AppPreferences
 
 struct WorkspaceCodeFileView: View {
     var windowController: NSWindowController
-    @ObservedObject var workspace: WorkspaceDocument
+
+    @ObservedObject
+    var workspace: WorkspaceDocument
+
+    @StateObject
+    private var prefs: AppPreferencesModel = .shared
 
     @ViewBuilder
     var codeView: some View {
@@ -46,6 +52,13 @@ struct WorkspaceCodeFileView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background {
+            if prefs.preferences.general.tabBarStyle == .xcode {
+                // Use the same background material as xcode tab bar style.
+                // Only when the tab bar style is set to `xcode`.
+                TabBarXcodeBackground()
+            }
+        }
         .safeAreaInset(edge: .top, spacing: 0) {
             VStack(spacing: 0) {
                 TabBar(windowController: windowController, workspace: workspace)


### PR DESCRIPTION
# Description

Fix the background material issue while there is no file opened (and the selected tab bar style is `xcode`).

For now, I keep background the same under `native` tab bar style.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #576

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="1102" alt="CleanShot 2022-05-01 at 14 22 43@2x" src="https://user-images.githubusercontent.com/36816148/166159706-8984de37-7e04-4d8a-9ddd-4093ad6d5c90.png">

<img width="1107" alt="CleanShot 2022-05-01 at 14 22 28@2x" src="https://user-images.githubusercontent.com/36816148/166159715-ba95d179-645f-4373-8fe3-47e99dc7065e.png">

