### PR TITLE
Add Tab right-click Actions

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		5CAD1B972806B57D0059A74E /* Breadcrumbs in Frameworks */ = {isa = PBXBuildFile; productRef = 5CAD1B962806B57D0059A74E /* Breadcrumbs */; };
 		5CF38A5E27E48E6C0096A0F7 /* CodeFile in Frameworks */ = {isa = PBXBuildFile; productRef = 5CF38A5D27E48E6C0096A0F7 /* CodeFile */; };
 		64B64EDE27F7B79400C400F1 /* About in Frameworks */ = {isa = PBXBuildFile; productRef = 64B64EDD27F7B79400C400F1 /* About */; };
+		6CDA84AD284C1BA000C1CC3A /* TabBarContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */; };
 		B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3327DA9E1000EA4DBD /* Assets.xcassets */; };
 		B658FB3727DA9E1000EA4DBD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3627DA9E1000EA4DBD /* Preview Assets.xcassets */; };
 		B6EE989027E8879A00CDD8AB /* InspectorSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EE988F27E8879A00CDD8AB /* InspectorSidebar.swift */; };
@@ -212,6 +213,7 @@
 		2BE487EE28245162003F3F64 /* FinderSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderSync.swift; sourceTree = "<group>"; };
 		2BE487F028245162003F3F64 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5C4BB1E028212B1E00A92FB2 /* World.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = World.swift; sourceTree = "<group>"; };
+		6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarContextMenu.swift; sourceTree = "<group>"; };
 		B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodeEdit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = WorkspaceView.swift; sourceTree = "<group>"; tabWidth = 4; };
 		B658FB3327DA9E1000EA4DBD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -464,6 +466,7 @@
 			children = (
 				287776E827E34BC700D46668 /* TabBar.swift */,
 				287776EE27E3515300D46668 /* TabBarItem.swift */,
+				6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */,
 				DE6F77862813625500D00A76 /* TabBarDivider.swift */,
 				DE6405A52817734700881FDF /* TabBarNative.swift */,
 				DE513F51281B672D002260B9 /* TabBarAccessory.swift */,
@@ -935,6 +938,7 @@
 				043BCF03281DA18A000AC47C /* WorkspaceDocument+Search.swift in Sources */,
 				04C325512800AC7400C8DA2D /* ExtensionInstallationViewModel.swift in Sources */,
 				28B0A19827E385C300B73177 /* NavigatorSidebarToolbarTop.swift in Sources */,
+				6CDA84AD284C1BA000C1CC3A /* TabBarContextMenu.swift in Sources */,
 				0463E51127FCC1DF00806D5C /* CodeEditAPI.swift in Sources */,
 				04C3255B2801F86400C8DA2D /* OutlineViewController.swift in Sources */,
 				28FFE1BF27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift in Sources */,

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		5CF38A5E27E48E6C0096A0F7 /* CodeFile in Frameworks */ = {isa = PBXBuildFile; productRef = 5CF38A5D27E48E6C0096A0F7 /* CodeFile */; };
 		64B64EDE27F7B79400C400F1 /* About in Frameworks */ = {isa = PBXBuildFile; productRef = 64B64EDD27F7B79400C400F1 /* About */; };
 		6CDA84AD284C1BA000C1CC3A /* TabBarContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */; };
+		6C05A8AF284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */; };
 		B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3327DA9E1000EA4DBD /* Assets.xcassets */; };
 		B658FB3727DA9E1000EA4DBD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3627DA9E1000EA4DBD /* Preview Assets.xcassets */; };
 		B6EE989027E8879A00CDD8AB /* InspectorSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EE988F27E8879A00CDD8AB /* InspectorSidebar.swift */; };
@@ -214,6 +215,7 @@
 		2BE487F028245162003F3F64 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5C4BB1E028212B1E00A92FB2 /* World.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = World.swift; sourceTree = "<group>"; };
 		6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarContextMenu.swift; sourceTree = "<group>"; };
+		6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkspaceDocument+Listeners.swift"; sourceTree = "<group>"; };
 		B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodeEdit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = WorkspaceView.swift; sourceTree = "<group>"; tabWidth = 4; };
 		B658FB3327DA9E1000EA4DBD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 				D7E201AD27E8B3C000CB86D0 /* String+Ranges.swift */,
 				043BCF02281DA18A000AC47C /* WorkspaceDocument+Search.swift */,
 				043BCF04281DA19A000AC47C /* WorkspaceDocument+Selection.swift */,
