### PR TITLE
Add UTType support for openAsMenu

### DIFF
--- a/CodeEditModules/Modules/ShellClient/src/Live.swift
+++ b/CodeEditModules/Modules/ShellClient/src/Live.swift
@@ -35,7 +35,7 @@ public extension ShellClient {
                 cancellables[id] = NotificationCenter
                     .default
                     .publisher(for: .NSFileHandleDataAvailable, object: outputHandler)
-                    .sink { _ in
+                    .sink { _ in
                         let data = outputHandler.availableData
                         // swiftlint:disable:next empty_count
                         guard data.count > 0 else {

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import TabBar
+import UniformTypeIdentifiers
 
 public extension WorkspaceClient {
     enum FileItemCodingKeys: String, CodingKey {
@@ -23,11 +24,11 @@ public extension WorkspaceClient {
         }
 
         public var title: String {
-            self.url.lastPathComponent
+            url.lastPathComponent
         }
 
         public var icon: Image {
-            Image(systemName: self.systemImage)
+            Image(systemName: systemImage)
         }
 
         public typealias ID = String
@@ -105,8 +106,13 @@ public extension WorkspaceClient {
         }
 
         /// Returns the extension of the file or an empty string if no extension is present.
-        private var fileType: String {
-            url.lastPathComponent.components(separatedBy: ".").last ?? ""
+        public var fileType: String {
+            url.pathExtension
+        }
+
+        /// Return the file's UTType
+        public var contentType: UTType? {
+            try? url.resourceValues(forKeys: [.contentTypeKey]).contentType
         }
 
         /// Returns a string describing a SFSymbol for folders
@@ -115,10 +121,10 @@ public extension WorkspaceClient {
         /// If it is a `.codeedit` folder this will return `"folder.fill.badge.gearshape"`.
         /// If it has children this will return `"folder.fill"` otherwise `"folder"`.
         private func folderIcon(_ children: [FileItem]) -> String {
-            if self.parent == nil {
+            if parent == nil {
                 return "square.dashed.inset.filled"
             }
-            if self.fileName == ".codeedit" {
+            if fileName == ".codeedit" {
                 return "folder.fill.badge.gearshape"
             }
             return children.isEmpty ? "folder" : "folder.fill"


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->

Xcode will show different openAsMenu result for different file type.

This PR add such feature. (And instead of using fileType/extension, I think we'd better use the UTType for identifying different file type)

- Add UTType support for openAsMenu
- Fix `fileType` implementation issue
   - (eg. call fileType on "/example/CodeEdit/" item will get "CodeEdit" instead of an empty string as expected)

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
