### PR TITLE
[Git] added progress to the clone repo API + added World + fixed shellclient injection

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		28FFE1BF27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FFE1BE27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift */; };
 		2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* AppDelegate.swift */; };
 		5C403B8F27E20F8000788241 /* WorkspaceClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5C403B8E27E20F8000788241 /* WorkspaceClient */; };
+		5C4BB1E128212B1E00A92FB2 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4BB1E028212B1E00A92FB2 /* World.swift */; };
 		5CA8776527FC6A95003F5CD5 /* QuickOpen in Frameworks */ = {isa = PBXBuildFile; productRef = 5CA8776427FC6A95003F5CD5 /* QuickOpen */; };
 		5CAD1B972806B57D0059A74E /* Breadcrumbs in Frameworks */ = {isa = PBXBuildFile; productRef = 5CAD1B962806B57D0059A74E /* Breadcrumbs */; };
 		5CF38A5E27E48E6C0096A0F7 /* CodeFile in Frameworks */ = {isa = PBXBuildFile; productRef = 5CF38A5D27E48E6C0096A0F7 /* CodeFile */; };
@@ -170,6 +171,7 @@
 		28B0A19727E385C300B73177 /* NavigatorSidebarToolbarTop.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarTop.swift; sourceTree = "<group>"; tabWidth = 4; };
 		28B8F883280FFE4600596236 /* NSTableView+Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Background.swift"; sourceTree = "<group>"; };
 		28FFE1BE27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarBottom.swift; sourceTree = "<group>"; tabWidth = 4; };
+		5C4BB1E028212B1E00A92FB2 /* World.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = World.swift; sourceTree = "<group>"; };
 		B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodeEdit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = WorkspaceView.swift; sourceTree = "<group>"; tabWidth = 4; };
 		B658FB3327DA9E1000EA4DBD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 				B658FB3527DA9E1000EA4DBD /* Preview Content */,
 				287776EB27E350BA00D46668 /* TabBar */,
 				0468438427DC76E200F8E88E /* AppDelegate.swift */,
+				5C4BB1E028212B1E00A92FB2 /* World.swift */,
 				B658FB3327DA9E1000EA4DBD /* Assets.xcassets */,
 				B658FB3827DA9E1000EA4DBD /* CodeEdit.entitlements */,
 				04660F6027E3A68A00477777 /* Info.plist */,
@@ -756,6 +759,7 @@
 				D7211D4327E066CE008F2ED7 /* Localized+Ex.swift in Sources */,
 				20D839AE280E0CA700B27357 /* PopoverView.swift in Sources */,
 				2072FA1E280D891500C7F8D4 /* Location.swift in Sources */,
