### PR TITLE
Non editor tabs

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		043BCF03281DA18A000AC47C /* WorkspaceDocument+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043BCF02281DA18A000AC47C /* WorkspaceDocument+Search.swift */; };
+		043BCF05281DA19A000AC47C /* WorkspaceDocument+Selection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043BCF04281DA19A000AC47C /* WorkspaceDocument+Selection.swift */; };
+		043BCF07281DA2F5000AC47C /* TabBar in Frameworks */ = {isa = PBXBuildFile; productRef = 043BCF06281DA2F5000AC47C /* TabBar */; };
 		043C321427E31FF6006AE443 /* CodeEditDocumentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043C321327E31FF6006AE443 /* CodeEditDocumentController.swift */; };
 		043C321627E3201F006AE443 /* WorkspaceDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043C321527E3201F006AE443 /* WorkspaceDocument.swift */; };
 		043C321A27E32295006AE443 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 043C321927E32295006AE443 /* MainMenu.xib */; };
@@ -120,6 +123,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		043BCF02281DA18A000AC47C /* WorkspaceDocument+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkspaceDocument+Search.swift"; sourceTree = "<group>"; };
+		043BCF04281DA19A000AC47C /* WorkspaceDocument+Selection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkspaceDocument+Selection.swift"; sourceTree = "<group>"; };
 		043C321327E31FF6006AE443 /* CodeEditDocumentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditDocumentController.swift; sourceTree = "<group>"; };
 		043C321527E3201F006AE443 /* WorkspaceDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDocument.swift; sourceTree = "<group>"; };
 		043C321927E32295006AE443 /* MainMenu.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainMenu.xib; sourceTree = "<group>"; };
@@ -182,7 +187,7 @@
 		D7E201B327E9989900CB86D0 /* FindNavigatorResultList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorResultList.swift; sourceTree = "<group>"; };
 		D7E201BC27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorResultFileItem.swift; sourceTree = "<group>"; };
 		DE6F77862813625500D00A76 /* TabBarDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarDivider.swift; sourceTree = "<group>"; };
-		FD6A3D3C2817C13B008BCF11 /* Package.resolved */ = {isa = PBXFileReference; lastKnownFileType = file; path = Package.resolved; sourceTree = SOURCE_ROOT; };
+		FD6A3D3C2817C13B008BCF11 /* Package.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Package.resolved; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -192,6 +197,7 @@
 			files = (
 				0483E34D27FCC46600354AC0 /* ExtensionsStore in Frameworks */,
 				64B64EDE27F7B79400C400F1 /* About in Frameworks */,
+				043BCF07281DA2F5000AC47C /* TabBar in Frameworks */,
 				04C3256B28034FC800C8DA2D /* CodeEditKit in Frameworks */,
 				2864BAAC28117B3F002DBD1A /* ShellClient in Frameworks */,
 				20C4319A28058B9E00964DD5 /* GitAccounts in Frameworks */,
@@ -238,6 +244,8 @@
 				04660F6927E51E5C00477777 /* CodeEditWindowController.swift */,
 				0485EB1E27E7458B00138301 /* WorkspaceCodeFileView.swift */,
 				D7E201AD27E8B3C000CB86D0 /* String+Ranges.swift */,
+				043BCF02281DA18A000AC47C /* WorkspaceDocument+Search.swift */,
+				043BCF04281DA19A000AC47C /* WorkspaceDocument+Selection.swift */,
 			);
 			path = Documents;
 			sourceTree = "<group>";
@@ -496,6 +504,7 @@
 				2816F593280CF50500DD548B /* CodeEditSymbols */,
 				2864BAAB28117B3F002DBD1A /* ShellClient */,
 				2864BAAD28117D7C002DBD1A /* TerminalEmulator */,
+				043BCF06281DA2F5000AC47C /* TabBar */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -752,6 +761,7 @@
 				D7E201BD27EA00E200CB86D0 /* FindNavigatorResultFileItem.swift in Sources */,
 				287776EF27E3515300D46668 /* TabBarItem.swift in Sources */,
 				04660F6A27E51E5C00477777 /* CodeEditWindowController.swift in Sources */,
+				043BCF05281DA19A000AC47C /* WorkspaceDocument+Selection.swift in Sources */,
 				2072FA18280D871200C7F8D4 /* TextEncoding.swift in Sources */,
 				2072FA16280D83A500C7F8D4 /* FileTypeList.swift in Sources */,
 				04C3254F2800AA4700C8DA2D /* ExtensionInstallationView.swift in Sources */,
@@ -759,6 +769,7 @@
 				20D839AB280DEB2900B27357 /* NoSelectionView.swift in Sources */,
 				20EBB505280C329800F3A5DA /* HistoryItem.swift in Sources */,
 				043C321627E3201F006AE443 /* WorkspaceDocument.swift in Sources */,
+				043BCF03281DA18A000AC47C /* WorkspaceDocument+Search.swift in Sources */,
 				04C325512800AC7400C8DA2D /* ExtensionInstallationViewModel.swift in Sources */,
 				28B0A19827E385C300B73177 /* NavigatorSidebarToolbarTop.swift in Sources */,
 				0463E51127FCC1DF00806D5C /* CodeEditAPI.swift in Sources */,
