### PR TITLE
Source Control Navigator: Added support for viewing file changes

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -30,6 +30,13 @@
 		04C3256C28034FC800C8DA2D /* CodeEditKit in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 04C3256A28034FC800C8DA2D /* CodeEditKit */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		200412EF280F3EAC00BCAF5C /* NoCommitHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200412EE280F3EAC00BCAF5C /* NoCommitHistoryView.swift */; };
 		2004A3832808468600FD9696 /* Feedback in Frameworks */ = {isa = PBXBuildFile; productRef = 2004A3822808468600FD9696 /* Feedback */; };
+		201169D72837B2E300F92B46 /* SourceControlNavigatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201169D62837B2E300F92B46 /* SourceControlNavigatorView.swift */; };
+		201169D92837B31200F92B46 /* SourceControlSearchToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201169D82837B31200F92B46 /* SourceControlSearchToolbar.swift */; };
+		201169DB2837B34000F92B46 /* ChangedFileItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201169DA2837B34000F92B46 /* ChangedFileItemView.swift */; };
+		201169DD2837B3AC00F92B46 /* SourceControlToolbarBottom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201169DC2837B3AC00F92B46 /* SourceControlToolbarBottom.swift */; };
+		201169E22837B3D800F92B46 /* ChangesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201169E12837B3D800F92B46 /* ChangesView.swift */; };
+		201169E52837B40300F92B46 /* RepositoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201169E42837B40300F92B46 /* RepositoriesView.swift */; };
+		201169E72837B5CA00F92B46 /* SourceControlModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201169E62837B5CA00F92B46 /* SourceControlModel.swift */; };
 		2040F0B1280AE96100411B6F /* CodeEditUtils in Frameworks */ = {isa = PBXBuildFile; productRef = 2040F0B0280AE96100411B6F /* CodeEditUtils */; };
 		2072FA13280D74ED00C7F8D4 /* HistoryInspectorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2072FA12280D74ED00C7F8D4 /* HistoryInspectorModel.swift */; };
 		2072FA16280D83A500C7F8D4 /* FileTypeList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2072FA15280D83A500C7F8D4 /* FileTypeList.swift */; };
