### PR TITLE
Disable tab's context menu option when unavailable.

### DIFF
--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -331,6 +331,8 @@ struct TabBarItem: View {
                     workspace.closeTabs(after: item.tabID)
                 }
             }
+            // Disable this option when current tab is the last one.
+            .disabled(workspace.selectionState.openedTabs.last?.id == item.tabID.id)
         }
     }
 }


### PR DESCRIPTION
# Description

* When focused tab is the trailing one, "close tabs to the right" option in context menu should be disabled.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #572
(Consideration 3)

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/36816148/166505723-f5bbcc45-9aaa-4abb-aeb5-58dba396bf35.mp4
