### PR TITLE
Add Find Navigator Result reflect general preference "Find Navigator Detail"

### DIFF
--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultFileItem.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultFileItem.swift
@@ -37,7 +37,8 @@ struct FindNavigatorResultFileItem: View {
 
     @ViewBuilder
     private func foundLineResult(_ lineContent: String?, keywordRange: Range<String.Index>?) -> some View {
-        if let lineContent = lineContent, let keywordRange = keywordRange {
+        if let lineContent = lineContent,
+           let keywordRange = keywordRange {
             Text(lineContent[lineContent.startIndex..<keywordRange.lowerBound]) +
             Text(lineContent[keywordRange.lowerBound..<keywordRange.upperBound])
                 .foregroundColor(.white)

--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultFileItem.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultFileItem.swift
@@ -8,10 +8,13 @@
 import SwiftUI
 import WorkspaceClient
 import Search
+import AppPreferences
 
 struct FindNavigatorResultFileItem: View {
     @ObservedObject
     private var state: WorkspaceDocument.SearchState
+    @StateObject
+    private var prefs: AppPreferencesModel = .shared
 
     @State
     private var isExpanded: Bool = true
@@ -32,17 +35,15 @@ struct FindNavigatorResultFileItem: View {
              self.jumpToFile = jumpToFile
     }
 
+    @ViewBuilder
     private func foundLineResult(_ lineContent: String?, keywordRange: Range<String.Index>?) -> some View {
-        guard let lineContent = lineContent, let keywordRange = keywordRange else {
-            return AnyView(EmptyView())
-        }
-        return AnyView(
+        if let lineContent = lineContent, let keywordRange = keywordRange {
             Text(lineContent[lineContent.startIndex..<keywordRange.lowerBound]) +
             Text(lineContent[keywordRange.lowerBound..<keywordRange.upperBound])
                 .foregroundColor(.white)
                 .font(.system(size: 12, weight: .bold)) +
             Text(lineContent[keywordRange.upperBound..<lineContent.endIndex])
-        )
+        }
     }
 
     var body: some View {
@@ -53,7 +54,7 @@ struct FindNavigatorResultFileItem: View {
                         .font(.system(size: 12))
                         .padding(.top, 2)
                     foundLineResult(result.lineContent, keywordRange: result.keywordRange)
-                        .lineLimit(Int.max)
+                        .lineLimit(prefs.preferences.general.findNavigatorDetail.rawValue)
                         .foregroundColor(Color(nsColor: .secondaryLabelColor))
                         .font(.system(size: 12, weight: .light))
                     Spacer()

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
@@ -142,7 +142,6 @@ private extension GeneralPreferencesView {
         }
     }
 
-    // TODO: Implement reflecting Find Navigator Detail preference and remove disabled modifier
     var findNavigatorDetailSection: some View {
         PreferencesSection("Find Navigator Detail") {
             Picker("Find Navigator Detail", selection: $prefs.preferences.general.findNavigatorDetail) {
@@ -152,7 +151,6 @@ private extension GeneralPreferencesView {
             }
             .frame(width: inputWidth)
         }
-        .disabled(true)
     }
 
     // TODO: Implement reflecting Issue Navigator Detail preference and remove disabled modifier


### PR DESCRIPTION
# Description

This pull request contains changes about reflecting "Find Navigator Detail" preference in Find Navigator

## Changes

- annotated foundLineResult function with @ViewBuilder, make it use if let unwrapping and removing AnyView usage
- add lineLimit modifier to foundLineResult from GeneralPreferences.findNavigatorDetail
- remove disabled modifier on GeneralPreferencesView findNavigatorDetailSection

# Related Issue

#376

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/36012972/166165986-5d7f1a79-f627-42f9-895d-9c03bb5ee9b8.mov



<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
