### PR TITLE
[ShellClient] add live mode API

### DIFF
--- a/CodeEdit/InspectorSidebar/Models/HistoryInspectorModel.swift
+++ b/CodeEdit/InspectorSidebar/Models/HistoryInspectorModel.swift
@@ -31,7 +31,7 @@ public final class HistoryInspectorModel: ObservableObject {
         self.fileURL = fileURL
         gitClient = GitClient.default(
             directoryURL: workspaceURL,
-            shellClient: .live
+            shellClient: .live()
         )
         do {
             let commitHistory = try gitClient.getCommitHistory(40, fileURL)

--- a/CodeEditModules/Modules/CodeEditUI/src/ToolbarBranchPicker.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/ToolbarBranchPicker.swift
@@ -29,7 +29,7 @@ public struct ToolbarBranchPicker: View {
         if let folderURL = workspace?.folderURL() {
             self.gitClient = GitClient.default(
                 directoryURL: folderURL,
-                shellClient: .live
+                shellClient: .live()
             )
         }
         self._currentBranch = State(initialValue: try? gitClient?.getCurrentBranchName())

--- a/CodeEditModules/Modules/ShellClient/src/Interface.swift
+++ b/CodeEditModules/Modules/ShellClient/src/Interface.swift
@@ -4,13 +4,17 @@
 //
 //  Created by Marco Carnevali on 27/03/22.
 //
+import Combine
 
 public struct ShellClient {
-    public var run: (_ command: String) throws -> String
+    public var runLive: (_ args: String...) -> AnyPublisher<String, Never>
+    public var run: (_ args: String...) throws -> String
 
     public init(
-        run: @escaping (_ command: String) throws -> String
+        runLive: @escaping (_ args: String...) -> AnyPublisher<String, Never>,
+        run: @escaping (_ args: String...) throws -> String
     ) {
+        self.runLive = runLive
         self.run = run
     }
 }

--- a/CodeEditModules/Modules/ShellClient/src/Live.swift
+++ b/CodeEditModules/Modules/ShellClient/src/Live.swift
@@ -5,17 +5,60 @@
 //  Created by Marco Carnevali on 27/03/22.
 //
 import Foundation
+import Combine
 
 public extension ShellClient {
-    static let live = ShellClient { command in
-        let task = Process()
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = pipe
-        task.arguments = ["-c", command]
-        task.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        try task.run()
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8) ?? ""
+    static func live() -> Self {
+        func generateProcessAndPipe(_ args: [String]) -> (Process, Pipe) {
+            var arguments = ["-c"]
+            arguments.append(contentsOf: args)
+            let task = Process()
+            let pipe = Pipe()
+            task.standardOutput = pipe
+            task.standardError = pipe
+            task.arguments = arguments
+            task.executableURL = URL(fileURLWithPath: "/bin/zsh")
+            return (task, pipe)
+        }
+
+        var cancellables: [UUID: AnyCancellable] = [:]
+
+        return ShellClient(
+            runLive: { args in
+                let subject = PassthroughSubject<String, Never>()
+                let (task, pipe) = generateProcessAndPipe(args)
+                let outputHandler = pipe.fileHandleForReading
+                // wait for the data to come in and then notify
+                // the Notification with Name: `NSFileHandleDataAvailable`
+                outputHandler.waitForDataInBackgroundAndNotify()
+                let id = UUID()
+                cancellables[id] = NotificationCenter
+                    .default
+                    .publisher(for: .NSFileHandleDataAvailable, object: outputHandler)
+                    .sink { _ in
+                        let data = outputHandler.availableData
+                        // swiftlint:disable:next empty_count
+                        guard data.count > 0 else {
+                            // if no data is available anymore
+                            // we should cancel this cancellable
+                            // and mark the subject as finished
+                            cancellables.removeValue(forKey: id)
+                            subject.send(completion: .finished)
+                            return
+                        }
+                        if let line = String(data: data, encoding: .utf8) {
+                            subject.send(line)
+                        }
+                        outputHandler.waitForDataInBackgroundAndNotify()
+                    }
+                task.launch()
+                return subject.eraseToAnyPublisher()
+            }, run: { args in
+                let (task, pipe) = generateProcessAndPipe(args)
+                try task.run()
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                return String(data: data, encoding: .utf8) ?? ""
+            }
+        )
     }
 }

--- a/CodeEditModules/Modules/ShellClient/src/Mocks.swift
+++ b/CodeEditModules/Modules/ShellClient/src/Mocks.swift
@@ -4,11 +4,18 @@
 //
 //  Created by Marco Carnevali on 27/03/22.
 //
+import Combine
 
 public extension ShellClient {
     static func always(_ output: String) -> Self {
-        ShellClient { _ in
-            output
-        }
+        Self(
+            runLive: { _ in
+                CurrentValueSubject<String, Never>(output)
+                    .eraseToAnyPublisher()
+            },
+            run: { _ in
+                output
+            }
+        )
     }
 }

--- a/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
+++ b/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
@@ -108,7 +108,7 @@ public class StatusBarModel: ObservableObject {
         self.workspaceURL = workspaceURL
         gitClient = GitClient.default(
             directoryURL: workspaceURL,
-            shellClient: .live
+            shellClient: .live()
         )
         do {
             let selectedBranch = try gitClient.getCurrentBranchName()

--- a/CodeEditModules/Modules/WelcomeModule/src/WelcomeView.swift
+++ b/CodeEditModules/Modules/WelcomeModule/src/WelcomeView.swift
@@ -203,7 +203,7 @@ public struct WelcomeView: View {
             }
         }
         .sheet(isPresented: $showGitClone) {
-            GitCloneView(shellClient: .live,
+            GitCloneView(shellClient: .live(),
                          isPresented: $showGitClone,
                          showCheckout: $showCheckoutBranch,
                          repoPath: $repoPath)
@@ -211,7 +211,7 @@ public struct WelcomeView: View {
         .sheet(isPresented: $showCheckoutBranch) {
             CheckoutBranchView(isPresented: $showCheckoutBranch,
                                 repoPath: $repoPath,
-                                shellClient: .live)
+                               shellClient: .live())
         }
     }
 


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->
This change will let us observe the output of a given command in live mode as data comes in.

Example of usage: 
```
client.runLive("git clone https://github.com/CodeEditApp/CodeEdit.git ~/Developer/CodeEdit --progress")
    .sink { value in 
        print("Value is: ", value)
    }
    .store(&cancellables)
```

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->


# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