@@ -1148,6 +1159,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		043BCF06281DA2F5000AC47C /* TabBar */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TabBar;
+		};
 		0483E34C27FCC46600354AC0 /* ExtensionsStore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ExtensionsStore;

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -181,7 +181,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
     private func getSelectedCodeFile() -> CodeFileDocument? {
         guard let id = workspace?.selectionState.selectedId else { return nil }
         guard let item = workspace?.selectionState.openFileItems.first(where: { item in
-            return item.id == id
+            return item.tabID == id
         }) else { return nil }
         guard let file = workspace?.selectionState.openedCodeFiles[item] else { return nil }
         return file
@@ -207,7 +207,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
                 let contentView = QuickOpenView(
                     state: state,
                     onClose: { panel.close() },
-                    openFile: workspace.openFile(item:)
+                    openFile: workspace.openTab(item:)
                 )
                 panel.contentView = NSHostingView(rootView: contentView)
                 window?.addChildWindow(panel, ordered: .above)

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -48,19 +48,6 @@ struct WorkspaceCodeFileView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background {
-            if prefs.preferences.general.tabBarStyle == .xcode {
-                // Use the same background material as xcode tab bar style.
-                // Only when the tab bar style is set to `xcode`.
-                TabBarXcodeBackground()
-            }
-        }
-        .safeAreaInset(edge: .top, spacing: 0) {
-            VStack(spacing: 0) {
-                TabBar(windowController: windowController, workspace: workspace)
-                TabBarBottomDivider()
-            }
-        }
     }
 
     var body: some View {

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -31,11 +31,7 @@ struct WorkspaceCodeFileView: View {
                                 BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
                                 Divider()
                             }
-                    } else {
-                        Text("CodeEdit cannot open this file because its file type is not supported.")
-                            .frame(minHeight: 0)
-                            .clipped()
-                    }
+                        }
                 } else {
                     Text("No Editor")
                         .font(.system(size: 17))
@@ -46,12 +42,6 @@ struct WorkspaceCodeFileView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .safeAreaInset(edge: .top, spacing: 0) {
-            VStack(spacing: 0) {
-                TabBar(windowController: windowController, workspace: workspace)
-                TabBarBottomDivider()
-            }
-        }
     }
 
     var body: some View {

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -18,18 +18,16 @@ struct WorkspaceCodeFileView: View {
     @ViewBuilder
     var codeView: some View {
         if let item = workspace.selectionState.openFileItems.first(where: { file in
-            if file.id == workspace.selectionState.selectedId {
+            if file.tabID == workspace.selectionState.selectedId {
                 print("Item loaded is: ", file.url)
             }
-            return file.id == workspace.selectionState.selectedId
+            return file.tabID == workspace.selectionState.selectedId
         }) {
             if let codeFile = workspace.selectionState.openedCodeFiles[item] {
                 CodeFileView(codeFile: codeFile)
                     .safeAreaInset(edge: .top, spacing: 0) {
                         VStack(spacing: 0) {
-                            TabBar(windowController: windowController, workspace: workspace)
-                            TabBarBottomDivider()
-                            BreadcrumbsView(file: item, tappedOpenFile: workspace.openFile(item:))
+                            BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
                             Divider()
                         }
                     }

--- a/CodeEdit/Documents/WorkspaceDocument+Search.swift
+++ b/CodeEdit/Documents/WorkspaceDocument+Search.swift
@@ -1,0 +1,70 @@
+//
+//  WorkspaceDocument+Search.swift
+//  CodeEdit
+//
+//  Created by Pavel Kasila on 30.04.22.
+//
+
+import Foundation
+import Search
+import WorkspaceClient
+
+extension WorkspaceDocument {
+    final class SearchState: ObservableObject {
+        var workspace: WorkspaceDocument
+        @Published var searchResult: [SearchResultModel] = []
+
+        init(_ workspace: WorkspaceDocument) {
+            self.workspace = workspace
+        }
+
+        func search(_ text: String) {
+            self.searchResult = []
+            if let url = self.workspace.fileURL {
+                let enumerator = FileManager.default.enumerator(at: url,
+                                                                includingPropertiesForKeys: [
+                                                                    .isRegularFileKey
+                                                                ],
+                                                                options: [
+                                                                    .skipsHiddenFiles,
+                                                                    .skipsPackageDescendants
+                                                                ])
+                if let filePaths = enumerator?.allObjects as? [URL] {
+                    filePaths.map { url in
+                        WorkspaceClient.FileItem(url: url, children: nil)
+                    }.forEach { fileItem in
+                        var fileAddedFlag = true
+                        do {
+                            let data = try Data(contentsOf: fileItem.url)
+                            data.withUnsafeBytes {
+                                $0.split(separator: UInt8(ascii: "\n"))
+                                    .map { String(decoding: UnsafeRawBufferPointer(rebasing: $0), as: UTF8.self) }
+                            }.enumerated().forEach { (index: Int, line: String) in
+                                let noSpaceLine = line.trimmingCharacters(in: .whitespaces)
+                                if noSpaceLine.contains(text) {
+                                    if fileAddedFlag {
+                                        searchResult.append(SearchResultModel(
+                                            file: fileItem,
+                                            lineNumber: nil,
+                                            lineContent: nil,
+                                            keywordRange: nil)
+                                        )
+                                        fileAddedFlag = false
+                                    }
+                                    noSpaceLine.ranges(of: text).forEach { range in
+                                        searchResult.append(SearchResultModel(
+                                            file: fileItem,
+                                            lineNumber: index,
+                                            lineContent: noSpaceLine,
+                                            keywordRange: range)
+                                        )
+                                    }
+                                }
+                            }
+                        } catch {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/CodeEdit/Documents/WorkspaceDocument+Selection.swift
+++ b/CodeEdit/Documents/WorkspaceDocument+Selection.swift
@@ -47,6 +47,9 @@ struct WorkspaceSelectionState: Codable {
         try container.encode(openedExtensions, forKey: .openedExtensions)
     }
 
+    /// Returns TabBarItemRepresentable by its identifier
+    /// - Parameter id: tab bar item's identifier
+    /// - Returns: item with passed identifier
     func getItemByTab(id: TabBarItemID) -> TabBarItemRepresentable? {
         switch id {
         case .codeEditor:

--- a/CodeEdit/Documents/WorkspaceDocument+Selection.swift
+++ b/CodeEdit/Documents/WorkspaceDocument+Selection.swift
@@ -1,0 +1,56 @@
+//
+//  WorkspaceDocument+Selection.swift
+//  CodeEdit
+//
+//  Created by Pavel Kasila on 30.04.22.
+//
+
+import Foundation
+import WorkspaceClient
+import CodeFile
+import TabBar
+
+struct WorkspaceSelectionState: Codable {
+
+    var selectedId: TabBarItemID?
+    var openedTabs: [TabBarItemID] = []
+
+    var selected: TabBarItemRepresentable? {
+        guard let selectedId = selectedId else { return nil }
+        switch selectedId {
+        case .codeEditor(let id):
+            return openFileItems.first(where: { $0.id == id })
+        }
+    }
+
+    var openFileItems: [WorkspaceClient.FileItem] = []
+    var openedCodeFiles: [WorkspaceClient.FileItem: CodeFileDocument] = [:]
+
+    enum CodingKeys: String, CodingKey {
+        case selectedId, openedTabs
+    }
+
+    init() {
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        selectedId = try container.decode(TabBarItemID?.self, forKey: .selectedId)
+        openedTabs = try container.decode([TabBarItemID].self, forKey: .openedTabs)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(selectedId, forKey: .selectedId)
+        try container.encode(openedTabs, forKey: .openedTabs)
+    }
+
+    func getItemByTab(id: TabBarItemID) -> TabBarItemRepresentable? {
+        switch id {
+        case .codeEditor:
+            return self.openFileItems.first { item in
+                item.tabID == id
+            }
+        }
+    }
+}

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -16,6 +16,7 @@ import QuickOpen
 import CodeEditKit
 import ExtensionsStore
 import StatusBar
+import TabBar
 
 @objc(WorkspaceDocument)
 final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
@@ -25,6 +26,7 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
 
     @Published var sortFoldersOnTop: Bool = true
     @Published var selectionState: WorkspaceSelectionState = .init()
+    @Published var fileItems: [WorkspaceClient.FileItem] = []
 
     var statusBarModel: StatusBarModel?
     var searchState: SearchState?
@@ -37,7 +39,84 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         cancellables.forEach { $0.cancel() }
     }
 
-    func closeFileTab(item: WorkspaceClient.FileItem) {
+    func openTab(item: TabBarItemRepresentable) {
+        do {
+            switch item.tabID {
+            case .codeEditor:
+                guard let file = item as? WorkspaceClient.FileItem else { return }
+                try self.openFile(item: file)
+            }
+
+            if !selectionState.openedTabs.contains(item.tabID) {
+                selectionState.openedTabs.append(item.tabID)
+            }
+
+            if selectionState.selectedId != item.tabID {
+                selectionState.selectedId = item.tabID
+            }
+        } catch let err {
+            Swift.print(err)
+        }
+    }
+
+    private func openFile(item: WorkspaceClient.FileItem) throws {
+        let codeFile = try CodeFileDocument(
+            for: item.url,
+            withContentsOf: item.url,
+            ofType: "public.source-code"
+        )
+
+        if !selectionState.openFileItems.contains(item) {
+            selectionState.openFileItems.append(item)
+
+            selectionState.openedCodeFiles[item] = codeFile
+        }
+        Swift.print("Opening file for item: ", item.url)
+        self.windowControllers.first?.window?.subtitle = item.url.lastPathComponent
+    }
+
+    func closeTab(item id: TabBarItemID) {
+        guard let idx = selectionState.openedTabs.firstIndex(of: id) else { return }
+        let closedID = selectionState.openedTabs.remove(at: idx)
+        guard closedID == id else { return }
+
+        switch id {
+        case .codeEditor:
+            guard let item = selectionState.getItemByTab(id: id) as? WorkspaceClient.FileItem else { return }
+            closeFileTab(item: item)
+        }
+
+        if selectionState.openedTabs.isEmpty {
+            selectionState.selectedId = nil
+        } else if idx == 0 {
+            selectionState.selectedId = selectionState.openedTabs.first
+        } else {
+            selectionState.selectedId = selectionState.openedTabs[idx - 1]
+        }
+    }
+
+    func closeTabs<Items>(items: Items) where Items: Collection, Items.Element == TabBarItemID {
+        // TODO: Could potentially be optimized
+        for item in items {
+            closeTab(item: item)
+        }
+    }
+
+    func closeTab(where predicate: (TabBarItemID) -> Bool) {
+        closeTabs(items: selectionState.openedTabs.filter(predicate))
+    }
+
+    func closeTabs(after id: TabBarItemID) {
+        guard let startIdx = selectionState.openFileItems.firstIndex(where: { $0.tabID == id }) else {
+            assert(false, "Expected file item to be present in openFileItems")
+            return
+        }
+
+        let range = selectionState.openedTabs[(startIdx+1)...]
+        closeTabs(items: range)
+    }
+
+    private func closeFileTab(item: WorkspaceClient.FileItem) {
         defer {
             let file = selectionState.openedCodeFiles.removeValue(forKey: item)
             file?.save(self)
@@ -46,57 +125,6 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         guard let idx = selectionState.openFileItems.firstIndex(of: item) else { return }
         let closedFileItem = selectionState.openFileItems.remove(at: idx)
         guard closedFileItem.id == item.id else { return }
-
-        if selectionState.openFileItems.isEmpty {
-            selectionState.selectedId = nil
-        } else if idx == 0 {
-            selectionState.selectedId = selectionState.openFileItems.first?.id
-        } else {
-            selectionState.selectedId = selectionState.openFileItems[idx - 1].id
-        }
-    }
-    func closeFileTabs<Items>(items: Items) where Items: Collection, Items.Element == WorkspaceClient.FileItem {
-        // TODO: Could potentially be optimized
-        for item in items {
-            closeFileTab(item: item)
-        }
-    }
-
-    func closeFileTab(where predicate: (WorkspaceClient.FileItem) -> Bool) {
-        closeFileTabs(items: selectionState.openFileItems.filter(predicate))
-    }
-
-    func closeFileTabs(after item: WorkspaceClient.FileItem) {
-        guard let startIdx = selectionState.openFileItems.firstIndex(where: { $0.id == item.id }) else {
-            assert(false, "Expected file item to be present in openFileItems")
-            return
-        }
-
-        let range = selectionState.openFileItems[(startIdx+1)...]
-        closeFileTabs(items: range)
-    }
-
-    func openFile(item: WorkspaceClient.FileItem) {
-        do {
-            let codeFile = try CodeFileDocument(
-                for: item.url,
-                withContentsOf: item.url,
-                ofType: "public.source-code"
-            )
-
-            if !selectionState.openFileItems.contains(item) {
-                selectionState.openFileItems.append(item)
-
-                selectionState.openedCodeFiles[item] = codeFile
-            }
-            if selectionState.selectedId != item.id {
-                selectionState.selectedId = item.id
-            }
-            Swift.print("Opening file for item: ", item.url)
-            self.windowControllers.first?.window?.subtitle = item.url.lastPathComponent
-        } catch let err {
-            Swift.print(err)
-        }
     }
 
     private let ignoredFilesAndDirectory = [
@@ -149,11 +177,15 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
                 if FileManager.default.fileExists(atPath: selectionStateFile.path) {
                     let state = try JSONDecoder().decode(WorkspaceSelectionState.self,
                                                          from: Data(contentsOf: selectionStateFile))
-                    self.selectionState.fileItems = state.fileItems
-                    state.openFileItems
-                        .compactMap { try? workspaceClient?.getFileItem($0.id) }
+                    state.openedTabs
+                        .compactMap { tab in
+                            switch tab {
+                            case .codeEditor(let path):
+                                return try? workspaceClient?.getFileItem(path)
+                            }
+                        }
                         .forEach { item in
-                        self.openFile(item: item)
+                        self.openTab(item: item)
                     }
                     self.selectionState.selectedId = state.selectedId
                 }
@@ -167,8 +199,8 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
             .sink { [weak self] files in
                 guard let self = self else { return }
 
-                guard !self.selectionState.fileItems.isEmpty else {
-                    self.selectionState.fileItems = files
+                guard !self.fileItems.isEmpty else {
+                    self.fileItems = files
                     return
                 }
 
@@ -177,12 +209,12 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
                 // and now. If the index of the file exists in the array
                 // it means we need to remove the element, otherwise we need to append
                 // it.
-                let diff = files.difference(from: self.selectionState.fileItems)
+                let diff = files.difference(from: self.fileItems)
                 diff.forEach { newFile in
-                    if let index = self.selectionState.fileItems.firstIndex(of: newFile) {
-                        self.selectionState.fileItems.remove(at: index)
+                    if let index = self.fileItems.firstIndex(of: newFile) {
+                        self.fileItems.remove(at: index)
                     } else {
-                        self.selectionState.fileItems.append(newFile)
+                        self.fileItems.append(newFile)
                     }
                 }
             }
@@ -237,102 +269,6 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         }
 
         super.close()
-    }
-}
-
-// MARK: - Search
-
-extension WorkspaceDocument {
-    final class SearchState: ObservableObject {
-        var workspace: WorkspaceDocument
-        @Published var searchResult: [SearchResultModel] = []
-
-        init(_ workspace: WorkspaceDocument) {
-            self.workspace = workspace
-        }
-
-        func search(_ text: String) {
-            self.searchResult = []
-            if let url = self.workspace.fileURL {
-                let enumerator = FileManager.default.enumerator(at: url,
-                                                                includingPropertiesForKeys: [
-                                                                    .isRegularFileKey
-                                                                ],
-                                                                options: [
-                                                                    .skipsHiddenFiles,
-                                                                    .skipsPackageDescendants
-                                                                ])
-                if let filePaths = enumerator?.allObjects as? [URL] {
-                    filePaths.map { url in
-                        WorkspaceClient.FileItem(url: url, children: nil)
-                    }.forEach { fileItem in
-                        var fileAddedFlag = true
-                        do {
-                            let data = try Data(contentsOf: fileItem.url)
-                            data.withUnsafeBytes {
-                                $0.split(separator: UInt8(ascii: "\n"))
-                                    .map { String(decoding: UnsafeRawBufferPointer(rebasing: $0), as: UTF8.self) }
-                            }.enumerated().forEach { (index: Int, line: String) in
-                                let noSpaceLine = line.trimmingCharacters(in: .whitespaces)
-                                if noSpaceLine.contains(text) {
-                                    if fileAddedFlag {
-                                        searchResult.append(SearchResultModel(
-                                            file: fileItem,
-                                            lineNumber: nil,
-                                            lineContent: nil,
-                                            keywordRange: nil)
-                                        )
-                                        fileAddedFlag = false
-                                    }
-                                    noSpaceLine.ranges(of: text).forEach { range in
-                                        searchResult.append(SearchResultModel(
-                                            file: fileItem,
-                                            lineNumber: index,
-                                            lineContent: noSpaceLine,
-                                            keywordRange: range)
-                                        )
-                                    }
-                                }
-                            }
-                        } catch {}
-                    }
-                }
-            }
-        }
-    }
-}
-
-// MARK: - Selection
-
-struct WorkspaceSelectionState: Codable {
-
-    var selectedId: String?
-    var openFileItems: [WorkspaceClient.FileItem] = []
-    var fileItems: [WorkspaceClient.FileItem] = []
-
-    var selected: WorkspaceClient.FileItem? {
-        guard let selectedId = selectedId else { return nil }
-        return fileItems.first(where: { $0.id == selectedId })
-    }
-    var openedCodeFiles: [WorkspaceClient.FileItem: CodeFileDocument] = [:]
-
-    enum CodingKeys: String, CodingKey {
-        case selectedId, openFileItems
-    }
-
-    init() {
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        selectedId = try container.decode(String?.self, forKey: .selectedId)
-        openFileItems = try container.decode([WorkspaceClient.FileItem].self, forKey: .openFileItems)
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(selectedId, forKey: .selectedId)
-        try container.encode(openFileItems, forKey: .openFileItems)
     }
 }
 

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -99,12 +99,12 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
 
         if selectionState.openedTabs.isEmpty {
             selectionState.selectedId = nil
-        } else if selectionState.selectedId == closedFileItem.tabID {
+        } else if selectionState.selectedId == closedID {
             // If the closed item is the selected one, then select another tab.
             if idx == 0 {
-                selectionState.selectedId = selectionState.openedTabs.first?.tabID
+                selectionState.selectedId = selectionState.openedTabs.first
             } else {
-                selectionState.selectedId = selectionState.openedTabs[idx - 1].id
+                selectionState.selectedId = selectionState.openedTabs[idx - 1]
             }
         } else {
             // If the closed item is not the selected one, then do nothing.

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -39,6 +39,8 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         cancellables.forEach { $0.cancel() }
     }
 
+    /// Opens new tab
+    /// - Parameter item: any item which can be represented as a tab
     func openTab(item: TabBarItemRepresentable) {
         do {
             switch item.tabID {
@@ -83,6 +85,8 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         }
     }
 
+    /// Closes single tab
+    /// - Parameter id: tab bar item's identifier to be closed
     func closeTab(item id: TabBarItemID) {
         guard let idx = selectionState.openedTabs.firstIndex(of: id) else { return }
         let closedID = selectionState.openedTabs.remove(at: idx)
@@ -111,6 +115,8 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         }
     }
 
+    /// Closes collection of tab bar items
+    /// - Parameter items: items to be closed
     func closeTabs<Items>(items: Items) where Items: Collection, Items.Element == TabBarItemID {
         // TODO: Could potentially be optimized
         for item in items {
@@ -118,10 +124,14 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         }
     }
 
+    /// Closes tabs according to predicator
+    /// - Parameter predicate: predicator which returns whether tab should be closed based on its identifier
     func closeTab(where predicate: (TabBarItemID) -> Bool) {
         closeTabs(items: selectionState.openedTabs.filter(predicate))
     }
 
+    /// Closes tabs after specified identifier
+    /// - Parameter id: identifier after which tabs will be closed
     func closeTabs(after id: TabBarItemID) {
         guard let startIdx = selectionState.openFileItems.firstIndex(where: { $0.tabID == id }) else {
             assert(false, "Expected file item to be present in openFileItems")

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>3194aae569c52a4cf16d66d302671c79ccc9fd09</string>
+	<string>ca269586637e270cd99b113ddaf7de12d9261953</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>99d806bb0a7aae61463e1d48668ba0782f10dc64</string>
+	<string>0897d2e1ccf134bdfc0e5059b6ec42043fb50737</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>2e478b8a0b1b0457eb40d470f8494f12e4c59f8a</string>
+	<string>9c10a36435e60ef79f5225b462ddf66d4c1f209e</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>ca269586637e270cd99b113ddaf7de12d9261953</string>
+	<string>015432d65bf8743e0ebfc6760f32af01f45e6c1f</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>c37b4b0e31e8b9cbb314820f9e814883052df390</string>
+	<string>2e478b8a0b1b0457eb40d470f8494f12e4c59f8a</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>0897d2e1ccf134bdfc0e5059b6ec42043fb50737</string>
+	<string>c37b4b0e31e8b9cbb314820f9e814883052df390</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>015432d65bf8743e0ebfc6760f32af01f45e6c1f</string>
+	<string>99d806bb0a7aae61463e1d48668ba0782f10dc64</string>
 </dict>
 </plist>

--- a/CodeEdit/InspectorSidebar/InspectorSidebar.swift
+++ b/CodeEdit/InspectorSidebar/InspectorSidebar.swift
@@ -27,7 +27,7 @@ struct InspectorSidebar: View {
     var body: some View {
         VStack {
             if let item = workspace.selectionState.openFileItems.first(where: { file in
-                return file.id == workspace.selectionState.selectedId
+                return file.tabID == workspace.selectionState.selectedId
             }) {
                 if let codeFile = workspace.selectionState.openedCodeFiles[item] {
                     switch selection {

--- a/CodeEdit/NavigatorSidebar/ExtensionNavigator/ExtensionInstallationView.swift
+++ b/CodeEdit/NavigatorSidebar/ExtensionNavigator/ExtensionInstallationView.swift
@@ -9,51 +9,88 @@ import SwiftUI
 import ExtensionsStore
 
 struct ExtensionInstallationView: View {
-    var dismiss: () -> Void
+    init(plugin: Plugin) {
+        self.model = .init(plugin: plugin)
+        self.installed = ExtensionsManager.shared?.isInstalled(plugin: plugin) ?? false
+    }
+
     @ObservedObject var model: ExtensionInstallationViewModel
+    @EnvironmentObject var document: WorkspaceDocument
+    @State var reopenAlert = false
+    @State var installed: Bool = false
 
     var body: some View {
         VStack {
             Text(self.model.plugin.manifest.displayName)
                 .font(.headline)
-            Picker("Release", selection: $model.release) {
-                ForEach(model.releases) { release in
-                    Text(release.version)
-                        .tag(release as PluginRelease?)
-                }
-
-                if !model.listFull {
-                    ProgressView()
-                        .progressViewStyle(CircularProgressViewStyle())
-                        .onAppear {
-                            model.fetch()
+            HStack {
+                if !self.installed {
+                    Picker("Release", selection: $model.release) {
+                        ForEach(model.releases) { release in
+                            Text(release.version)
+                                .tag(release as PluginRelease?)
                         }
-                }
-            }
-        }
-        .toolbar {
-            HStack(spacing: 16.0) {
-                Button {
-                    dismiss()
-                } label: {
-                    Text("Cancel")
-                }
-                Button {
-                    Task {
-                        do {
-                            if let release = self.model.release {
-                                try await ExtensionsManager.shared?.install(plugin: self.model.plugin, release: release)
-                                dismiss()
+
+                        if !model.listFull {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle())
+                                .onAppear {
+                                    model.fetch()
+                                }
+                        }
+                    }
+                    Button {
+                        Task {
+                            do {
+                                if let release = self.model.release {
+                                    try await ExtensionsManager.shared?.install(
+                                        plugin: self.model.plugin, release: release)
+                                    self.installed = ExtensionsManager.shared?.isInstalled(
+                                        plugin: model.plugin) ?? false
+                                    if self.installed {
+                                        self.reopenAlert = true
+                                    }
+                                }
+                            } catch let error {
+                                print(error)
                             }
+                        }
+                    } label: {
+                        Text("Install")
+                    }
+                    .disabled(self.model.release == nil)
+                } else {
+                    Button {
+                        do {
+                            try ExtensionsManager.shared?.remove(plugin: self.model.plugin)
+                            self.installed = ExtensionsManager.shared?.isInstalled(plugin: model.plugin) ?? false
                         } catch let error {
                             print(error)
                         }
+                    } label: {
+                        Text("Uninstall")
                     }
-                } label: {
-                    Text("Install")
                 }
-                .disabled(self.model.release == nil)
             }
+        }
+        .alert("Extension is installed", isPresented: $reopenAlert) {
+            Button("Reopen workspace") {
+                guard let url = document.fileURL else { return }
+                document.close()
+                CodeEditDocumentController.shared.reopenDocument(for: url,
+                                                                 withContentsOf: url,
+                                                                 display: true) { _, _, _ in
+                }
+            }
+            Button("Reopen later") {
+                self.reopenAlert = false
+            }
+        } message: {
+            Text("To make extension work, you need to reopen the workspace.")
+        }
+        .padding(.vertical)
+        .onAppear {
+            self.installed = ExtensionsManager.shared?.isInstalled(plugin: model.plugin) ?? false
         }
     }
 }

--- a/CodeEdit/NavigatorSidebar/ExtensionNavigator/ExtensionNavigatorItem.swift
+++ b/CodeEdit/NavigatorSidebar/ExtensionNavigator/ExtensionNavigatorItem.swift
@@ -9,90 +9,25 @@ import SwiftUI
 import ExtensionsStore
 
 struct ExtensionNavigatorItem: View {
-    init(plugin: Plugin) {
-        self.plugin = plugin
-        self.installed = ExtensionsManager.shared?.isInstalled(plugin: plugin) ?? false
-    }
-
     var plugin: Plugin
-    @State var showing = false
-    @State var reopenAlert = false
-    @State var installed: Bool = false
     @EnvironmentObject var document: WorkspaceDocument
 
     var body: some View {
-        HStack {
-            VStack(alignment: .leading) {
-                Text(plugin.manifest.displayName)
-                    .font(.headline)
-                Text(plugin.manifest.name)
-                    .font(.subheadline)
-            }
-            Spacer()
-            if !installed {
-                Button {
-                    self.showing = true
-                } label: {
-                    Text("INSTALL")
-                        .font(.callout.bold())
-                        .foregroundColor(Color.white)
-                        .padding(.vertical, 4)
-                        .padding(.horizontal, 8)
-                        .background(Color.accentColor)
-                        .clipShape(Capsule())
-                }
-                .buttonStyle(PlainButtonStyle())
-            } else {
-                Button {
-                    do {
-                        try ExtensionsManager.shared?.remove(plugin: plugin)
-                        self.installed = false
-                    } catch let error {
-                        print(error)
+        Button {
+            document.openTab(item: plugin)
+        } label: {
+            ZStack {
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text(plugin.manifest.displayName)
+                            .font(.headline)
+                        Text(plugin.manifest.name)
+                            .font(.subheadline)
                     }
-                } label: {
-                    Text("UNINSTALL")
-                        .font(.callout.bold())
-                        .foregroundColor(Color.white)
-                        .padding(.vertical, 4)
-                        .padding(.horizontal, 8)
-                        .background(Color.red)
-                        .clipShape(Capsule())
-                }
-                .buttonStyle(PlainButtonStyle())
-            }
-        }
-        .sheet(isPresented: $showing) {
-
-        } content: {
-            ExtensionInstallationView(dismiss: {
-                self.showing = false
-                self.installed = ExtensionsManager.shared?.isInstalled(plugin: plugin) ?? false
-
-                if self.installed {
-                    self.reopenAlert = true
-                }
-            }, model: .init(plugin: plugin))
-                .frame(width: 500, height: 400, alignment: .center)
-        }
-        .alert("Extension is installed", isPresented: $reopenAlert) {
-            Button("Reopen workspace") {
-                guard let url = document.fileURL else { return }
-                document.close()
-                CodeEditDocumentController.shared.reopenDocument(for: url,
-                                                                 withContentsOf: url,
-                                                                 display: true) { _, _, _ in
+                    Spacer()
                 }
             }
-            Button("Reopen later") {
-                self.reopenAlert = false
-            }
-        } message: {
-            Text("To make extension work, you need to reopen the workspace.")
         }
-        .padding(.vertical)
-        .onAppear {
-            self.installed = ExtensionsManager.shared?.isInstalled(plugin: plugin) ?? false
-        }
+        .buttonStyle(.plain)
     }
 }

--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultList.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultList.swift
@@ -35,14 +35,14 @@ struct FindNavigatorResultList: View {
                 FindNavigatorResultFileItem(
                     state: state,
                     fileItem: foundFile.file, results: getResultWith(foundFile.file)) {
-                        state.workspace.openFile(item: foundFile.file)
+                        state.workspace.openTab(item: foundFile.file)
                     }
             }
         }
         .listStyle(.sidebar)
         .onChange(of: selectedResult) { newValue in
             if let file = newValue?.file {
-                state.workspace.openFile(item: file)
+                state.workspace.openTab(item: file)
             }
         }
     }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import WorkspaceClient
 import AppPreferences
+import TabBar
 
 /// A `NSViewController` that handles the **ProjectNavigator** in the **NavigatorSideabr**.
 ///
@@ -25,7 +26,7 @@ final class OutlineViewController: NSViewController {
     /// Also creates a top level item "root" which represents the projects root directory and automatically expands it.
     private var content: [Item] {
         guard let folderURL = workspace?.workspaceClient?.folderURL() else { return [] }
-        let children = workspace?.selectionState.fileItems.sortItems(foldersOnTop: true)
+        let children = workspace?.fileItems.sortItems(foldersOnTop: true)
         guard let root = try? workspace?.workspaceClient?.getFileItem(folderURL.path) else { return [] }
         root.children = children
         return [root]
@@ -179,7 +180,7 @@ extension OutlineViewController: NSOutlineViewDelegate {
         guard let item = outlineView.item(atRow: selectedIndex) as? Item else { return }
 
         if item.children == nil {
-            workspace?.openFile(item: item)
+            workspace?.openTab(item: item)
         }
     }
 
@@ -207,9 +208,9 @@ extension OutlineViewController: NSOutlineViewDelegate {
     /// Recursively gets and selects an ``Item`` from an array of ``Item`` and their `children` based on the `id`.
     /// - Parameters:
     ///   - id: the id of the item item
-    ///   - collection: the array to search for
-    private func select(by id: Item.ID, from collection: [Item]) {
-        guard let item = collection.first(where: { $0.id == id }) else {
+    ///   - collection: the array to searchx for
+    private func select(by id: TabBarItemID, from collection: [Item]) {
+        guard let item = collection.first(where: { $0.tabID == id }) else {
             for item in collection {
                 select(by: id, from: item.children ?? [])
             }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -208,7 +208,7 @@ extension OutlineViewController: NSOutlineViewDelegate {
     /// Recursively gets and selects an ``Item`` from an array of ``Item`` and their `children` based on the `id`.
     /// - Parameters:
     ///   - id: the id of the item item
-    ///   - collection: the array to searchx for
+    ///   - collection: the array to search for
     private func select(by id: TabBarItemID, from collection: [Item]) {
         guard let item = collection.first(where: { $0.tabID == id }) else {
             for item in collection {

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -85,14 +85,16 @@ struct TabBar: View {
                             alignment: .center,
                             spacing: -1
                         ) {
-                            ForEach(workspace.selectionState.openedTabs, id: \.id) { item in
-                                TabBarItem(
-                                    expectedWidth: $expectedTabWidth,
-                                    item: item,
-                                    windowController: windowController,
-                                    workspace: workspace
-                                )
-                                .frame(height: TabBar.height)
+                            ForEach(workspace.selectionState.openedTabs, id: \.id) { id in
+                                if let item = workspace.selectionState.getItemByTab(id: id) {
+                                    TabBarItem(
+                                        expectedWidth: $expectedTabWidth,
+                                        item: item,
+                                        windowController: windowController,
+                                        workspace: workspace
+                                    )
+                                    .frame(height: TabBar.height)
+                                }
                             }
                         }
                         // This padding is to hide dividers at two ends under the accessory view divider.

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -60,12 +60,14 @@ struct TabBar: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 ScrollViewReader { value in
                     HStack(alignment: .center, spacing: -1) {
-                        ForEach(workspace.selectionState.openFileItems, id: \.id) { item in
-                            TabBarItem(
-                                item: item,
-                                windowController: windowController,
-                                workspace: workspace
-                            )
+                        ForEach(workspace.selectionState.openedTabs, id: \.id) { id in
+                            if let item = self.workspace.selectionState.getItemByTab(id: id) {
+                                TabBarItem(
+                                    item: item,
+                                    windowController: windowController,
+                                    workspace: workspace
+                                )
+                            }
                         }
                     }
                     .onAppear {

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -46,7 +46,7 @@ struct TabBar: View {
     private func updateExpectedTabWidth(proxy: GeometryProxy) {
         expectedTabWidth = max(
             // Equally divided size of a native tab.
-            (proxy.size.width + 1) / CGFloat(workspace.selectionState.openFileItems.count) + 1,
+            (proxy.size.width + 1) / CGFloat(workspace.selectionState.openedTabs.count) + 1,
             // Min size of a native tab.
             CGFloat(140)
         )
@@ -111,7 +111,7 @@ struct TabBar: View {
                             scrollReader.scrollTo(selectedId)
                         }
                         // When tabs are changing, re-compute the expected tab width.
-                        .onChange(of: workspace.selectionState.openFileItems.count) { _ in
+                        .onChange(of: workspace.selectionState.openedTabs.count) { _ in
                             // Only update the expected width when user is not hovering over tabs.
                             // This should give users a better experience on closing multiple tabs continuously.
                             if !isHoveringOverTabs {

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -49,7 +49,7 @@ struct TabBarItem: View {
     private var windowController: NSWindowController
 
     var isActive: Bool {
-        item.id == workspace.selectionState.selectedId
+        item.tabID == workspace.selectionState.selectedId
     }
 
     private func switchAction() {
@@ -68,13 +68,6 @@ struct TabBarItem: View {
         ) {
             workspace.closeTab(item: item.tabID)
         }
-    }
-
-    @ObservedObject
-    private var workspace: WorkspaceDocument
-
-    private var isActive: Bool {
-        item.tabID == workspace.selectionState.selectedId
     }
 
     init(

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import WorkspaceClient
 import StatusBar
+import ExtensionsStore
 
 struct WorkspaceView: View {
     init(windowController: NSWindowController, workspace: WorkspaceDocument) {
@@ -47,6 +48,12 @@ struct WorkspaceView: View {
             switch tabID {
             case .codeEditor:
                 WorkspaceCodeFileView(windowController: windowController, workspace: workspace)
+            case .extensionInstallation:
+                if let plugin = workspace.selectionState.selected as? Plugin {
+                    ExtensionInstallationView(plugin: plugin)
+                        .environmentObject(workspace)
+                        .frame(alignment: .center)
+                }
             }
         } else {
             noEditor
@@ -56,7 +63,9 @@ struct WorkspaceView: View {
     var body: some View {
         ZStack {
             if workspace.workspaceClient != nil, let model = workspace.statusBarModel {
-                tabContent
+                ZStack {
+                    tabContent
+                }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .safeAreaInset(edge: .top, spacing: 0) {
                         VStack(spacing: 0) {

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -10,6 +10,7 @@ import WorkspaceClient
 import StatusBar
 import ExtensionsStore
 import AppKit
+import AppPreferences
 
 struct WorkspaceView: View {
     init(windowController: NSWindowController, workspace: WorkspaceDocument) {
@@ -23,6 +24,9 @@ struct WorkspaceView: View {
 
     @ObservedObject
     var workspace: WorkspaceDocument
+
+    @StateObject
+    private var prefs: AppPreferencesModel = .shared
 
     @State
     private var showingAlert = false
@@ -79,6 +83,13 @@ struct WorkspaceView: View {
                     tabContent
                 }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background {
+                        if prefs.preferences.general.tabBarStyle == .xcode {
+                            // Use the same background material as xcode tab bar style.
+                            // Only when the tab bar style is set to `xcode`.
+                            TabBarXcodeBackground()
+                        }
+                    }
                     .safeAreaInset(edge: .top, spacing: 0) {
                         VStack(spacing: 0) {
                             TabBar(windowController: windowController, workspace: workspace)

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -34,10 +34,36 @@ struct WorkspaceView: View {
     @State
     var showInspector = true
 
+    var noEditor: some View {
+        Text("No Editor")
+            .font(.system(size: 17))
+            .foregroundColor(.secondary)
+            .frame(minHeight: 0)
+            .clipped()
+    }
+
+    @ViewBuilder var tabContent: some View {
+        if let tabID = workspace.selectionState.selectedId {
+            switch tabID {
+            case .codeEditor:
+                WorkspaceCodeFileView(windowController: windowController, workspace: workspace)
+            }
+        } else {
+            noEditor
+        }
+    }
+
     var body: some View {
         ZStack {
             if workspace.workspaceClient != nil, let model = workspace.statusBarModel {
-                WorkspaceCodeFileView(windowController: windowController, workspace: workspace)
+                tabContent
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .safeAreaInset(edge: .top, spacing: 0) {
+                        VStack(spacing: 0) {
+                            TabBar(windowController: windowController, workspace: workspace)
+                            TabBarBottomDivider()
+                        }
+                    }
                     .safeAreaInset(edge: .bottom) {
                         StatusBarView(model: model)
                     }

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -46,7 +46,7 @@ struct WorkspaceView: View {
 
     @State
     private var leaveFullscreenObserver: Any?
-    
+
     var noEditor: some View {
         Text("No Editor")
             .font(.system(size: 17))

--- a/CodeEditModules/Modules/ExtensionsStore/src/Models/Plugin.swift
+++ b/CodeEditModules/Modules/ExtensionsStore/src/Models/Plugin.swift
@@ -6,9 +6,27 @@
 //
 
 import Foundation
+import SwiftUI
 import CodeEditKit
+import TabBar
 
-public struct Plugin: Codable, Identifiable, Hashable {
+public struct Plugin: Codable, Identifiable, Hashable, TabBarItemRepresentable {
+    public var tabID: TabBarItemID {
+        .extensionInstallation(self.id)
+    }
+
+    public var title: String {
+        self.manifest.displayName
+    }
+
+    public var icon: Image {
+        Image(systemName: "puzzlepiece.extension.fill")
+    }
+
+    public var iconColor: Color {
+        .blue
+    }
+
     public var id: UUID
     public var manifest: ExtensionManifest
     public var author: UUID

--- a/CodeEditModules/Modules/TabBar/src/Documentation.docc/Adding New Tab Type.md
+++ b/CodeEditModules/Modules/TabBar/src/Documentation.docc/Adding New Tab Type.md
@@ -1,0 +1,90 @@
+# Adding a New Tab Type
+
+This article is about how to add a new tab type to `TabBar`
+
+## Overview
+
+First of all, each data type to be represented as tab in the UI should conform to
+``TabBarItemRepresentable`` protocol. For example, this is how it is done for
+`FileItem`:
+
+```swift
+final class FileItem: Identifiable, Codable, TabBarItemRepresentable {
+    public var tabID: TabBarItemID {
+        .codeEditor(id)
+    }
+
+    public var title: String {
+        self.url.lastPathComponent
+    }
+
+    public var icon: Image {
+        Image(systemName: self.systemImage)
+    }
+
+    public var iconColor: Color {
+        ...
+    }
+
+    ...
+}
+```
+
+### Add new item identifier case
+
+Each new tab type must have new identifier case, for example:
+```swift
+public enum TabBarItemID: Codable, Identifiable, Hashable {
+    public var id: String {
+        switch self {
+        ...
+        case .gitHistory(let repo):
+            return "gitHistory_\(repo)"
+        }
+    }
+
+    /// Represents Git history
+    case gitHistory(String)
+}
+```
+
+### Opening and closing new tab types
+
+Tabs are opened using ``WorkspaceDocument.openTab(item:)`` method. It does a set of common
+things for all tabs. But also it calls a private method based on the ``TabBarItemID`` of the
+item. The private method for your ``TabBarItemRepresentable`` MUST persist this item
+somewhere (I recommend persisting them in ``WorkspaceDocument.SelectionState``).
+
+The same is for closing tabs using ``WorkspaceDocument.closeTab(item:)`` method.
+Closing multiple tabs at once is handled by common functions, so there are no changes
+required for them.
+
+Also, because previously opened tabs are persisted in `.codeedit/selection.json`,
+they should be recovered some way later. To recover new tab types you need to add
+a case for ``WorkspaceDocument.read`` to let it know how to recover your new tab type.
+
+If you need to persist something as code editor tabs do for files, then you need to add
+functionality to persist changes to ``WorkspaceDocument.close``.
+
+Also, you need to add a case for new tab type to
+``WorkspaceDocument.SelectionState.getItemByTab(id:)``. It will allow to use
+``WorkspaceDocument.SelectionState.selected`` property and other features.
+
+### Adding a view for the new tab type
+
+To add a view for new tab type, you need to add a case for your tab type to
+``WorkspaceView.tabContent``:
+
+```swift
+@ViewBuilder var tabContent: some View {
+    if let tabID = workspace.selectionState.selectedId {
+        switch tabID {
+            ...
+        case .gitHistory:
+            GitHistoryView(windowController: windowController, workspace: workspace)
+        }
+    } else {
+        noEditor
+    }
+}
+```

--- a/CodeEditModules/Modules/TabBar/src/Documentation.docc/Documentation.md
+++ b/CodeEditModules/Modules/TabBar/src/Documentation.docc/Documentation.md
@@ -1,0 +1,7 @@
+# ``TabBar``
+
+Common types for `TabBar` items
+
+## Overview
+
+This module contains protocol for `TabBar` items to conform to and tab identifier type.

--- a/CodeEditModules/Modules/TabBar/src/TabBarItemID.swift
+++ b/CodeEditModules/Modules/TabBar/src/TabBarItemID.swift
@@ -1,0 +1,20 @@
+//
+//  TabBarItemID.swift
+//  
+//
+//  Created by Pavel Kasila on 30.04.22.
+//
+
+import Foundation
+
+/// Enum to represent item's ID to tab bar
+public enum TabBarItemID: Codable, Identifiable, Hashable {
+    public var id: String {
+        switch self {
+        case .codeEditor(let path):
+            return "codeEditor_\(path)"
+        }
+    }
+
+    case codeEditor(String)
+}

--- a/CodeEditModules/Modules/TabBar/src/TabBarItemID.swift
+++ b/CodeEditModules/Modules/TabBar/src/TabBarItemID.swift
@@ -18,6 +18,9 @@ public enum TabBarItemID: Codable, Identifiable, Hashable {
         }
     }
 
+    /// Represents code editor tab
     case codeEditor(String)
+
+    /// Represents extension installation tab
     case extensionInstallation(UUID)
 }

--- a/CodeEditModules/Modules/TabBar/src/TabBarItemID.swift
+++ b/CodeEditModules/Modules/TabBar/src/TabBarItemID.swift
@@ -13,8 +13,11 @@ public enum TabBarItemID: Codable, Identifiable, Hashable {
         switch self {
         case .codeEditor(let path):
             return "codeEditor_\(path)"
+        case .extensionInstallation(let id):
+            return "extensionInstallation_\(id.uuidString)"
         }
     }
 
     case codeEditor(String)
+    case extensionInstallation(UUID)
 }

--- a/CodeEditModules/Modules/TabBar/src/TabBarItemRepresentable.swift
+++ b/CodeEditModules/Modules/TabBar/src/TabBarItemRepresentable.swift
@@ -1,0 +1,15 @@
+//
+//  TabBarItemRepresentable.swift
+//  
+//
+//  Created by Pavel Kasila on 30.04.22.
+//
+
+import SwiftUI
+
+public protocol TabBarItemRepresentable {
+    var tabID: TabBarItemID { get }
+    var title: String { get }
+    var icon: Image { get }
+    var iconColor: Color { get }
+}

--- a/CodeEditModules/Modules/TabBar/src/TabBarItemRepresentable.swift
+++ b/CodeEditModules/Modules/TabBar/src/TabBarItemRepresentable.swift
@@ -7,9 +7,14 @@
 
 import SwiftUI
 
+/// Protocol for data passed to TabBarItem to conform to
 public protocol TabBarItemRepresentable {
+    /// Unique tab identifier
     var tabID: TabBarItemID { get }
+    /// String to be shown as tab's title
     var title: String { get }
+    /// Image to be shown as tab's icon
     var icon: Image { get }
+    /// Color of the tab's icon
     var iconColor: Color { get }
 }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import TabBar
 
 public extension WorkspaceClient {
     enum FileItemCodingKeys: String, CodingKey {
@@ -16,7 +17,18 @@ public extension WorkspaceClient {
     }
 
     /// An object containing all necessary information and actions for a specific file in the workspace
-    final class FileItem: Identifiable, Codable {
+    final class FileItem: Identifiable, Codable, TabBarItemRepresentable {
+        public var tabID: TabBarItemID {
+            .codeEditor(id)
+        }
+
+        public var title: String {
+            self.url.lastPathComponent
+        }
+
+        public var icon: Image {
+            Image(systemName: self.systemImage)
+        }
 
         public typealias ID = String
 

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -85,6 +85,10 @@ let package = Package(
             name: "CodeEditUtils",
             targets: ["CodeEditUtils"]
         ),
+        .library(
+            name: "TabBar",
+            targets: ["TabBar"]
+        ),
     ],
     dependencies: [
         .package(
@@ -130,6 +134,9 @@ let package = Package(
     targets: [
         .target(
             name: "WorkspaceClient",
+            dependencies: [
+                "TabBar"
+            ],
             path: "Modules/WorkspaceClient/src"
         ),
         .testTarget(
@@ -321,7 +328,10 @@ let package = Package(
         .target(
             name: "CodeEditUtils",
             path: "Modules/CodeEditUtils/src"
-
+        ),
+        .target(
+            name: "TabBar",
+            path: "Modules/TabBar/src"
         ),
     ]
 )


### PR DESCRIPTION
# Description

Adds ability to have tabs of different types.

Currently supported tab types:
* code editor tabs (as before)
* extension installation tabs

## How new tab types can be added?

Each `TabBarItem` represents a structure which conforms to `TabBarItemRepresentable`-protocol.

```swift
public protocol TabBarItemRepresentable {
    /// Unique tab identifier
    var tabID: TabBarItemID { get }
    /// String to be shown as tab's title
    var title: String { get }
    /// Image to be shown as tab's icon
    var icon: Image { get }
    /// Color of the tab's icon
    var iconColor: Color { get }
}
```

`TabBarItemID` is a enum which has cases for each tab type:
```swift 
public enum TabBarItemID: Codable, Identifiable, Hashable {
    ...

    /// Represents code editor tab
    case codeEditor(String)

    /// Represents extension installation tab
    case extensionInstallation(UUID)
}
```

Tabs are opened using `WorkspaceDocument.openTab(item:TabBarItemRespresentable)` method.
It does a set of common things for all tabs but also it calls private method based on `TabBarItemID`
of the item to be opened. The private method for your `TabBarItemRepresentable` **MUST** persist this item
somewhere (I recommend persisting them in `WorkspaceDocument.SelectionState`).

The same is for closing tabs using  `WorkspaceDocument.closeTab(item:TabBarItemID)` method
(ID is passed here, not the item itself). Closing multiple tabs at once is handled by common functions,
so there are no changes required for them.

Also, because previously opened tabs are being persisted in `.codeedit/selection.json`, then they should
be recovered some way later. To recover new tab types you need to add a case for `WorkspaceDocument.read`
to get it to know how to recover your new tab type.

If you need to persist something as code editor tabs do for files, then you need to add functionality to persist changes to `WorkspaceDocument.close`.

Also, you need to add a case for new tab type to `WorkspaceDocument.SelectionState.getItemByTab(id: TabBarItemID)`.
It will allow to use `WorkspaceDocument.SelectionState.selected` property and other features.

To add a view for new tab type, you need to add a case for your tab type to `WorkspaceView.tabContent`:
```swift
@ViewBuilder var tabContent: some View {
    if let tabID = workspace.selectionState.selectedId {
        switch tabID {
            ...
        }
    } else {
        noEditor
    }
}
```

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #561

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/17158860/166160638-9397df12-cc09-45ec-93a5-0ff6d5db284f.mov