+				6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */,
 			);
 			path = Documents;
 			sourceTree = "<group>";
@@ -941,6 +944,7 @@
 				6CDA84AD284C1BA000C1CC3A /* TabBarContextMenu.swift in Sources */,
 				0463E51127FCC1DF00806D5C /* CodeEditAPI.swift in Sources */,
 				04C3255B2801F86400C8DA2D /* OutlineViewController.swift in Sources */,
+				6C05A8AF284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift in Sources */,
 				28FFE1BF27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CodeEdit/Documents/WorkspaceDocument+Listeners.swift
+++ b/CodeEdit/Documents/WorkspaceDocument+Listeners.swift
@@ -1,0 +1,18 @@
+//
+//  WorkspaceDocument+CommandListeners.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 6/5/22.
+//
+
+import Foundation
+import WorkspaceClient
+import Combine
+
+class WorkspaceNotificationModel: ObservableObject {
+    init() {
+        highlitedFileItem = nil
+    }
+
+    @Published var highlitedFileItem: WorkspaceClient.FileItem?
+}

--- a/CodeEdit/Documents/WorkspaceDocument+Listeners.swift
+++ b/CodeEdit/Documents/WorkspaceDocument+Listeners.swift
@@ -11,8 +11,8 @@ import Combine
 
 class WorkspaceNotificationModel: ObservableObject {
     init() {
-        highlitedFileItem = nil
+        highlightedFileItem = nil
     }
 
-    @Published var highlitedFileItem: WorkspaceClient.FileItem?
+    @Published var highlightedFileItem: WorkspaceClient.FileItem?
 }

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -31,6 +31,7 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     var statusBarModel: StatusBarModel?
     var searchState: SearchState?
     var quickOpenState: QuickOpenState?
+    var listenerModel: WorkspaceNotificationModel = .init()
     private var cancellables = Set<AnyCancellable>()
 
     @Published var targets: [Target] = []

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>cbc639a25fd4582f2023a15bec9e2f30bacf0dad</string>
+	<string>95198e1cb40f469c0372629a32e53075e0e99dbd</string>
 </dict>
 </plist>

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import WorkspaceClient
 import AppPreferences