+				5C4BB1E128212B1E00A92FB2 /* World.swift in Sources */,
 				D7E201B227E8D50000CB86D0 /* FindNavigatorModeSelector.swift in Sources */,
 				287776E927E34BC700D46668 /* TabBar.swift in Sources */,
 				285FEC7027FE4B9800E57D53 /* OutlineTableViewCell.swift in Sources */,

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -134,6 +134,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         let windowController = NSWindowController(window: window)
         window.center()
         let contentView = WelcomeWindowView(
+            shellClient: Current.shellClient,
             openDocument: { url, opened in
                 if let url = url {
                     CodeEditDocumentController.shared.openDocument(

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -162,7 +162,12 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
             return toolbarItem
         case .branchPicker:
             let toolbarItem = NSToolbarItem(itemIdentifier: .branchPicker)
-            let view = NSHostingView(rootView: ToolbarBranchPicker(workspace?.workspaceClient))
+            let view = NSHostingView(
+                rootView: ToolbarBranchPicker(
+                    shellClient: Current.shellClient,
+                    workspace: workspace?.workspaceClient
+                )
+            )
             toolbarItem.view = view
 
             return toolbarItem

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -192,7 +192,7 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         )
         self.searchState = .init(self)
         self.quickOpenState = .init(fileURL: url)
-        self.statusBarModel = .init(workspaceURL: url)
+        self.statusBarModel = .init(shellClient: Current.shellClient, workspaceURL: url)
     }
 
     override func read(from url: URL, ofType typeName: String) throws {

--- a/CodeEdit/InspectorSidebar/Models/HistoryInspectorModel.swift
+++ b/CodeEdit/InspectorSidebar/Models/HistoryInspectorModel.swift
@@ -31,7 +31,7 @@ public final class HistoryInspectorModel: ObservableObject {
         self.fileURL = fileURL
         gitClient = GitClient.default(
             directoryURL: workspaceURL,
-            shellClient: .live()
+            shellClient: Current.shellClient
         )
         do {
             let commitHistory = try gitClient.getCommitHistory(40, fileURL)

--- a/CodeEdit/World.swift
+++ b/CodeEdit/World.swift
@@ -1,0 +1,9 @@
+import ShellClient
+
+// swiftlint:disable:next identifier_name
+var Current: World = .init()
+
+// Inspired by: https://vimeo.com/291588126
+struct World {
+    var shellClient: ShellClient = .live()
+}

--- a/CodeEditModules/Modules/CodeEditUI/Tests/UnitTests.swift
+++ b/CodeEditModules/Modules/CodeEditUI/Tests/UnitTests.swift
@@ -88,7 +88,10 @@ final class CodeEditUIUnitTests: XCTestCase {
     // MARK: ToolbarBranchPicker
 
     func testBranchPickerLight() throws {
-        let view = ToolbarBranchPicker(nil)
+        let view = ToolbarBranchPicker(
+            shellClient: .always(""),
+            workspace: nil
+        )
         let hosting = NSHostingView(rootView: view)
         hosting.appearance = .init(named: .aqua)
         hosting.frame = CGRect(origin: .zero, size: .init(width: 100, height: 50))
@@ -96,7 +99,10 @@ final class CodeEditUIUnitTests: XCTestCase {
     }
 
     func testBranchPickerDark() throws {
-        let view = ToolbarBranchPicker(nil)
+        let view = ToolbarBranchPicker(
+            shellClient: .always(""),
+            workspace: nil
+        )
         let hosting = NSHostingView(rootView: view)
         hosting.appearance = .init(named: .darkAqua)
         hosting.frame = CGRect(origin: .zero, size: .init(width: 100, height: 50))

--- a/CodeEditModules/Modules/CodeEditUI/src/ToolbarBranchPicker.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/ToolbarBranchPicker.swift
@@ -9,37 +9,34 @@ import SwiftUI
 import CodeEditSymbols
 import WorkspaceClient
 import Git
+import ShellClient
 
 /// A view that pops up a branch picker.
 public struct ToolbarBranchPicker: View {
-
     @Environment(\.controlActiveState)
     private var controlActive
-
     private var workspace: WorkspaceClient?
-
     private var gitClient: GitClient?
-
+    @State private var isHovering: Bool = false
+    @State private var displayPopover: Bool = false
     @State private var currentBranch: String?
 
     /// Initializes the ``ToolbarBranchPicker`` with an instance of a `WorkspaceClient`
+    /// - Parameter shellClient: An instance of the current `ShellClient`
     /// - Parameter workspace: An instance of the current `WorkspaceClient`
-    public init(_ workspace: WorkspaceClient?) {
+    public init(
+        shellClient: ShellClient,
+        workspace: WorkspaceClient?
+    ) {
         self.workspace = workspace
         if let folderURL = workspace?.folderURL() {
             self.gitClient = GitClient.default(
                 directoryURL: folderURL,
-                shellClient: .live()
+                shellClient: shellClient
             )
         }
         self._currentBranch = State(initialValue: try? gitClient?.getCurrentBranchName())
     }
-
-    @State
-    private var isHovering: Bool = false
-
-    @State
-    private var displayPopover: Bool = false
 
     public var body: some View {
         HStack(alignment: .center, spacing: 5) {

--- a/CodeEditModules/Modules/Git/src/Client/Interface.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Interface.swift
@@ -4,15 +4,15 @@
 //
 //  Created by Marco Carnevali on 21/03/22.
 //
-
 import Foundation
+import Combine
 
 public struct GitClient {
     public var getCurrentBranchName: () throws -> String
     public var getBranches: (Bool) throws -> [String]
     public var checkoutBranch: (String) throws -> Void
     public var pull: () throws -> Void
-    public var cloneRepository: (String) throws -> Void
+    public var cloneRepository: (String) -> AnyPublisher<CloneProgressResult, GitClientError>
     /// Get commit history
     /// - Parameters:
     ///   - entries: number of commits we want to fetch. Will use max if nil
@@ -25,7 +25,7 @@ public struct GitClient {
         getBranches: @escaping (Bool) throws -> [String],
         checkoutBranch: @escaping (String) throws -> Void,
         pull: @escaping () throws -> Void,
-        cloneRepository: @escaping (String) throws -> Void,
+        cloneRepository: @escaping (String) -> AnyPublisher<CloneProgressResult, GitClientError>,
         getCommitHistory: @escaping (_ entries: Int?, _ fileLocalPath: String?) throws -> [Commit]
     ) {
         self.getCurrentBranchName = getCurrentBranchName
@@ -39,5 +39,11 @@ public struct GitClient {
     public enum GitClientError: Error {
         case outputError(String)
         case notGitRepository
+    }
+
+    public enum CloneProgressResult {
+        case receivingProgress(Int)
+        case resolvingProgress(Int)
+        case other(String)
     }
 }

--- a/CodeEditModules/Modules/ShellClient/src/Live.swift
+++ b/CodeEditModules/Modules/ShellClient/src/Live.swift
@@ -46,8 +46,11 @@ public extension ShellClient {
                             subject.send(completion: .finished)
                             return
                         }
-                        if let line = String(data: data, encoding: .utf8) {
-                            subject.send(line)
+                        if let line = String(data: data, encoding: .utf8)?
+                            .split(whereSeparator: \.isNewline) {
+                            line
+                                .map(String.init)
+                                .forEach(subject.send(_:))
                         }
                         outputHandler.waitForDataInBackgroundAndNotify()
                     }

--- a/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
+++ b/CodeEditModules/Modules/StatusBar/src/Model/StatusBarModel.swift
@@ -7,6 +7,7 @@
 
 import Git
 import SwiftUI
+import ShellClient
 
 public enum StatusBarTab: String, CaseIterable, Identifiable {
     case terminal
@@ -104,11 +105,11 @@ public class StatusBarModel: ObservableObject {
     /// Initialize with a GitClient
     /// - Parameter workspaceURL: the current workspace URL
     ///
-    public init(workspaceURL: URL) {
+    public init(shellClient: ShellClient, workspaceURL: URL) {
         self.workspaceURL = workspaceURL
         gitClient = GitClient.default(
             directoryURL: workspaceURL,
-            shellClient: .live()
+            shellClient: shellClient
         )
         do {
             let selectedBranch = try gitClient.getCurrentBranchName()

--- a/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
@@ -108,7 +108,7 @@ struct SwiftUIView_Previews: PreviewProvider {
     static var previews: some View {
         ZStack(alignment: .bottom) {
             Color.white
-            StatusBarView(model: StatusBarModel(workspaceURL: URL(fileURLWithPath: "")))
+            StatusBarView(model: StatusBarModel(shellClient: .live(), workspaceURL: URL(fileURLWithPath: "")))
                 .previewLayout(.fixed(width: 1.336, height: 500.0))
                 .preferredColorScheme(.light)
         }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarDrawer/BottomBar/StatusBarClearButton.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarDrawer/BottomBar/StatusBarClearButton.swift
@@ -29,6 +29,6 @@ internal struct StatusBarClearButton: View {
 struct StatusBarClearButton_Previews: PreviewProvider {
     static var previews: some View {
         let url = URL(string: "~/Developer")!
-        StatusBarClearButton(model: StatusBarModel(workspaceURL: url))
+        StatusBarClearButton(model: StatusBarModel(shellClient: .live(), workspaceURL: url))
     }
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarDrawer/BottomBar/StatusBarMaximizeButton.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarDrawer/BottomBar/StatusBarMaximizeButton.swift
@@ -29,6 +29,6 @@ internal struct StatusBarMaximizeButton: View {
 struct StatusBarMaximizeButton_Previews: PreviewProvider {
     static var previews: some View {
         let url = URL(string: "~/Developer")!
-        StatusBarMaximizeButton(model: StatusBarModel(workspaceURL: url))
+        StatusBarMaximizeButton(model: StatusBarModel(shellClient: .live(), workspaceURL: url))
     }
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarDrawer/BottomBar/StatusBarSplitTerminalButton.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarDrawer/BottomBar/StatusBarSplitTerminalButton.swift
@@ -29,6 +29,6 @@ internal struct StatusBarSplitTerminalButton: View {
 struct StatusBarSplitTerminalButton_Previews: PreviewProvider {
     static var previews: some View {
         let url = URL(string: "~/Developer")!
-        StatusBarSplitTerminalButton(model: StatusBarModel(workspaceURL: url))
+        StatusBarSplitTerminalButton(model: StatusBarModel(shellClient: .live(), workspaceURL: url))
     }
 }

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarBreakpointButton.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarBreakpointButton.swift
@@ -35,6 +35,6 @@ internal struct StatusBarBreakpointButton: View {
 struct StatusBarBreakpointButton_Previews: PreviewProvider {
     static var previews: some View {
         let url = URL(string: "~/Developer")!
-        StatusBarBreakpointButton(model: StatusBarModel(workspaceURL: url))
+        StatusBarBreakpointButton(model: StatusBarModel(shellClient: .live(), workspaceURL: url))
     }
 }

--- a/CodeEditModules/Modules/WelcomeModule/src/WelcomeView.swift
+++ b/CodeEditModules/Modules/WelcomeModule/src/WelcomeView.swift
@@ -10,6 +10,7 @@ import AppKit
 import Foundation
 import AppPreferences
 import Git
+import ShellClient
 
 public struct WelcomeView: View {
     @Environment(\.colorScheme) var colorScheme
@@ -23,12 +24,15 @@ public struct WelcomeView: View {
     private let openDocument: (URL?, @escaping () -> Void) -> Void
     private let newDocument: () -> Void
     private let dismissWindow: () -> Void
+    private let shellClient: ShellClient
 
     public init(
+        shellClient: ShellClient,
         openDocument: @escaping (URL?, @escaping () -> Void) -> Void,
         newDocument: @escaping () -> Void,
         dismissWindow: @escaping () -> Void
     ) {
+        self.shellClient = shellClient
         self.openDocument = openDocument
         self.newDocument = newDocument
         self.dismissWindow = dismissWindow
@@ -203,15 +207,19 @@ public struct WelcomeView: View {
             }
         }
         .sheet(isPresented: $showGitClone) {
-            GitCloneView(shellClient: .live(),
-                         isPresented: $showGitClone,
-                         showCheckout: $showCheckoutBranch,
-                         repoPath: $repoPath)
+            GitCloneView(
+                shellClient: shellClient,
+                isPresented: $showGitClone,
+                showCheckout: $showCheckoutBranch,
+                repoPath: $repoPath
+            )
         }
         .sheet(isPresented: $showCheckoutBranch) {
-            CheckoutBranchView(isPresented: $showCheckoutBranch,
-                                repoPath: $repoPath,
-                               shellClient: .live())
+            CheckoutBranchView(
+                isPresented: $showCheckoutBranch,
+                repoPath: $repoPath,
+                shellClient: shellClient
+            )
         }
     }
 
@@ -240,6 +248,7 @@ public struct WelcomeView: View {
 struct WelcomeView_Previews: PreviewProvider {
     static var previews: some View {
         WelcomeView(
+            shellClient: .live(),
             openDocument: { _, _  in },
             newDocument: {},
             dismissWindow: {}

--- a/CodeEditModules/Modules/WelcomeModule/src/WelcomeWindowView.swift
+++ b/CodeEditModules/Modules/WelcomeModule/src/WelcomeWindowView.swift
@@ -6,18 +6,22 @@
 //
 
 import SwiftUI
+import ShellClient
 
 public struct WelcomeWindowView: View {
 
     private let openDocument: (URL?, @escaping () -> Void) -> Void
     private let newDocument: () -> Void
     private let dismissWindow: () -> Void
+    private let shellClient: ShellClient
 
     public init(
+        shellClient: ShellClient,
         openDocument: @escaping (URL?, @escaping () -> Void) -> Void,
         newDocument: @escaping () -> Void,
         dismissWindow: @escaping () -> Void
     ) {
+        self.shellClient = shellClient
         self.openDocument = openDocument
         self.newDocument = newDocument
         self.dismissWindow = dismissWindow
@@ -26,6 +30,7 @@ public struct WelcomeWindowView: View {
     public var body: some View {
         HStack(spacing: 0) {
             WelcomeView(
+                shellClient: shellClient,
                 openDocument: openDocument,
                 newDocument: newDocument,
                 dismissWindow: dismissWindow


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->
This PR contains a couple of changes that I will list below: 
1. Fix for the shellClient live implementation where it parses newlines so it ensure that the string published represent only 1 line
2. Fix for the shellClient initialisation. Previously the client was initialized inside each consumer. This is a bad behaviour, the client should be injected to each consumer and only one instance should be used. To do this I've created a new `World` struct that will hold clients like the shellClient. I've added a comment with a video that explains what the world is and how it can be used. It's a really powerful concept!
3. I've added a code (that should be improved in the future) that parse the clone repository progress and  republish the content

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #ISSUE_NUMBER

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
