### PR TITLE
fix: Closing all editors should open welcome screen

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		5CF38A5E27E48E6C0096A0F7 /* CodeFile in Frameworks */ = {isa = PBXBuildFile; productRef = 5CF38A5D27E48E6C0096A0F7 /* CodeFile */; };
 		64B64EDE27F7B79400C400F1 /* About in Frameworks */ = {isa = PBXBuildFile; productRef = 64B64EDD27F7B79400C400F1 /* About */; };
 		6CDA84AB284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AA284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift */; };
+		9C3E1A07284E8E020042BEC0 /* WelcomeModuleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3E1A06284E8E020042BEC0 /* WelcomeModuleExtensions.swift */; };
 		B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3327DA9E1000EA4DBD /* Assets.xcassets */; };
 		B658FB3727DA9E1000EA4DBD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3627DA9E1000EA4DBD /* Preview Assets.xcassets */; };
 		B6EE989027E8879A00CDD8AB /* InspectorSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EE988F27E8879A00CDD8AB /* InspectorSidebar.swift */; };
@@ -214,6 +215,7 @@
 		2BE487F028245162003F3F64 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5C4BB1E028212B1E00A92FB2 /* World.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = World.swift; sourceTree = "<group>"; };
 		6CDA84AA284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItemButtonStyle.swift; sourceTree = "<group>"; };
+		9C3E1A06284E8E020042BEC0 /* WelcomeModuleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeModuleExtensions.swift; sourceTree = "<group>"; };
 		B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodeEdit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = WorkspaceView.swift; sourceTree = "<group>"; tabWidth = 4; };
 		B658FB3327DA9E1000EA4DBD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -309,6 +311,7 @@
 				0463E51027FCC1DF00806D5C /* CodeEditAPI.swift */,
 				0463E51227FCC1FB00806D5C /* CodeEditTargetsAPI.swift */,
 				28B8F883280FFE4600596236 /* NSTableView+Background.swift */,
+				9C3E1A06284E8E020042BEC0 /* WelcomeModuleExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -931,6 +934,7 @@
 				2072FA16280D83A500C7F8D4 /* FileTypeList.swift in Sources */,
 				04C3254F2800AA4700C8DA2D /* ExtensionInstallationView.swift in Sources */,
 				B6EE989027E8879A00CDD8AB /* InspectorSidebar.swift in Sources */,
+				9C3E1A07284E8E020042BEC0 /* WelcomeModuleExtensions.swift in Sources */,
 				201169D72837B2E300F92B46 /* SourceControlNavigatorView.swift in Sources */,
 				20D839AB280DEB2900B27357 /* NoSelectionView.swift in Sources */,
 				20EBB505280C329800F3A5DA /* HistoryItem.swift in Sources */,

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -125,43 +125,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     @IBAction func openWelcome(_ sender: Any) {
         if tryFocusWindow(of: WelcomeWindowView.self) { return }
 
-        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 800, height: 460),
-                              styleMask: [.titled, .fullSizeContentView], backing: .buffered, defer: false)
-        let windowController = NSWindowController(window: window)
-        window.center()
-        let contentView = WelcomeWindowView(
-            shellClient: Current.shellClient,
-            openDocument: { url, opened in
-                if let url = url {
-                    CodeEditDocumentController.shared.openDocument(
-                        withContentsOf: url,
-                        display: true
-                    ) { doc, _, _ in
-                        if doc != nil {
-                            opened()
-                        }
-                    }
-
-                } else {
-                    windowController.window?.close()
-                    CodeEditDocumentController.shared.openDocument(onCompletion: { _, _ in
-                        opened()
-                    }, onCancel: {
-                        self.openWelcome(self)
-                    })
-                }
-            },
-            newDocument: {
-                CodeEditDocumentController.shared.newDocument(nil)
-            },
-            dismissWindow: {
-                windowController.window?.close()
-            }
-        )
-        window.titlebarAppearsTransparent = true
-        window.isMovableByWindowBackground = true
-        window.contentView = NSHostingView(rootView: contentView)
-        window.makeKeyAndOrderFront(self)
+        WelcomeWindowView.openWelcomeWindow()
     }
 
     @IBAction func openAbout(_ sender: Any) {

--- a/CodeEdit/Documents/CodeEditDocumentController.swift
+++ b/CodeEdit/Documents/CodeEditDocumentController.swift
@@ -6,6 +6,7 @@
 //
 
 import Cocoa
+import WelcomeModule
 
 final class CodeEditDocumentController: NSDocumentController {
     override func openDocument(_ sender: Any?) {
@@ -31,6 +32,14 @@ final class CodeEditDocumentController: NSDocumentController {
             }
             self.updateRecent(url)
             completionHandler(document, documentWasAlreadyOpen, error)
+        }
+    }
+
+    override func removeDocument(_ document: NSDocument) {
+        super.removeDocument(document)
+
+        if CodeEditDocumentController.shared.documents.isEmpty {
+            WelcomeWindowView.openWelcomeWindow()
         }
     }
 

--- a/CodeEdit/Extensions/WelcomeModuleExtensions.swift
+++ b/CodeEdit/Extensions/WelcomeModuleExtensions.swift
@@ -1,0 +1,54 @@
+//
+//  Welcome.swift
+//  CodeEdit
+//
+//  Created by Nazar Rudnyk on 06.06.2022.
+//
+
+import SwiftUI
+import WelcomeModule
+
+extension WelcomeWindowView {
+
+    /// Helper function which opens welcome view
+    /// TODO: Move this to WelcomeModule after CodeEditDocumentController is in separate module
+    static func openWelcomeWindow() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 460),
+            styleMask: [.titled, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.titlebarAppearsTransparent = true
+        window.isMovableByWindowBackground = true
+        window.center()
+
+        let windowController = NSWindowController(window: window)
+
+        window.contentView = NSHostingView(rootView: WelcomeWindowView(
+            shellClient: Current.shellClient,
+            openDocument: { url, opened in
+                if let url = url {
+                    CodeEditDocumentController.shared.openDocument(withContentsOf: url, display: true) { doc, _, _ in
+                        if doc != nil {
+                            opened()
+                        }
+                    }
+                } else {
+                    windowController.window?.close()
+                    CodeEditDocumentController.shared.openDocument(
+                        onCompletion: { _, _ in opened() },
+                        onCancel: { WelcomeWindowView.openWelcomeWindow() }
+                    )
+                }
+            },
+            newDocument: {
+                CodeEditDocumentController.shared.newDocument(nil)
+            },
+            dismissWindow: {
+                windowController.window?.close()
+            }
+        ))
+        window.makeKeyAndOrderFront(self)
+    }
+}

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>75805bea3228a176edce091175fc5d58273606ee</string>
+	<string>8c06736911ffddf5ae690561773f658efbafbe5b</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Description
When documents count is 0 we should open WelcomeView
The extension I added could be placed in WelcomeModule, but since CodeEditDocumentController isn't in separate module - it's now impossible.

Moreover - I'd look for implementation in more SwiftUI way, with a single source of truth. 
While it fixes the issue it more looks like a workaround.

# Related Issue
* #235

# Checklist
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested @austincondiff @lukepistrol

# Screenshots
Nothing to screenshot here