+import Combine
 
 /// Wraps an ``OutlineViewController`` inside a `NSViewControllerRepresentable`
 struct OutlineView: NSViewControllerRepresentable {
@@ -25,6 +26,8 @@ struct OutlineView: NSViewControllerRepresentable {
         controller.workspace = workspace
         controller.iconColor = prefs.preferences.general.fileIconStyle
 
+        context.coordinator.controller = controller
+
         return controller
     }
 
@@ -36,6 +39,32 @@ struct OutlineView: NSViewControllerRepresentable {
         nsViewController.hiddenFileExtensions = prefs.preferences.general.hiddenFileExtensions
         nsViewController.updateSelection()
         return
+    }
+
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(workspace)
+    }
+
+    class Coordinator: NSObject {
+        init(_ workspace: WorkspaceDocument) {
+            self.workspace = workspace
+            super.init()
+
+            listener = workspace.listenerModel.$highlitedFileItem.sink(receiveValue: { [weak self] fileItem in
+                guard let fileItem = fileItem else {
+                    return
+                }
+                self?.controller?.reveal(fileItem)
+            })
+        }
+
+        var listener: AnyCancellable?
+        var workspace: WorkspaceDocument
+        var controller: OutlineViewController?
+
+        deinit {
+            listener?.cancel()
+        }
     }
 
     /// Returns the row height depending on the `projectNavigatorSize` in `AppPreferences`.

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
@@ -50,7 +50,8 @@ struct OutlineView: NSViewControllerRepresentable {
             self.workspace = workspace
             super.init()
 
-            listener = workspace.listenerModel.$highlightedFileItem.sink(receiveValue: { [weak self] fileItem in
+            listener = workspace.listenerModel.$highlightedFileItem
+                .sink(receiveValue: { [weak self] fileItem in
                 guard let fileItem = fileItem else {
                     return
                 }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
@@ -50,7 +50,7 @@ struct OutlineView: NSViewControllerRepresentable {
             self.workspace = workspace
             super.init()
 
-            listener = workspace.listenerModel.$highlitedFileItem.sink(receiveValue: { [weak self] fileItem in
+            listener = workspace.listenerModel.$highlightedFileItem.sink(receiveValue: { [weak self] fileItem in
                 guard let fileItem = fileItem else {
                     return
                 }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -238,6 +238,34 @@ extension OutlineViewController: NSOutlineViewDelegate {
         }
         outlineView.selectRowIndexes(.init(integer: row), byExtendingSelection: false)
     }
+
+    /// Reveals the given `fileItem` in the outline view by expanding all the parent directories of the file.
+    /// If the file is not found, it will present an alert saying so.
+    /// - Parameter fileItem: The file to reveal.
+    public func reveal(_ fileItem: Item) {
+        if let parent = fileItem.parent {
+            expandParent(item: parent)
+        }
+        let row = outlineView.row(forItem: fileItem)
+        outlineView.selectRowIndexes(.init(integer: row), byExtendingSelection: false)
+
+        if row < 0 {
+            let alert = NSAlert()
+            alert.messageText = NSLocalizedString("Could not find file",
+                                                  comment: "Could not find file")
+            alert.runModal()
+            return
+        }
+    }
+
+    /// Method for recursively expanding a file's parent directories.
+    /// - Parameter item:
+    private func expandParent(item: Item) {
+        if let parent = item.parent as Item? {
+            expandParent(item: parent)
+        }
+        outlineView.expandItem(item)
+    }
 }
 
 extension OutlineViewController: NSMenuDelegate {

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -235,6 +235,14 @@ extension OutlineViewController: NSOutlineViewDelegate {
     ///   - id: the id of the item item
     ///   - collection: the array to search for
     private func select(by id: TabBarItemID, from collection: [Item]) {
+        // If the user has set "Reveal file on selection change" on, we need to reveal the item before
+        // selecting the row.
+        if AppPreferencesModel.shared.preferences.general.revealFileOnFocusChange,
+           case let .codeEditor(id) = id,
+           let fileItem = try? workspace?.workspaceClient?.getFileItem(id as Item.ID) as? Item {
+            reveal(fileItem)
+        }
+
         guard let item = collection.first(where: { $0.tabID == id }) else {
             for item in collection {
                 select(by: id, from: item.children ?? [])
@@ -266,6 +274,8 @@ extension OutlineViewController: NSOutlineViewDelegate {
                                                   comment: "Could not find file")
             alert.runModal()
             return
+        } else {
+            outlineView.scrollRowToVisible(row)
         }
     }
 

--- a/CodeEdit/TabBar/TabBarContextMenu.swift
+++ b/CodeEdit/TabBar/TabBarContextMenu.swift
@@ -12,22 +12,26 @@ import TabBar
 
 extension View {
     func tabBarContextMenu(item: TabBarItemRepresentable,
-                           workspace: WorkspaceDocument) -> some View {
-        modifier(TabBarContextMenu(item: item, workspace: workspace))
+                           workspace: WorkspaceDocument,
+                           isTemporary: Bool) -> some View {
+        modifier(TabBarContextMenu(item: item, workspace: workspace, isTemporary: isTemporary))
     }
 }
 
 struct TabBarContextMenu: ViewModifier {
     init(item: TabBarItemRepresentable,
-         workspace: WorkspaceDocument) {
+         workspace: WorkspaceDocument,
+         isTemporary: Bool) {
         self.item = item
         self.workspace = workspace
+        self.isTemporary = isTemporary
     }
 
     @ObservedObject
     var workspace: WorkspaceDocument
 
     private var item: TabBarItemRepresentable
+    private var isTemporary: Bool
 
     func body(content: Content) -> some View {
         content.contextMenu(menuItems: {
@@ -55,6 +59,12 @@ struct TabBarContextMenu: ViewModifier {
                 Button("Close All") {
                     withAnimation {
                         workspace.closeTabs(items: workspace.selectionState.openedTabs)
+                    }
+                }
+
+                if isTemporary {
+                    Button("Keep Open") {
+                        workspace.convertTemporaryTab()
                     }
                 }
             }

--- a/CodeEdit/TabBar/TabBarContextMenu.swift
+++ b/CodeEdit/TabBar/TabBarContextMenu.swift
@@ -80,9 +80,8 @@ struct TabBarContextMenu: ViewModifier {
                     }
 
                     Button("Reveal in Project Navigator") {
-                        
+                        workspace.listenerModel.highlitedFileItem = item
                     }
-                    .disabled(true)
 
                     Button("Open in New Window") {
 

--- a/CodeEdit/TabBar/TabBarContextMenu.swift
+++ b/CodeEdit/TabBar/TabBarContextMenu.swift
@@ -80,7 +80,7 @@ struct TabBarContextMenu: ViewModifier {
                     }
 
                     Button("Reveal in Project Navigator") {
-                        workspace.listenerModel.highlitedFileItem = item
+                        workspace.listenerModel.highlightedFileItem = item
                     }
 
                     Button("Open in New Window") {

--- a/CodeEdit/TabBar/TabBarContextMenu.swift
+++ b/CodeEdit/TabBar/TabBarContextMenu.swift
@@ -1,0 +1,131 @@
+//
+//  TabBarContextMenu.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 6/4/22.
+//
+
+import Foundation
+import SwiftUI
+import WorkspaceClient
+import TabBar
+
+extension View {
+    func tabBarContextMenu(item: TabBarItemRepresentable,
+                           workspace: WorkspaceDocument) -> some View {
+        modifier(TabBarContextMenu(item: item, workspace: workspace))
+    }
+}
+
+struct TabBarContextMenu: ViewModifier {
+    init(item: TabBarItemRepresentable,
+         workspace: WorkspaceDocument) {
+        self.item = item
+        self.workspace = workspace
+    }
+
+    @ObservedObject
+    var workspace: WorkspaceDocument
+
+    private var item: TabBarItemRepresentable
+
+    func body(content: Content) -> some View {
+        content.contextMenu(menuItems: {
+            Group {
+                Button("Close Tab") {
+                    withAnimation {
+                        workspace.closeTab(item: item.tabID)
+                    }
+                }
+                .keyboardShortcut("w", modifiers: [.command])
+
+                Button("Close Other Tabs") {
+                    withAnimation {
+                        workspace.closeTab(where: { $0 != item.tabID })
+                    }
+                }
+                Button("Close Tabs to the Right") {
+                    withAnimation {
+                        workspace.closeTabs(after: item.tabID)
+                    }
+                }
+                // Disable this option when current tab is the last one.
+                .disabled(workspace.selectionState.openedTabs.last?.id == item.tabID.id)
+
+                Button("Close All") {
+                    withAnimation {
+                        workspace.closeTabs(items: workspace.selectionState.openedTabs)
+                    }
+                }
+            }
+
+            Divider()
+
+            if let item = item as? WorkspaceClient.FileItem {
+                Group {
+                    Button("Copy Path") {
+                        copyPath(item: item)
+                    }
+
+                    Button("Copy Relative Path") {
+                        copyRelativePath(item: item)
+                    }
+                }
+
+                Divider()
+
+                Group {
+                    Button("Show in Finder") {
+                        item.showInFinder()
+                    }
+
+                    Button("Reveal in Project Navigator") {
+                        
+                    }
+                    .disabled(true)
+
+                    Button("Open in New Window") {
+
+                    }
+                    .disabled(true)
+                }
+            }
+        })
+    }
+
+    // MARK: - Actions
+
+    /// Copies the absolute path of the given `FileItem`
+    /// - Parameter item: The `FileItem` to use.
+    private func copyPath(item: WorkspaceClient.FileItem) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(item.url.standardizedFileURL.path, forType: .string)
+    }
+
+    /// Copies the relative path from the workspace folder to the given file item to the pasteboard.
+    /// - Parameter item: The `FileItem` to use.
+    private func copyRelativePath(item: WorkspaceClient.FileItem) {
+        guard let rootPath = workspace.workspaceClient?.folderURL() else {
+            return
+        }
+        // Calculate the relative path
+        var rootComponents = rootPath.standardizedFileURL.pathComponents
+        var destinationComponents = item.url.standardizedFileURL.pathComponents
+
+        // Remove any same path components
+        while !rootComponents.isEmpty && !destinationComponents.isEmpty
+                && rootComponents.first == destinationComponents.first {
+            rootComponents.remove(at: 0)
+            destinationComponents.remove(at: 0)
+        }
+
+        // Make a "../" for each remaining component in the root URL
+        var relativePath: String = String(repeating: "../", count: rootComponents.count)
+        // Add the remaining components for the destination url.
+        relativePath += destinationComponents.joined(separator: "/")
+
+        // Copy it to the clipboard
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(relativePath, forType: .string)
+    }
+}

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -315,25 +315,7 @@ struct TabBarItem: View {
             }
         }
         .id(item.tabID)
-        .contextMenu {
-            Button("Close Tab") {
-                withAnimation {
-                    workspace.closeTab(item: item.tabID)
-                }
-            }
-            Button("Close Other Tabs") {
-                withAnimation {
-                    workspace.closeTab(where: { $0 != item.tabID })
-                }
-            }
-            Button("Close Tabs to the Right") {
-                withAnimation {
-                    workspace.closeTabs(after: item.tabID)
-                }
-            }
-            // Disable this option when current tab is the last one.
-            .disabled(workspace.selectionState.openedTabs.last?.id == item.tabID.id)
-        }
+        .tabBarContextMenu(item: item, workspace: workspace)
     }
 }
 // swiftlint:enable type_body_length

--- a/CodeEdit/TabBar/TabBarItem.swift
+++ b/CodeEdit/TabBar/TabBarItem.swift
@@ -337,7 +337,7 @@ struct TabBarItem: View {
             }
         }
         .id(item.tabID)
-        .tabBarContextMenu(item: item, workspace: workspace)
+        .tabBarContextMenu(item: item, workspace: workspace, isTemporary: isTemporary)
     }
 }
 // swiftlint:enable type_body_length

--- a/CodeEditModules/Modules/AppPreferences/src/Model/General/GeneralPreferences.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/General/GeneralPreferences.swift
@@ -47,6 +47,9 @@ public extension AppPreferences {
         /// The Issue Navigator Detail line limit
         public var issueNavigatorDetail: NavigatorDetail = .upTo3
 
+        /// The reveal file in navigator when focus changes behavior of the app.
+        public var revealFileOnFocusChange: Bool = false
+
         /// Default initializer
         public init() {}
 
@@ -102,6 +105,10 @@ public extension AppPreferences {
                 NavigatorDetail.self,
                 forKey: .issueNavigatorDetail
             ) ?? .upTo3
+            self.revealFileOnFocusChange = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .revealFileOnFocusChange
+            ) ?? false
         }
         // swiftlint:enable function_body_length
     }

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
@@ -227,7 +227,7 @@ private extension GeneralPreferencesView {
 
     var revealFileOnFocusChangeToggle: some View {
         PreferencesSection("Project Navigator Behavior", hideLabels: false) {
-            Toggle("Highlight current file in Navigator", isOn: $prefs.preferences.general.revealFileOnFocusChange)
+            Toggle("Automatically Show Active File", isOn: $prefs.preferences.general.revealFileOnFocusChange)
                 .toggleStyle(.checkbox)
         }
     }

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
@@ -46,7 +46,10 @@ public struct GeneralPreferencesView: View {
                 issueNavigatorDetailSection
                 dialogWarningsSection
             }
-            openInCodeEditToggle
+            Group {
+                openInCodeEditToggle
+                revealFileOnFocusChangeToggle
+            }
         }
     }
 }
@@ -219,6 +222,13 @@ private extension GeneralPreferencesView {
 
                     defaults.set(newValue, forKey: "enableOpenInCE")
                 }
+        }
+    }
+
+    var revealFileOnFocusChangeToggle: some View {
+        PreferencesSection("Project Navigator Behavior", hideLabels: false) {
+            Toggle("Highlight current file in Navigator", isOn: $prefs.preferences.general.revealFileOnFocusChange)
+                .toggleStyle(.checkbox)
         }
     }
 }


### PR DESCRIPTION
# Description

This PR adds some useful right-click actions to the existing tab actions. Specifically it adds:
- [x] Close All
- [x] Copy Path
- [x] Copy Relative Path
- [x] Show in Finder
- [x] Reveal in Project Navigator

This also adds a view modifier `TabBarContextMenu` that is just a refactor of the existing `contextMenu` on the `TabBarItem`. This modifier handles all of the actions in the context menu including copying the relative path, highlighting the file, etc.

# Related Issue

* #647

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/35942988/172066840-d11ed1da-a63a-4d1e-a246-dfc9bd64eb38.mov
<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
