### PR TITLE
Fix: `About` and `Feedback` windows opens only if aren't already

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -176,6 +176,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         FeedbackView().showWindow()
     }
 
+
+    /// Tries to focus a window with specified view content type.
+    /// - Parameter type: The type of viewContent which hosted in a window to be focused.
+    /// - Returns: ``true`` if window exist and focused, oterwise - ``false``
     private func tryFocusWindow<T: View>(of type: T.Type) -> Bool {
         guard let window = NSApp.windows.filter({ ($0.contentView as? NSHostingView<T>) != nil }).first
         else { return false }

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -123,12 +123,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     @IBAction func openWelcome(_ sender: Any) {
-        if let window = NSApp.windows.filter({ window in
-            return (window.contentView as? NSHostingView<WelcomeWindowView>) != nil
-        }).first {
-            window.makeKeyAndOrderFront(self)
-            return
-        }
+        if tryFocusWindow(of: WelcomeWindowView.self) { return }
 
         let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 800, height: 460),
                               styleMask: [.titled, .fullSizeContentView], backing: .buffered, defer: false)
@@ -170,11 +165,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     @IBAction func openAbout(_ sender: Any) {
+        if tryFocusWindow(of: AboutView.self) { return }
+
         AboutView().showWindow(width: 530, height: 220)
     }
 
     @IBAction func openFeedback(_ sender: Any) {
+        if tryFocusWindow(of: FeedbackView.self) { return }
+
         FeedbackView().showWindow()
+    }
+
+    private func tryFocusWindow<T: View>(of type: T.Type) -> Bool {
+        guard let window = NSApp.windows.filter({ ($0.contentView as? NSHostingView<T>) != nil }).first
+        else { return false }
+
+        window.makeKeyAndOrderFront(self)
+        return true
     }
 
     // MARK: - Open With CodeEdit (Extension) functions

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -176,7 +176,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         FeedbackView().showWindow()
     }
 
-
     /// Tries to focus a window with specified view content type.
     /// - Parameter type: The type of viewContent which hosted in a window to be focused.
     /// - Returns: `true` if window exist and focused, oterwise - `false`

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -179,7 +179,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
     /// Tries to focus a window with specified view content type.
     /// - Parameter type: The type of viewContent which hosted in a window to be focused.
-    /// - Returns: ``true`` if window exist and focused, oterwise - ``false``
+    /// - Returns: `true` if window exist and focused, oterwise - `false`
     private func tryFocusWindow<T: View>(of type: T.Type) -> Bool {
         guard let window = NSApp.windows.filter({ ($0.contentView as? NSHostingView<T>) != nil }).first
         else { return false }

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>cbc639a25fd4582f2023a15bec9e2f30bacf0dad</string>
+	<string>99e73ca1aff5a854390788d17a57d0d0461c0640</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>99e73ca1aff5a854390788d17a57d0d0461c0640</string>
+	<string>75805bea3228a176edce091175fc5d58273606ee</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Description
Make sure that about and feedback windows not opened if already. 
Done the same ways as welcome screen. 
Extracted similar code to helper function.

# Related Issue
* #649 

# Checklist
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [ ] Review requested

# Screenshots
Nothing to screenshot here. Mentioned windows are now focused if already exist
