### PR TITLE
Fix ruler thickness calculation issue

### DIFF
--- a/CodeEditModules/Modules/CodeFile/src/LineGutter/LineGutter.swift
+++ b/CodeEditModules/Modules/CodeFile/src/LineGutter/LineGutter.swift
@@ -55,7 +55,6 @@ final class LineGutter: NSRulerView {
     }
 
     private let rulerMargin: CGFloat = 5
-    private let rulerWidth: CGFloat
     public var font: NSFont {
         didSet {
             needsDisplay = true
@@ -71,7 +70,6 @@ final class LineGutter: NSRulerView {
         textColor: NSColor,
         backgroundColor: NSColor
     ) {
-        rulerWidth = width
         self.font = font
         self.textColor = textColor
         self.backgroundColor = backgroundColor
@@ -132,7 +130,7 @@ final class LineGutter: NSRulerView {
     func calculateRuleThickness() -> CGFloat {
         let string = String(lineIndices?.last ?? 0) as NSString
         let rect = calculateStringSize(string)
-        return max(rect.width, rulerWidth)
+        return max(rect.width + 2 * rulerMargin, ruleThickness)
     }
 
     func calculateLines() {


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->
1. Removed unused `rulerWidth` to prevent confusion. 
2. Fix `calculateRuleThickness` by taking into account rulerMargin

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #631 

# Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] I documented my code
- [ ] Review requested

# Screenshots

<img width="545" alt="image" src="https://user-images.githubusercontent.com/7891810/169708706-24b5422d-8d9e-40af-a9f6-468b0f641c76.png">


<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
