### PR TITLE
[WIP] Automatic forward on autocompletion pairs

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>8aca261a483dd996548d0090ba604c04126321d4</string>
+	<string>014dc9e37f3a985f929cc84c2a40fd3a7e253930</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>014dc9e37f3a985f929cc84c2a40fd3a7e253930</string>
+	<string>ce3c4e99ff52b518fcd941c0fdd8fe73c87c999f</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/CodeFile/src/TextView/CodeEditorTextView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/TextView/CodeEditorTextView.swift
@@ -95,10 +95,27 @@ public final class CodeEditorTextView: NSTextView {
     }
 
     public override func insertText(_ string: Any, replacementRange: NSRange) {
+        let nextChar = getNextCharacter()
+        if autoPairs.values.contains(nextChar)
+                && string as? String == nextChar {
+            super.moveForward(self)
+            return
+        }
         super.insertText(string, replacementRange: replacementRange)
         guard let string = string as? String
         else { return }
         self.autocompleteSymbols(string)
+    }
+
+    private func getNextCharacter() -> String {
+        let index = swiftSelectedRange.lowerBound
+        let max = self.string.index(self.string.endIndex, offsetBy: -1)
+        if index <= max {
+            return String(self.string[index])
+        }
+        else {
+            return ""
+        }
     }
 
     public override func insertTab(_ sender: Any?) {

--- a/CodeEditModules/Modules/CodeFile/src/TextView/CodeEditorTextView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/TextView/CodeEditorTextView.swift
@@ -112,8 +112,7 @@ public final class CodeEditorTextView: NSTextView {
         let max = self.string.index(self.string.endIndex, offsetBy: -1)
         if index <= max {
             return String(self.string[index])
-        }
-        else {
+        } else {
             return ""
         }
     }


### PR DESCRIPTION
# Description

Currently, an issue with the pair autocompletion is that when you type the closing character, it will duplicate. For example, you type `(`, it completes to `()`, and if you type `)`, it will become `())` which is undesirable. This PR fixes this issue and automatically skips the closing character, forwarding the cursor. This behavior is standard across all code editors and IDEs, including Xcode.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
