### PR TITLE
Fixed Statusbar Divider Color

### DIFF
--- a/CodeEditModules/Modules/CodeEditUI/src/PanelDivider.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/PanelDivider.swift
@@ -14,12 +14,11 @@ public struct PanelDivider: View {
     public init() {}
 
     public var body: some View {
-        Rectangle()
-            .foregroundColor(
-                Color(nsColor: .black)
+        Divider()
+            .opacity(0)
+            .overlay(
+                Color(.black)
                     .opacity(colorScheme == .dark ? 0.65 : 0.13)
-
             )
-            .frame(height: 1.0)
     }
 }

--- a/CodeEditModules/Modules/CodeEditUI/src/PanelDivider.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/PanelDivider.swift
@@ -1,0 +1,25 @@
+//
+//  PanelDivider.swift
+//  
+//
+//  Created by Austin Condiff on 5/10/22.
+//
+
+import SwiftUI
+
+public struct PanelDivider: View {
+    @Environment(\.colorScheme)
+    private var colorScheme
+
+    public init() {}
+
+    public var body: some View {
+        Rectangle()
+            .foregroundColor(
+                Color(nsColor: .black)
+                    .opacity(colorScheme == .dark ? 0.65 : 0.13)
+
+            )
+            .frame(height: 1.0)
+    }
+}

--- a/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBar.swift
@@ -68,11 +68,11 @@ public struct StatusBarView: View {
             .padding(.horizontal, 10)
         }
         .overlay(alignment: .top) {
-            Divider()
+            PanelDivider()
         }
         .overlay(alignment: .bottom) {
             if model.isExpanded {
-                Divider()
+                PanelDivider()
             }
         }
         .frame(height: 29)

--- a/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarCursorLocationLabel.swift
+++ b/CodeEditModules/Modules/StatusBar/src/StatusBarItems/StatusBarCursorLocationLabel.swift
@@ -19,7 +19,7 @@ internal struct StatusBarCursorLocationLabel: View {
     }
 
     internal var body: some View {
-        Text("Ln \(model.currentLine), Col \(model.currentCol)")
+        Text("Line: \(model.currentLine)  Col: \(model.currentCol)")
             .font(model.toolbarFont)
             .foregroundColor(foregroundColor)
             .fixedSize()


### PR DESCRIPTION
# Description

Statusbar dividers should be black in dark mode instead of the default Divider transparent white. This PR fixes the color and adds a new PanelDivider to CodeEditUI.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #605

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="552" alt="image" src="https://user-images.githubusercontent.com/806104/167559067-b514841e-2295-46e9-9aa6-31f8e46d3568.png">