### PR TITLE
Fix navigation sidebar top divider color issue.

### DIFF
--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -86,7 +86,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
             // In xcode tab bar style, we use default toolbar background with
             // line separator.
             self.window?.titlebarAppearsTransparent = false
-            self.window?.titlebarSeparatorStyle = .line
+            self.window?.titlebarSeparatorStyle = .automatic
         }
         self.window?.toolbar = toolbar
     }

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -150,7 +150,7 @@ struct WorkspaceView: View {
                     windowController.window?.titlebarSeparatorStyle = .none
                 } else {
                     windowController.window?.titlebarAppearsTransparent = false
-                    windowController.window?.titlebarSeparatorStyle = .line
+                    windowController.window?.titlebarSeparatorStyle = .automatic
                 }
             }
         }


### PR DESCRIPTION
# Description

Fix the incorrect color at the top divider of navigation sidebar.

# Related Issue

* #602 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="557" alt="CleanShot 2022-05-15 at 17 50 45@2x" src="https://user-images.githubusercontent.com/36816148/168495305-25ef8b88-e292-43ec-8879-494fef0faeab.png">

<img width="515" alt="CleanShot 2022-05-15 at 17 46 44@2x" src="https://user-images.githubusercontent.com/36816148/168495206-10a650fb-2a7d-4928-b0f3-8afb759ab71f.png">

