### PR TITLE
`Tabbar`: Accessory Button enhancements

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>a8e63ed1d032d782d649b50fd046258144802c30</string>
+	<string>359ca3e014a6d46c41c780cf66b8c6f0259b3131</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>9c10a36435e60ef79f5225b462ddf66d4c1f209e</string>
+	<string>a8e63ed1d032d782d649b50fd046258144802c30</string>
 </dict>
 </plist>

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -55,7 +55,7 @@ struct TabBar: View {
     var body: some View {
         HStack(alignment: .center, spacing: 0) {
             // Tab bar navigation control.
-            HStack(spacing: 10) {
+            HStack(spacing: 2) {
                 TabBarAccessoryIcon(
                     icon: .init(systemName: "chevron.left"),
                     action: { /* TODO */ }
@@ -66,10 +66,10 @@ struct TabBar: View {
                     icon: .init(systemName: "chevron.right"),
                     action: { /* TODO */ }
                 )
-                .foregroundColor(.secondary.opacity(0.5))
+                .foregroundColor(.secondary)
                 .buttonStyle(.plain)
             }
-            .padding(.horizontal, 11)
+            .padding(.horizontal, 7)
             .opacity(activeState != .inactive ? 1.0 : 0.5)
             .frame(maxHeight: .infinity) // Fill out vertical spaces.
             .background {
@@ -147,7 +147,7 @@ struct TabBar: View {
                 }
             }
             // Tab bar tools (e.g. split view).
-            HStack(spacing: 10) {
+            HStack(spacing: 2) {
                 TabBarAccessoryIcon(
                     icon: .init(systemName: "ellipsis.circle"),
                     action: { /* TODO */ }
@@ -167,7 +167,7 @@ struct TabBar: View {
                 .foregroundColor(.secondary)
                 .buttonStyle(.plain)
             }
-            .padding(.horizontal, 11)
+            .padding(.horizontal, 7)
             .opacity(activeState != .inactive ? 1.0 : 0.5)
             .frame(maxHeight: .infinity) // Fill out vertical spaces.
             .background {

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -167,12 +167,14 @@ struct TabBar: View {
             )
             .foregroundColor(.secondary)
             .buttonStyle(.plain)
+            .help("Navigate back")
             TabBarAccessoryIcon(
                 icon: .init(systemName: "chevron.right"),
                 action: { /* TODO */ }
             )
             .foregroundColor(.secondary)
             .buttonStyle(.plain)
+            .help("Navigate forward")
         }
         .padding(.horizontal, 7)
         .opacity(activeState != .inactive ? 1.0 : 0.5)
@@ -192,18 +194,21 @@ struct TabBar: View {
             )
             .foregroundColor(.secondary)
             .buttonStyle(.plain)
+            .help("Options")
             TabBarAccessoryIcon(
                 icon: .init(systemName: "arrow.left.arrow.right.square"),
                 action: { /* TODO */ }
             )
             .foregroundColor(.secondary)
             .buttonStyle(.plain)
+            .help("Enable Code Review")
             TabBarAccessoryIcon(
                 icon: .init(systemName: "square.split.2x1"),
                 action: { /* TODO */ }
             )
             .foregroundColor(.secondary)
             .buttonStyle(.plain)
+            .help("Split View")
         }
         .padding(.horizontal, 7)
         .opacity(activeState != .inactive ? 1.0 : 0.5)

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -55,28 +55,7 @@ struct TabBar: View {
     var body: some View {
         HStack(alignment: .center, spacing: 0) {
             // Tab bar navigation control.
-            HStack(spacing: 2) {
-                TabBarAccessoryIcon(
-                    icon: .init(systemName: "chevron.left"),
-                    action: { /* TODO */ }
-                )
-                .foregroundColor(.secondary)
-                .buttonStyle(.plain)
-                TabBarAccessoryIcon(
-                    icon: .init(systemName: "chevron.right"),
-                    action: { /* TODO */ }
-                )
-                .foregroundColor(.secondary)
-                .buttonStyle(.plain)
-            }
-            .padding(.horizontal, 7)
-            .opacity(activeState != .inactive ? 1.0 : 0.5)
-            .frame(maxHeight: .infinity) // Fill out vertical spaces.
-            .background {
-                if prefs.preferences.general.tabBarStyle == .native {
-                    TabBarAccessoryNativeBackground(dividerAt: .trailing)
-                }
-            }
+            leadingAccessories
             // Tab bar items.
             GeometryReader { geometryProxy in
                 ScrollView(.horizontal, showsIndicators: false) {
@@ -147,35 +126,7 @@ struct TabBar: View {
                 }
             }
             // Tab bar tools (e.g. split view).
-            HStack(spacing: 2) {
-                TabBarAccessoryIcon(
-                    icon: .init(systemName: "ellipsis.circle"),
-                    action: { /* TODO */ }
-                )
-                .foregroundColor(.secondary)
-                .buttonStyle(.plain)
-                TabBarAccessoryIcon(
-                    icon: .init(systemName: "arrow.left.arrow.right.square"),
-                    action: { /* TODO */ }
-                )
-                .foregroundColor(.secondary)
-                .buttonStyle(.plain)
-                TabBarAccessoryIcon(
-                    icon: .init(systemName: "square.split.2x1"),
-                    action: { /* TODO */ }
-                )
-                .foregroundColor(.secondary)
-                .buttonStyle(.plain)
-            }
-            .padding(.horizontal, 7)
-            .opacity(activeState != .inactive ? 1.0 : 0.5)
-            .frame(maxHeight: .infinity) // Fill out vertical spaces.
-            .background {
-                if prefs.preferences.general.tabBarStyle == .native {
-                    TabBarAccessoryNativeBackground(dividerAt: .leading)
-                }
-            }
-            // TODO: Tab bar tools (e.g. split view).
+            trailingAccessories
         }
         .frame(height: TabBar.height)
         .overlay(alignment: .top) {
@@ -204,5 +155,63 @@ struct TabBar: View {
             }
         }
         .padding(.leading, -1)
+    }
+
+    // MARK: Accessories
+
+    private var leadingAccessories: some View {
+        HStack(spacing: 2) {
+            TabBarAccessoryIcon(
+                icon: .init(systemName: "chevron.left"),
+                action: { /* TODO */ }
+            )
+            .foregroundColor(.secondary)
+            .buttonStyle(.plain)
+            TabBarAccessoryIcon(
+                icon: .init(systemName: "chevron.right"),
+                action: { /* TODO */ }
+            )
+            .foregroundColor(.secondary)
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 7)
+        .opacity(activeState != .inactive ? 1.0 : 0.5)
+        .frame(maxHeight: .infinity) // Fill out vertical spaces.
+        .background {
+            if prefs.preferences.general.tabBarStyle == .native {
+                TabBarAccessoryNativeBackground(dividerAt: .trailing)
+            }
+        }
+    }
+
+    private var trailingAccessories: some View {
+        HStack(spacing: 2) {
+            TabBarAccessoryIcon(
+                icon: .init(systemName: "ellipsis.circle"),
+                action: { /* TODO */ }
+            )
+            .foregroundColor(.secondary)
+            .buttonStyle(.plain)
+            TabBarAccessoryIcon(
+                icon: .init(systemName: "arrow.left.arrow.right.square"),
+                action: { /* TODO */ }
+            )
+            .foregroundColor(.secondary)
+            .buttonStyle(.plain)
+            TabBarAccessoryIcon(
+                icon: .init(systemName: "square.split.2x1"),
+                action: { /* TODO */ }
+            )
+            .foregroundColor(.secondary)
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 7)
+        .opacity(activeState != .inactive ? 1.0 : 0.5)
+        .frame(maxHeight: .infinity) // Fill out vertical spaces.
+        .background {
+            if prefs.preferences.general.tabBarStyle == .native {
+                TabBarAccessoryNativeBackground(dividerAt: .leading)
+            }
+        }
     }
 }

--- a/CodeEdit/TabBar/TabBarAccessory.swift
+++ b/CodeEdit/TabBar/TabBarAccessory.swift
@@ -23,7 +23,13 @@ struct TabBarAccessoryIcon: View {
     var body: some View {
         Button(
             action: action,
-            label: { icon.font(TabBarAccessoryIcon.iconFont) }
+            label: {
+                icon
+                    .font(TabBarAccessoryIcon.iconFont)
+                    .frame(height: TabBar.height - 2)
+                    .padding(.horizontal, 4)
+                    .contentShape(Rectangle())
+            }
         )
     }
 }


### PR DESCRIPTION
# Description

This PR brings some enhancements for the Accessory Buttons on the Tabbar:

- Increased Hitbox
- Added Help labels

Also moved the accessories `HStacks` to a sub-view.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

## Hitbox

<img width="54" alt="Group 1" src="https://user-images.githubusercontent.com/9460130/166218210-fee3c774-4401-4746-8ea0-7d8aa383b42f.png">

## Help Labels

<img width="176" alt="Screen Shot 2022-05-02 at 12 01 39" src="https://user-images.githubusercontent.com/9460130/166218085-011aed20-cd72-41a7-b233-de339d9fa164.png">

<img width="173" alt="Screen Shot 2022-05-02 at 12 01 54" src="https://user-images.githubusercontent.com/9460130/166218093-a04fc60f-54a8-41cf-b6e2-f70c4b442ac0.png">