@@ -163,6 +170,13 @@
 		04C3254E2800AA4700C8DA2D /* ExtensionInstallationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInstallationView.swift; sourceTree = "<group>"; };
 		04C325502800AC7400C8DA2D /* ExtensionInstallationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInstallationViewModel.swift; sourceTree = "<group>"; };
 		200412EE280F3EAC00BCAF5C /* NoCommitHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoCommitHistoryView.swift; sourceTree = "<group>"; };
+		201169D62837B2E300F92B46 /* SourceControlNavigatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlNavigatorView.swift; sourceTree = "<group>"; };
+		201169D82837B31200F92B46 /* SourceControlSearchToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlSearchToolbar.swift; sourceTree = "<group>"; };
+		201169DA2837B34000F92B46 /* ChangedFileItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedFileItemView.swift; sourceTree = "<group>"; };
+		201169DC2837B3AC00F92B46 /* SourceControlToolbarBottom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlToolbarBottom.swift; sourceTree = "<group>"; };
+		201169E12837B3D800F92B46 /* ChangesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesView.swift; sourceTree = "<group>"; };
+		201169E42837B40300F92B46 /* RepositoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoriesView.swift; sourceTree = "<group>"; };
+		201169E62837B5CA00F92B46 /* SourceControlModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlModel.swift; sourceTree = "<group>"; };
 		2072FA12280D74ED00C7F8D4 /* HistoryInspectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryInspectorModel.swift; sourceTree = "<group>"; };
 		2072FA15280D83A500C7F8D4 /* FileTypeList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeList.swift; sourceTree = "<group>"; };
 		2072FA17280D871200C7F8D4 /* TextEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEncoding.swift; sourceTree = "<group>"; };
@@ -309,6 +323,52 @@
 			path = ExtensionNavigator;
 			sourceTree = "<group>";
 		};
+		201169D52837B29600F92B46 /* SourceControlNavigator */ = {
+			isa = PBXGroup;
+			children = (
+				201169DF2837B3CB00F92B46 /* Model */,
+				201169DE2837B3C700F92B46 /* Views */,
+				201169D62837B2E300F92B46 /* SourceControlNavigatorView.swift */,
+				201169D82837B31200F92B46 /* SourceControlSearchToolbar.swift */,
+				201169DC2837B3AC00F92B46 /* SourceControlToolbarBottom.swift */,
+			);
+			path = SourceControlNavigator;
+			sourceTree = "<group>";
+		};
+		201169DE2837B3C700F92B46 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				201169E32837B3EF00F92B46 /* Repositories */,
+				201169E02837B3D100F92B46 /* Changes */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		201169DF2837B3CB00F92B46 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				201169E62837B5CA00F92B46 /* SourceControlModel.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		201169E02837B3D100F92B46 /* Changes */ = {
+			isa = PBXGroup;
+			children = (
+				201169E12837B3D800F92B46 /* ChangesView.swift */,
+				201169DA2837B34000F92B46 /* ChangedFileItemView.swift */,
+			);
+			path = Changes;
+			sourceTree = "<group>";
+		};
+		201169E32837B3EF00F92B46 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				201169E42837B40300F92B46 /* RepositoriesView.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
 		2072FA14280D838800C7F8D4 /* Lists */ = {
 			isa = PBXGroup;
 			children = (
@@ -388,6 +448,7 @@
 		287776EA27E350A100D46668 /* NavigatorSidebar */ = {
 			isa = PBXGroup;
 			children = (
+				201169D52837B29600F92B46 /* SourceControlNavigator */,
 				0483E34E27FDB15F00354AC0 /* ExtensionNavigator */,
 				286471AC27ED52950039369D /* ProjectNavigator */,
 				D7012EE627E757660001E1EF /* FindNavigator */,
@@ -816,26 +877,32 @@
 			buildActionMask = 2147483647;
 			files = (
 				2072FA13280D74ED00C7F8D4 /* HistoryInspectorModel.swift in Sources */,
+				201169E52837B40300F92B46 /* RepositoriesView.swift in Sources */,
 				DE513F52281B672D002260B9 /* TabBarAccessory.swift in Sources */,
 				2813F93927ECC4C300E305E4 /* NavigatorSidebar.swift in Sources */,
 				DE513F54281DE5D0002260B9 /* TabBarXcode.swift in Sources */,
 				20EBB50D280C383700F3A5DA /* LanguageType.swift in Sources */,
 				2813F93827ECC4AA00E305E4 /* FindNavigatorResultList.swift in Sources */,
+				201169D92837B31200F92B46 /* SourceControlSearchToolbar.swift in Sources */,
 				0483E35027FDB17700354AC0 /* ExtensionNavigator.swift in Sources */,
+				201169DB2837B34000F92B46 /* ChangedFileItemView.swift in Sources */,
 				2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */,
 				D7012EE827E757850001E1EF /* FindNavigator.swift in Sources */,
 				D7E201AE27E8B3C000CB86D0 /* String+Ranges.swift in Sources */,
 				20EBB50F280C389300F3A5DA /* FileInspectorModel.swift in Sources */,
 				0463E51327FCC1FB00806D5C /* CodeEditTargetsAPI.swift in Sources */,
+				201169DD2837B3AC00F92B46 /* SourceControlToolbarBottom.swift in Sources */,
 				04C3254D27FF331B00C8DA2D /* ExtensionNavigatorItem.swift in Sources */,
 				D7E201B027E8C07300CB86D0 /* FindNavigatorSearchBar.swift in Sources */,
 				2072FA1C280D874000C7F8D4 /* IndentUsing.swift in Sources */,
 				B6EE989227E887C600CDD8AB /* InspectorSidebarToolbar.swift in Sources */,
+				201169E72837B5CA00F92B46 /* SourceControlModel.swift in Sources */,
 				28B8F884280FFE4600596236 /* NSTableView+Background.swift in Sources */,
 				200412EF280F3EAC00BCAF5C /* NoCommitHistoryView.swift in Sources */,
 				043C321427E31FF6006AE443 /* CodeEditDocumentController.swift in Sources */,
 				20EBB503280C327C00F3A5DA /* HistoryInspector.swift in Sources */,
 				2072FA1A280D872600C7F8D4 /* LineEndings.swift in Sources */,
+				201169E22837B3D800F92B46 /* ChangesView.swift in Sources */,
 				20EBB507280C32D300F3A5DA /* QuickHelpInspector.swift in Sources */,
 				DE6405A62817734700881FDF /* TabBarNative.swift in Sources */,
 				04C3255C2801F86900C8DA2D /* OutlineMenu.swift in Sources */,
@@ -861,6 +928,7 @@
 				2072FA16280D83A500C7F8D4 /* FileTypeList.swift in Sources */,
 				04C3254F2800AA4700C8DA2D /* ExtensionInstallationView.swift in Sources */,
 				B6EE989027E8879A00CDD8AB /* InspectorSidebar.swift in Sources */,
+				201169D72837B2E300F92B46 /* SourceControlNavigatorView.swift in Sources */,
 				20D839AB280DEB2900B27357 /* NoSelectionView.swift in Sources */,
 				20EBB505280C329800F3A5DA /* HistoryItem.swift in Sources */,
 				043C321627E3201F006AE443 /* WorkspaceDocument.swift in Sources */,

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>09ab9e64d4f375b6cedb8f7d67398dd692e931b3</string>
+	<string>c15197302b622989e87c6006cebe747daa3980c8</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>8aca261a483dd996548d0090ba604c04126321d4</string>
+	<string>09ab9e64d4f375b6cedb8f7d67398dd692e931b3</string>
 </dict>
 </plist>

--- a/CodeEdit/NavigatorSidebar/NavigatorSidebar.swift
+++ b/CodeEdit/NavigatorSidebar/NavigatorSidebar.swift
@@ -17,6 +17,8 @@ struct NavigatorSidebar: View {
     @State
     private var selection: Int = 0
 
+    private let toolbarPadding: Double = -8.0
+
     init(workspace: WorkspaceDocument, windowController: NSWindowController) {
         self.workspace = workspace
         self.windowController = windowController
@@ -27,6 +29,8 @@ struct NavigatorSidebar: View {
             switch selection {
             case 0:
                 ProjectNavigator(workspace: workspace, windowController: windowController)
+            case 1:
+                SourceControlNavigatorView(workspace: workspace)
             case 2:
                 FindNavigator(state: workspace.searchState ?? .init(workspace))
             case 7:
@@ -38,11 +42,26 @@ struct NavigatorSidebar: View {
         }
         .safeAreaInset(edge: .top) {
             NavigatorSidebarToolbarTop(selection: $selection)
-                .padding(.bottom, -8)
+                .padding(.bottom, toolbarPadding)
         }
         .safeAreaInset(edge: .bottom) {
-            NavigatorSidebarToolbarBottom(workspace: workspace)
-                .padding(.top, -8)
+            switch selection {
+            case 0:
+                NavigatorSidebarToolbarBottom(workspace: workspace)
+                    .padding(.top, toolbarPadding)
+            case 1:
+                SourceControlToolbarBottom()
+                    .padding(.top, toolbarPadding)
+            case 2:
+                NavigatorSidebarToolbarBottom(workspace: workspace)
+                    .padding(.top, toolbarPadding)
+            case 7:
+                NavigatorSidebarToolbarBottom(workspace: workspace)
+                    .padding(.top, toolbarPadding)
+            default:
+                NavigatorSidebarToolbarBottom(workspace: workspace)
+                    .padding(.top, toolbarPadding)
+            }
         }
     }
 }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -180,9 +180,9 @@ extension OutlineViewController: NSOutlineViewDelegate {
         case .showAll:
             return item.fileName(typeHidden: false)
         case .showOnly:
-            return item.fileName(typeHidden: !shownFileExtensions.extensions.contains(item.fileType))
+            return item.fileName(typeHidden: !shownFileExtensions.extensions.contains(item.fileType.rawValue))
         case .hideOnly:
-            return item.fileName(typeHidden: hiddenFileExtensions.extensions.contains(item.fileType))
+            return item.fileName(typeHidden: hiddenFileExtensions.extensions.contains(item.fileType.rawValue))
         }
     }
 

--- a/CodeEdit/NavigatorSidebar/SourceControlNavigator/Model/SourceControlModel.swift
+++ b/CodeEdit/NavigatorSidebar/SourceControlNavigator/Model/SourceControlModel.swift
@@ -20,7 +20,7 @@ public final class SourceControlModel: ObservableObject {
 
     /// A list of changed files
     @Published
-    public var changed: [ChangedFiles]
+    public var changed: [ChangedFile]
 
     /// Initialize with a GitClient
     /// - Parameter workspaceURL: the current workspace URL we also need this to open files in finder

--- a/CodeEdit/NavigatorSidebar/SourceControlNavigator/Model/SourceControlModel.swift
+++ b/CodeEdit/NavigatorSidebar/SourceControlNavigator/Model/SourceControlModel.swift
@@ -1,0 +1,40 @@
+//
+//  SourceControlModel.swift
+//  CodeEdit
+//
+//  Created by Nanashi Li on 2022/05/20.
+//
+
+import Foundation
+import Git
+
+/// This model handle the fetching and adding of changes etc... for the
+/// Source Control Navigator
+public final class SourceControlModel: ObservableObject {
+
+    /// A GitClient instance
+    let gitClient: GitClient
+
+    /// The base URL of the workspace
+    let workspaceURL: URL
+
+    /// A list of changed files
+    @Published
+    public var changed: [ChangedFiles]
+
+    /// Initialize with a GitClient
+    /// - Parameter workspaceURL: the current workspace URL we also need this to open files in finder
+    ///
+    public init(workspaceURL: URL) {
+        self.workspaceURL = workspaceURL
+        gitClient = GitClient.default(
+            directoryURL: workspaceURL,
+            shellClient: Current.shellClient
+        )
+        do {
+            changed = try gitClient.getChangedFiles()
+        } catch {
+            changed = []
+        }
+    }
+}

--- a/CodeEdit/NavigatorSidebar/SourceControlNavigator/SourceControlNavigatorView.swift
+++ b/CodeEdit/NavigatorSidebar/SourceControlNavigator/SourceControlNavigatorView.swift
@@ -1,0 +1,47 @@
+//
+//  SourceControlNavigatorView.swift
+//  CodeEdit
+//
+//  Created by Nanashi Li on 2022/05/20.
+//
+
+import SwiftUI
+import CodeEditUI
+
+struct SourceControlNavigatorView: View {
+
+    @ObservedObject
+    private var workspace: WorkspaceDocument
+
+    @State
+    private var selectedSection: Int = 0
+
+    init(workspace: WorkspaceDocument) {
+        self.workspace = workspace
+    }
+
+    var body: some View {
+        VStack {
+            SegmentedControl($selectedSection,
+                             options: ["Changes", "Repositories"],
+                             prominent: true)
+            .frame(maxWidth: .infinity)
+            .frame(height: 27)
+            .padding(.horizontal, 8)
+            .padding(.bottom, 2)
+            .overlay(alignment: .bottom) {
+                Divider()
+            }
+
+            if selectedSection == 0 {
+                if let urlString = workspace.fileURL {
+                    ChangesView(workspaceURL: urlString)
+                }
+            }
+
+            if selectedSection == 1 {
+                RepositoriesView()
+            }
+        }
+    }
+}

--- a/CodeEdit/NavigatorSidebar/SourceControlNavigator/SourceControlSearchToolbar.swift
+++ b/CodeEdit/NavigatorSidebar/SourceControlNavigator/SourceControlSearchToolbar.swift
@@ -1,0 +1,57 @@
+//
+//  SourceControlSearchToolbar.swift
+//  CodeEdit
+//
+//  Created by Nanashi Li on 2022/05/20.
+//
+
+import SwiftUI
+import CodeEditUI
+
+struct SourceControlSearchToolbar: View {
+
+    @Environment(\.colorScheme)
+    var colorScheme
+
+    @Environment(\.controlActiveState)
+    private var controlActive
+
+    @State
+    private var text = ""
+
+    var body: some View {
+        HStack {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .foregroundColor(.secondary)
+            textField
+            if !text.isEmpty { clearButton }
+        }
+        .padding(.horizontal, 5)
+        .padding(.vertical, 3)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.gray, lineWidth: 0.5).cornerRadius(6))
+    }
+
+    private var textField: some View {
+        TextField("Filter", text: $text)
+            .disableAutocorrection(true)
+            .textFieldStyle(PlainTextFieldStyle())
+    }
+
+    private var clearButton: some View {
+        Button {
+            self.text = ""
+        } label: {
+            Image(systemName: "xmark.circle.fill")
+        }
+        .foregroundColor(.secondary)
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+struct SourceControlSearchToolbar_Previews: PreviewProvider {
+    static var previews: some View {
+        SourceControlSearchToolbar()
+    }
+}

--- a/CodeEdit/NavigatorSidebar/SourceControlNavigator/SourceControlToolbarBottom.swift
+++ b/CodeEdit/NavigatorSidebar/SourceControlNavigator/SourceControlToolbarBottom.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SourceControlToolbarBottom: View {
     var body: some View {
         HStack(spacing: 0) {
-            addNewFileButton
+            sourceControlMenu
             SourceControlSearchToolbar()
         }
         .frame(height: 29, alignment: .center)
@@ -21,7 +21,7 @@ struct SourceControlToolbarBottom: View {
         }
     }
 
-    private var addNewFileButton: some View {
+    private var sourceControlMenu: some View {
         Menu {
             Button("Discard Changes...") {}
                 .disabled(true) // TODO: Implementation Needed

--- a/CodeEdit/NavigatorSidebar/SourceControlNavigator/SourceControlToolbarBottom.swift
+++ b/CodeEdit/NavigatorSidebar/SourceControlNavigator/SourceControlToolbarBottom.swift
@@ -1,0 +1,47 @@
+//
+//  SourceControlToolbarBottom.swift
+//  CodeEdit
+//
+//  Created by Nanashi Li on 2022/05/20.
+//
+
+import SwiftUI
+
+struct SourceControlToolbarBottom: View {
+    var body: some View {
+        HStack(spacing: 0) {
+            addNewFileButton
+            SourceControlSearchToolbar()
+        }
+        .frame(height: 29, alignment: .center)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 4)
+        .overlay(alignment: .top) {
+            Divider()
+        }
+    }
+
+    private var addNewFileButton: some View {
+        Menu {
+            Button("Discard Changes...") {}
+                .disabled(true) // TODO: Implementation Needed
+            Button("Stash Changes...") {}
+                .disabled(true) // TODO: Implementation Needed
+            Button("Commit...") {}
+                .disabled(true) // TODO: Implementation Needed
+            Button("Create Pull Request...") {}
+                .disabled(true) // TODO: Implementation Needed
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(maxWidth: 30)
+    }
+}
+
+struct SourceControlToolbarBottom_Previews: PreviewProvider {
+    static var previews: some View {
+        SourceControlToolbarBottom()
+    }
+}

--- a/CodeEdit/NavigatorSidebar/SourceControlNavigator/Views/Changes/ChangedFileItemView.swift
+++ b/CodeEdit/NavigatorSidebar/SourceControlNavigator/Views/Changes/ChangedFileItemView.swift
@@ -1,0 +1,62 @@
+//
+//  ChangedFileItemView.swift
+//  CodeEdit
+//
+//  Created by Nanashi Li on 2022/05/20.
+//
+
+import SwiftUI
+ import Git
+
+ struct ChangedFileItemView: View {
+
+     @State
+     var changedFile: ChangedFiles
+     @State
+     var workspaceURL: URL
+
+     var body: some View {
+         HStack {
+             Image(systemName: changedFile.systemImage)
+                 .frame(width: 11, height: 11)
+                 .foregroundColor(changedFile.iconColor)
+             Text(changedFile.fileName)
+                 .font(.system(size: 11))
+                 .foregroundColor(.primary)
+         }
+         .contextMenu {
+             Group {
+                 Button("View in Finder") {
+                     changedFile.showInFinder(workspaceURL: workspaceURL)
+                 }
+                 Button("Reveal in Project Navigator") {}
+                     .disabled(true) // TODO: Implementation Needed
+                 Divider()
+             }
+             Group {
+                 Button("Open in New Tab") {}
+                     .disabled(true) // TODO: Implementation Needed
+                 Button("Open in New Window") {}
+                     .disabled(true) // TODO: Implementation Needed
+                 Button("Open with External Editor") {}
+                     .disabled(true) // TODO: Implementation Needed
+             }
+             Group {
+                 Divider()
+                 Button("Commit \(changedFile.fileName)...") {}
+                     .disabled(true) // TODO: Implementation Needed
+                 Divider()
+                 Button("Discard Changes in \(changedFile.fileName)...") {}
+                     .disabled(true) // TODO: Implementation Needed
+                 Divider()
+             }
+             Group {
+                 Button("Add \(changedFile.fileName)") {}
+                     .disabled(true) // TODO: Implementation Needed
+                 Button("Mark \(changedFile.fileName) as Resolved") {}
+                     .disabled(true) // TODO: Implementation Needed
+             }
+         }
+         .padding(.leading, 15)
+     }
+ }

--- a/CodeEdit/NavigatorSidebar/SourceControlNavigator/Views/Changes/ChangedFileItemView.swift
+++ b/CodeEdit/NavigatorSidebar/SourceControlNavigator/Views/Changes/ChangedFileItemView.swift
@@ -11,7 +11,7 @@ import SwiftUI
  struct ChangedFileItemView: View {
 
      @State
-     var changedFile: ChangedFiles
+     var changedFile: ChangedFile
      @State
      var workspaceURL: URL
 

--- a/CodeEdit/NavigatorSidebar/SourceControlNavigator/Views/Changes/ChangesView.swift
+++ b/CodeEdit/NavigatorSidebar/SourceControlNavigator/Views/Changes/ChangesView.swift
@@ -15,7 +15,7 @@ struct ChangesView: View {
     var model: SourceControlModel
 
     @State
-    var selectedFile: ChangedFiles.ID?
+    var selectedFile: ChangedFile.ID?
 
     /// Initialize with GitClient
     /// - Parameter gitClient: a GitClient

--- a/CodeEdit/NavigatorSidebar/SourceControlNavigator/Views/Changes/ChangesView.swift
+++ b/CodeEdit/NavigatorSidebar/SourceControlNavigator/Views/Changes/ChangesView.swift
@@ -1,0 +1,47 @@
+//
+//  ChangesView.swift
+//  CodeEdit
+//
+//  Created by Nanashi Li on 2022/05/20.
+//
+
+import SwiftUI
+import CodeEditUI
+import Git
+
+struct ChangesView: View {
+
+    @ObservedObject
+    var model: SourceControlModel
+
+    @State
+    var selectedFile: ChangedFiles.ID?
+
+    /// Initialize with GitClient
+    /// - Parameter gitClient: a GitClient
+    init(workspaceURL: URL) {
+        self.model = .init(workspaceURL: workspaceURL)
+    }
+
+    var body: some View {
+        VStack(alignment: .center) {
+            if model.changed.isEmpty {
+                Text("No Changes")
+                    .font(.system(size: 16))
+                    .foregroundColor(.secondary)
+            } else {
+                List(selection: $selectedFile) {
+                    Section("Local Changes") {
+                        ForEach(model.changed) { file in
+                            ChangedFileItemView(changedFile: file,
+                                                workspaceURL: model.workspaceURL)
+                        }
+                    }
+                    .foregroundColor(.secondary)
+                }
+                .listStyle(.sidebar)
+            }
+        }
+        .frame(maxHeight: .infinity)
+    }
+}

--- a/CodeEdit/NavigatorSidebar/SourceControlNavigator/Views/Repositories/RepositoriesView.swift
+++ b/CodeEdit/NavigatorSidebar/SourceControlNavigator/Views/Repositories/RepositoriesView.swift
@@ -1,0 +1,23 @@
+//
+//  RepositoriesView.swift
+//  CodeEdit
+//
+//  Created by Nanashi Li on 2022/05/20.
+//
+
+import SwiftUI
+
+struct RepositoriesView: View {
+    var body: some View {
+        VStack(alignment: .center) {
+            Text("Needs Implementation")
+        }
+        .frame(maxHeight: .infinity)
+    }
+}
+
+struct RepositoriesView_Previews: PreviewProvider {
+    static var previews: some View {
+        RepositoriesView()
+    }
+}

--- a/CodeEditModules/Modules/Git/src/Client/Interface.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Interface.swift
@@ -13,6 +13,9 @@ public struct GitClient {
     public var checkoutBranch: (String) throws -> Void
     public var pull: () throws -> Void
     public var cloneRepository: (String) -> AnyPublisher<CloneProgressResult, GitClientError>
+    /// Displays paths that have differences between the index file and the current HEAD commit,
+    /// paths that have differences between the working tree and the index file, and paths in the working tree
+    public var getChangedFiles: () throws -> [ChangedFiles]
     /// Get commit history
     /// - Parameters:
     ///   - entries: number of commits we want to fetch. Will use max if nil
@@ -26,6 +29,7 @@ public struct GitClient {
         checkoutBranch: @escaping (String) throws -> Void,
         pull: @escaping () throws -> Void,
         cloneRepository: @escaping (String) -> AnyPublisher<CloneProgressResult, GitClientError>,
+        getChangedFiles: @escaping () throws -> [ChangedFiles],
         getCommitHistory: @escaping (_ entries: Int?, _ fileLocalPath: String?) throws -> [Commit]
     ) {
         self.getCurrentBranchName = getCurrentBranchName
@@ -33,12 +37,14 @@ public struct GitClient {
         self.checkoutBranch = checkoutBranch
         self.pull = pull
         self.cloneRepository = cloneRepository
+        self.getChangedFiles = getChangedFiles
         self.getCommitHistory = getCommitHistory
     }
 
     public enum GitClientError: Error {
         case outputError(String)
         case notGitRepository
+        case failedToDecodeURL
     }
 
     public enum CloneProgressResult {

--- a/CodeEditModules/Modules/Git/src/Client/Interface.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Interface.swift
@@ -15,7 +15,7 @@ public struct GitClient {
     public var cloneRepository: (String) -> AnyPublisher<CloneProgressResult, GitClientError>
     /// Displays paths that have differences between the index file and the current HEAD commit,
     /// paths that have differences between the working tree and the index file, and paths in the working tree
-    public var getChangedFiles: () throws -> [ChangedFiles]
+    public var getChangedFiles: () throws -> [ChangedFile]
     /// Get commit history
     /// - Parameters:
     ///   - entries: number of commits we want to fetch. Will use max if nil
@@ -29,7 +29,7 @@ public struct GitClient {
         checkoutBranch: @escaping (String) throws -> Void,
         pull: @escaping () throws -> Void,
         cloneRepository: @escaping (String) -> AnyPublisher<CloneProgressResult, GitClientError>,
-        getChangedFiles: @escaping () throws -> [ChangedFiles],
+        getChangedFiles: @escaping () throws -> [ChangedFile],
         getCommitHistory: @escaping (_ entries: Int?, _ fileLocalPath: String?) throws -> [Commit]
     ) {
         self.getCurrentBranchName = getCurrentBranchName

--- a/CodeEditModules/Modules/Git/src/Client/Live.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Live.swift
@@ -59,6 +59,31 @@ public extension GitClient {
             }
         }
 
+        func getChangedFiles() throws -> [ChangedFiles] {
+            let output = try shellClient.run(
+                "cd \(directoryURL.relativePath.escapedWhiteSpaces());git status -s --porcelain -u"
+            )
+            if output.contains("fatal: not a git repository") {
+                throw GitClientError.notGitRepository
+            }
+            return try output
+                .split(whereSeparator: \.isNewline)
+                .map { line -> ChangedFiles in
+                    let paramData = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let parameters = paramData.components(separatedBy: " ")
+                    guard let url = URL(string: parameters[safe: 1] ?? String(describing: URLError.badURL)) else {
+                        throw GitClientError.failedToDecodeURL
+                    }
+
+                    var gitType: GitType {
+                        .init(rawValue: parameters[safe: 0] ?? "") ?? GitType.unknown
+                    }
+
+                    return ChangedFiles(changeType: gitType,
+                                        fileLink: url)
+                }
+        }
+
         /// Gets the commit history log of the current file opened
         /// in the workspace.
 
@@ -154,6 +179,7 @@ public extension GitClient {
                     }
                     .eraseToAnyPublisher()
             },
+            getChangedFiles: getChangedFiles,
             getCommitHistory: getCommitHistory(entries:fileLocalPath:)
         )
     }

--- a/CodeEditModules/Modules/Git/src/Client/Live.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Live.swift
@@ -59,7 +59,7 @@ public extension GitClient {
             }
         }
 
-        func getChangedFiles() throws -> [ChangedFiles] {
+        func getChangedFiles() throws -> [ChangedFile] {
             let output = try shellClient.run(
                 "cd \(directoryURL.relativePath.escapedWhiteSpaces());git status -s --porcelain -u"
             )
@@ -68,7 +68,7 @@ public extension GitClient {
             }
             return try output
                 .split(whereSeparator: \.isNewline)
-                .map { line -> ChangedFiles in
+                .map { line -> ChangedFile in
                     let paramData = line.trimmingCharacters(in: .whitespacesAndNewlines)
                     let parameters = paramData.components(separatedBy: " ")
                     guard let url = URL(string: parameters[safe: 1] ?? String(describing: URLError.badURL)) else {
@@ -79,7 +79,7 @@ public extension GitClient {
                         .init(rawValue: parameters[safe: 0] ?? "") ?? GitType.unknown
                     }
 
-                    return ChangedFiles(changeType: gitType,
+                    return ChangedFile(changeType: gitType,
                                         fileLink: url)
                 }
         }

--- a/CodeEditModules/Modules/Git/src/Client/Models/ChangedFile.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Models/ChangedFile.swift
@@ -1,5 +1,5 @@
 //
-//  ChangedFiles.swift
+//  ChangedFile.swift
 //  
 //
 //  Created by Nanashi Li on 2022/05/20.
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 import WorkspaceClient
 
-public struct ChangedFiles: Codable, Hashable, Identifiable {
+public struct ChangedFile: Codable, Hashable, Identifiable {
     /// ID of the changed file
     public var id = UUID()
 

--- a/CodeEditModules/Modules/Git/src/Client/Models/ChangedFiles.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Models/ChangedFiles.swift
@@ -1,0 +1,61 @@
+//
+//  ChangedFiles.swift
+//  
+//
+//  Created by Nanashi Li on 2022/05/20.
+//
+
+import Foundation
+import SwiftUI
+import WorkspaceClient
+
+public struct ChangedFiles: Codable, Hashable, Identifiable {
+    /// ID of the changed file
+    public var id = UUID()
+
+    /// Change type is to tell us whether the type is a new file, modified or deleted
+    public let changeType: GitType?
+
+    /// Link of the file
+    public let fileLink: URL
+
+    /// Use it like this
+    /// ```swift
+    /// Image(systemName: item.systemImage)
+    /// ```
+    public var systemImage: String {
+        if fileLink.hasDirectoryPath {
+            return "folder.fill"
+        } else {
+            return FileIcon.fileIcon(fileType: fileType)
+        }
+    }
+
+    /// Returns the file name (e.g.: `Package.swift`)
+    public var fileName: String {
+        fileLink.lastPathComponent
+    }
+
+    /// Returns the extension of the file or an empty string if no extension is present.
+    private var fileType: FileIcon.FileType {
+        .init(rawValue: fileLink.pathExtension) ?? .txt
+    }
+
+    /// Returns a `Color` for a specific `fileType`
+    ///
+    /// If not specified otherwise this will return `Color.accentColor`
+    public var iconColor: Color {
+        FileIcon.iconColor(fileType: fileType)
+    }
+
+    // MARK: Intents
+    /// Allows the user to view the file or folder in the finder application
+    public func showInFinder(workspaceURL: URL) {
+        let workspace = workspaceURL.absoluteString
+        let file = fileLink.absoluteString
+        guard let url = URL(string: workspace + file) else {
+            return print("Failed to decode URL")
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+}

--- a/CodeEditModules/Modules/Git/src/Client/Models/GitType.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Models/GitType.swift
@@ -1,0 +1,19 @@
+//
+//  GitType.swift
+//  
+//
+//  Created by Nanashi Li on 2022/05/20.
+//
+
+import Foundation
+
+public enum GitType: String, Codable {
+    case modified = "M"
+    case unknown = "??"
+    case fileTypeChange = "T"
+    case added = "A"
+    case deleted = "D"
+    case renamed = "R"
+    case copied = "C"
+    case updatedUnmerged = "U"
+}

--- a/CodeEditModules/Modules/Git/src/Clone/CheckoutBranch.swift
+++ b/CodeEditModules/Modules/Git/src/Clone/CheckoutBranch.swift
@@ -42,6 +42,8 @@ public extension CheckoutBranchView {
                 alert.messageText = "Not a git repository"
             case let .outputError(message):
                 alert.messageText = message
+            case .failedToDecodeURL:
+                alert.messageText = "Failed to decode URL"
             }
             alert.runModal()
         }

--- a/CodeEditModules/Modules/Git/src/Clone/GitCloneView.swift
+++ b/CodeEditModules/Modules/Git/src/Clone/GitCloneView.swift
@@ -183,6 +183,8 @@ extension GitCloneView {
                             showAlert(alertMsg: "Error", infoText: "Not a git repository")
                         case let .outputError(error):
                             showAlert(alertMsg: "Error", infoText: error)
+                        case .failedToDecodeURL:
+                            showAlert(alertMsg: "Error", infoText: "Failed to decode URL")
                         }
                     case .finished: break
                     }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -94,7 +94,7 @@ public extension WorkspaceClient {
         public var systemImage: String {
             switch children {
             case nil:
-                return fileIcon
+                return FileIcon.fileIcon(fileType: fileType)
             case let .some(children):
                 return folderIcon(children)
             }
@@ -106,8 +106,23 @@ public extension WorkspaceClient {
         }
 
         /// Returns the extension of the file or an empty string if no extension is present.
-        public var fileType: String {
-            url.pathExtension
+        public var fileType: FileIcon.FileType {
+            .init(rawValue: url.pathExtension) ?? .txt
+        }
+
+        /// Returns a string describing a SFSymbol for folders
+        ///
+        /// If it is the top-level folder this will return `"square.dashed.inset.filled"`.
+        /// If it is a `.codeedit` folder this will return `"folder.fill.badge.gearshape"`.
+        /// If it has children this will return `"folder.fill"` otherwise `"folder"`.
+        private func folderIcon(_ children: [FileItem]) -> String {
+            if self.parent == nil {
+                return "square.dashed.inset.filled"
+            }
+            if self.fileName == ".codeedit" {
+                return "folder.fill.badge.gearshape"
+            }
+            return children.isEmpty ? "folder" : "folder.fill"
         }
 
         /// Returns the file name with optional extension (e.g.: `Package.swift`)
@@ -120,103 +135,11 @@ public extension WorkspaceClient {
             try? url.resourceValues(forKeys: [.contentTypeKey]).contentType
         }
 
-        /// Returns a string describing a SFSymbol for folders
-        ///
-        /// If it is the top-level folder this will return `"square.dashed.inset.filled"`.
-        /// If it is a `.codeedit` folder this will return `"folder.fill.badge.gearshape"`.
-        /// If it has children this will return `"folder.fill"` otherwise `"folder"`.
-        private func folderIcon(_ children: [FileItem]) -> String {
-            if parent == nil {
-                return "square.dashed.inset.filled"
-            }
-            if fileName == ".codeedit" {
-                return "folder.fill.badge.gearshape"
-            }
-            return children.isEmpty ? "folder" : "folder.fill"
-        }
-
-        /// Returns a string describing a SFSymbol for files
-        ///
-        /// If not specified otherwise this will return `"doc"`
-        private var fileIcon: String {
-            switch fileType {
-            case "json", "js":
-                return "curlybraces"
-            case "css":
-                return "number"
-            case "jsx":
-                return "atom"
-            case "swift":
-                return "swift"
-            case "env", "example":
-                return "gearshape.fill"
-            case "gitignore":
-                return "arrow.triangle.branch"
-            case "png", "jpg", "jpeg", "ico":
-                return "photo"
-            case "svg":
-                return "square.fill.on.circle.fill"
-            case "entitlements":
-                return "checkmark.seal"
-            case "plist":
-                return "tablecells"
-            case "md", "txt", "rtf":
-                return "doc.plaintext"
-            case "html", "py", "sh":
-                return "chevron.left.forwardslash.chevron.right"
-            case "LICENSE":
-                return "key.fill"
-            case "java":
-                return "cup.and.saucer"
-            case "h":
-                return "h.square"
-            case "m":
-                return "m.square"
-            case "vue":
-                return "v.square"
-            case "go":
-                return "g.square"
-            case "sum":
-                return "s.square"
-            case "mod":
-                return "m.square"
-            case "Makefile":
-                return "terminal"
-            default:
-                return "doc"
-            }
-        }
-
         /// Returns a `Color` for a specific `fileType`
         ///
         /// If not specified otherwise this will return `Color.accentColor`
         public var iconColor: Color {
-            switch fileType {
-            case "swift", "html":
-                return .orange
-            case "java":
-                return .red
-            case "js", "entitlements", "json", "LICENSE":
-                return Color("SidebarYellow")
-            case "css", "ts", "jsx", "md", "py":
-                return .blue
-            case "sh":
-                return .green
-            case "vue":
-                return Color(red: 0.255, green: 0.722, blue: 0.514, opacity: 1.000)
-            case "h":
-                return Color(red: 0.667, green: 0.031, blue: 0.133, opacity: 1.000)
-            case "m":
-                return Color(red: 0.271, green: 0.106, blue: 0.525, opacity: 1.000)
-            case "go":
-                return Color(red: 0.02, green: 0.675, blue: 0.757, opacity: 1.0)
-            case "sum", "mod":
-                return Color(red: 0.925, green: 0.251, blue: 0.478, opacity: 1.0)
-            case "Makefile":
-                return Color(red: 0.937, green: 0.325, blue: 0.314, opacity: 1.0)
-            default:
-                return .accentColor
-            }
+            FileIcon.iconColor(fileType: fileType)
         }
 
         // MARK: Statics

--- a/CodeEditModules/Modules/WorkspaceClient/src/UI/FileIcon.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/UI/FileIcon.swift
@@ -1,0 +1,130 @@
+//
+//  FileIcon.swift
+//  
+//
+//  Created by Nanashi Li on 2022/05/20.
+//
+
+import SwiftUI
+
+// swiftlint:disable function_body_length
+// swiftlint:disable cyclomatic_complexity
+public struct FileIcon {
+
+    // swiftlint:disable identifier_name
+    public enum FileType: String {
+        case json
+        case js
+        case css
+        case jsx
+        case swift
+        case env
+        case example
+        case gitignore
+        case png
+        case jpg
+        case jpeg
+        case ico
+        case svg
+        case entitlements
+        case plist
+        case md
+        case txt = "text"
+        case rtf
+        case html
+        case py
+        case sh
+        case LICENSE
+        case java
+        case h
+        case m
+        case vue
+        case go
+        case sum
+        case mod
+        case Makefile
+        case ts
+    }
+
+    /// Returns a string describing a SFSymbol for files
+    /// If not specified otherwise this will return `"doc"`
+    public static func fileIcon(fileType: FileType) -> String {
+        switch fileType {
+        case .json, .js:
+            return "curlybraces"
+        case .css:
+            return "number"
+        case .jsx:
+            return "atom"
+        case .swift:
+            return "swift"
+        case .env, .example:
+            return "gearshape.fill"
+        case .gitignore:
+            return "arrow.triangle.branch"
+        case .png, .jpg, .jpeg, .ico:
+            return "photo"
+        case .svg:
+            return "square.fill.on.circle.fill"
+        case .entitlements:
+            return "checkmark.seal"
+        case .plist:
+            return "tablecells"
+        case .md, .txt, .rtf:
+            return "doc.plaintext"
+        case .html, .py, .sh:
+            return "chevron.left.forwardslash.chevron.right"
+        case .LICENSE:
+            return "key.fill"
+        case .java:
+            return "cup.and.saucer"
+        case .h:
+            return "h.square"
+        case .m:
+            return "m.square"
+        case .vue:
+            return "v.square"
+        case .go:
+            return "g.square"
+        case .sum:
+            return "s.square"
+        case .mod:
+            return "m.square"
+        case .Makefile:
+            return "terminal"
+        default:
+            return "doc"
+        }
+    }
+
+    /// Returns a `Color` for a specific `fileType`
+    /// If not specified otherwise this will return `Color.accentColor`
+    public static func iconColor(fileType: FileType) -> Color {
+        switch fileType {
+        case .swift, .html:
+            return .orange
+        case .java:
+            return .red
+        case .js, .entitlements, .json, .LICENSE:
+            return Color("SidebarYellow")
+        case .css, .ts, .jsx, .md, .py:
+            return .blue
+        case .sh:
+            return .green
+        case .vue:
+            return Color(red: 0.255, green: 0.722, blue: 0.514, opacity: 1.000)
+        case .h:
+            return Color(red: 0.667, green: 0.031, blue: 0.133, opacity: 1.000)
+        case .m:
+            return Color(red: 0.271, green: 0.106, blue: 0.525, opacity: 1.000)
+        case .go:
+            return Color(red: 0.02, green: 0.675, blue: 0.757, opacity: 1.0)
+        case .sum, .mod:
+            return Color(red: 0.925, green: 0.251, blue: 0.478, opacity: 1.0)
+        case .Makefile:
+            return Color(red: 0.937, green: 0.325, blue: 0.314, opacity: 1.0)
+        default:
+            return .accentColor
+        }
+    }
+}

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -319,7 +319,8 @@ let package = Package(
         .target(
             name: "Git",
             dependencies: [
-                "ShellClient"
+                "ShellClient",
+                "WorkspaceClient"
             ],
             path: "Modules/Git/src"
         ),


### PR DESCRIPTION
# Description

Added support for showing changed/created files in the currently opened workspace.

# Related Issue

✨ Source Control Navigator #352

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots
![Screenshot 2022-05-05 at 14 02 00](https://user-images.githubusercontent.com/63672227/166919075-56dd7102-053a-4b07-a8fe-dcdc34ea0dc2.png)
