### PR TITLE
Move UI Workspace configuration from project .codeedit/selection.json to UserDefaults/AppStorage #513

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -82,10 +82,11 @@
 		5CA8776527FC6A95003F5CD5 /* QuickOpen in Frameworks */ = {isa = PBXBuildFile; productRef = 5CA8776427FC6A95003F5CD5 /* QuickOpen */; };
 		5CAD1B972806B57D0059A74E /* Breadcrumbs in Frameworks */ = {isa = PBXBuildFile; productRef = 5CAD1B962806B57D0059A74E /* Breadcrumbs */; };
 		5CF38A5E27E48E6C0096A0F7 /* CodeFile in Frameworks */ = {isa = PBXBuildFile; productRef = 5CF38A5D27E48E6C0096A0F7 /* CodeFile */; };
+		61C33233285241D000EBB59D /* String+SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C33232285241D000EBB59D /* String+SHA256.swift */; };
 		64B64EDE27F7B79400C400F1 /* About in Frameworks */ = {isa = PBXBuildFile; productRef = 64B64EDD27F7B79400C400F1 /* About */; };
-		6CDA84AD284C1BA000C1CC3A /* TabBarContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */; };
 		6C05A8AF284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */; };
 		6CDA84AB284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AA284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift */; };
+		6CDA84AD284C1BA000C1CC3A /* TabBarContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */; };
 		9C3E1A07284E8E020042BEC0 /* WelcomeModuleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3E1A06284E8E020042BEC0 /* WelcomeModuleExtensions.swift */; };
 		B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3327DA9E1000EA4DBD /* Assets.xcassets */; };
 		B658FB3727DA9E1000EA4DBD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3627DA9E1000EA4DBD /* Preview Assets.xcassets */; };
@@ -216,9 +217,10 @@
 		2BE487EE28245162003F3F64 /* FinderSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderSync.swift; sourceTree = "<group>"; };
 		2BE487F028245162003F3F64 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5C4BB1E028212B1E00A92FB2 /* World.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = World.swift; sourceTree = "<group>"; };
-		6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarContextMenu.swift; sourceTree = "<group>"; };
+		61C33232285241D000EBB59D /* String+SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SHA256.swift"; sourceTree = "<group>"; };
 		6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkspaceDocument+Listeners.swift"; sourceTree = "<group>"; };
 		6CDA84AA284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItemButtonStyle.swift; sourceTree = "<group>"; };
+		6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarContextMenu.swift; sourceTree = "<group>"; };
 		9C3E1A06284E8E020042BEC0 /* WelcomeModuleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeModuleExtensions.swift; sourceTree = "<group>"; };
 		B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodeEdit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = WorkspaceView.swift; sourceTree = "<group>"; tabWidth = 4; };
@@ -317,6 +319,7 @@
 				0463E51227FCC1FB00806D5C /* CodeEditTargetsAPI.swift */,
 				28B8F883280FFE4600596236 /* NSTableView+Background.swift */,
 				9C3E1A06284E8E020042BEC0 /* WelcomeModuleExtensions.swift */,
+				61C33232285241D000EBB59D /* String+SHA256.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -894,6 +897,7 @@
 				2813F93927ECC4C300E305E4 /* NavigatorSidebar.swift in Sources */,
 				DE513F54281DE5D0002260B9 /* TabBarXcode.swift in Sources */,
 				20EBB50D280C383700F3A5DA /* LanguageType.swift in Sources */,
+				61C33233285241D000EBB59D /* String+SHA256.swift in Sources */,
 				2813F93827ECC4AA00E305E4 /* FindNavigatorResultList.swift in Sources */,
 				201169D92837B31200F92B46 /* SourceControlSearchToolbar.swift in Sources */,
 				0483E35027FDB17700354AC0 /* ExtensionNavigator.swift in Sources */,

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -267,6 +267,8 @@ import TabBar
     }
     
     /// Retrieves selection state from UserDefaults using SHA256 hash of project  path as key
+    /// - Throws: `DecodingError.dataCorrupted` error if retrived data from UserDefaults is not decodable
+    /// - Returns: retrived state from UserDefaults or default state if not found
     private func readSelectionState() throws -> WorkspaceSelectionState {
         guard let path = fileURL?.path,
               let hash = path.sha256Hash,
@@ -326,6 +328,7 @@ import TabBar
     // MARK: Close Workspace
 
     /// Saves selection state to UserDefaults using SHA256 hash of project  path as key
+    /// - Throws: `EncodingError.invalidValue` error if sellection state is not encodable
     private func saveSelectionState() throws {
         guard let path = fileURL?.path,
               let hash = path.sha256Hash else { return }

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -19,7 +19,6 @@ import StatusBar
 import TabBar
 import CryptoKit
 
-// swiftlint:disable:next type_body_length
 @objc(WorkspaceDocument) final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     var workspaceClient: WorkspaceClient?
 
@@ -269,9 +268,9 @@ import CryptoKit
     }
 
     private func readSelectionState() throws -> WorkspaceSelectionState {
-        guard fileURL != nil else { return selectionState }
-        guard fileURL!.path != "" else { return selectionState }
-        let path = fileURL!.path.data(using: .utf8)
+        guard let path = fileURL?.path.data(using: .utf8) else {
+            return selectionState
+        }
         let hash = String(CryptoKit.SHA256.hash(data: path!).hashValue)
         if let data = UserDefaults.standard.value(forKey: hash) as? Data {
             let state = try? PropertyListDecoder().decode(WorkspaceSelectionState.self, from: data)

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -268,13 +268,12 @@ import CryptoKit
     }
 
     private func readSelectionState() throws -> WorkspaceSelectionState {
-        guard let path = fileURL?.path.data(using: .utf8) else {
-            return selectionState
-        }
-        let hash = String(CryptoKit.SHA256.hash(data: path!).hashValue)
+        guard let path = fileURL?.path,
+              let pathData = path.data(using: .utf8) else { return selectionState }
+        let hash = String(CryptoKit.SHA256.hash(data: pathData).hashValue)
         if let data = UserDefaults.standard.value(forKey: hash) as? Data {
-            let state = try? PropertyListDecoder().decode(WorkspaceSelectionState.self, from: data)
-            if state != nil { return state! }
+            let state = try PropertyListDecoder().decode(WorkspaceSelectionState.self, from: data)
+            return state
         }
         return selectionState
     }
@@ -330,11 +329,10 @@ import CryptoKit
     // MARK: Close Workspace
 
     private func saveSelectionState() throws {
-        guard fileURL != nil else { return }
-        guard fileURL!.path != "" else { return }
-        let path = fileURL!.path.data(using: .utf8)
-        let hash = String(CryptoKit.SHA256.hash(data: path!).hashValue)
-        let data =  try? PropertyListEncoder().encode(selectionState)
+        guard let path = fileURL?.path,
+              let pathData = path.data(using: .utf8) else { return }
+        let hash = String(CryptoKit.SHA256.hash(data: pathData).hashValue)
+        let data =  try PropertyListEncoder().encode(selectionState)
         UserDefaults.standard.set(data, forKey: hash)
     }
 

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -286,7 +286,6 @@ import CryptoKit
         // Initialize Workspace
         do {
             selectionState = try readSelectionState()
-            Swift.print(selectionState)
         } catch {
             Swift.print("couldn't retrieve selection state from user defaults")
         }

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -19,6 +19,7 @@ import StatusBar
 import TabBar
 import CryptoKit
 
+// swiftlint:disable:next type_body_length
 @objc(WorkspaceDocument) final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     var workspaceClient: WorkspaceClient?
 
@@ -285,6 +286,7 @@ import CryptoKit
         // Initialize Workspace
         do {
             selectionState = try readSelectionState()
+            Swift.print(selectionState)
         } catch {
             Swift.print("couldn't retrieve selection state from user defaults")
         }

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -265,7 +265,7 @@ import TabBar
                                                name: NSNotification.Name("CodeEditor.didBeginEditing"),
                                                object: nil)
     }
-    
+
     /// Retrieves selection state from UserDefaults using SHA256 hash of project  path as key
     /// - Throws: `DecodingError.dataCorrupted` error if retrived data from UserDefaults is not decodable
     /// - Returns: retrived state from UserDefaults or default state if not found

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -265,7 +265,8 @@ import TabBar
                                                name: NSNotification.Name("CodeEditor.didBeginEditing"),
                                                object: nil)
     }
-
+    
+    /// Retrieves selection state from UserDefaults using SHA256 hash of project  path as key
     private func readSelectionState() throws -> WorkspaceSelectionState {
         guard let path = fileURL?.path,
               let hash = path.sha256Hash,
@@ -324,6 +325,7 @@ import TabBar
 
     // MARK: Close Workspace
 
+    /// Saves selection state to UserDefaults using SHA256 hash of project  path as key
     private func saveSelectionState() throws {
         guard let path = fileURL?.path,
               let hash = path.sha256Hash else { return }

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -17,7 +17,6 @@ import CodeEditKit
 import ExtensionsStore
 import StatusBar
 import TabBar
-import CryptoKit
 
 @objc(WorkspaceDocument) final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     var workspaceClient: WorkspaceClient?
@@ -268,14 +267,11 @@ import CryptoKit
     }
 
     private func readSelectionState() throws -> WorkspaceSelectionState {
-        guard let path = fileURL?.path else { return selectionState }
-        if let hash = path.sha256Hash {
-            if let data = UserDefaults.standard.value(forKey: hash) as? Data {
-                let state = try PropertyListDecoder().decode(WorkspaceSelectionState.self, from: data)
-                return state
-            }
-        }
-        return selectionState
+        guard let path = fileURL?.path,
+              let hash = path.sha256Hash,
+              let data = UserDefaults.standard.value(forKey: hash) as? Data  else { return selectionState }
+        let state = try PropertyListDecoder().decode(WorkspaceSelectionState.self, from: data)
+        return state
     }
 
     override func read(from url: URL, ofType typeName: String) throws {
@@ -329,11 +325,10 @@ import CryptoKit
     // MARK: Close Workspace
 
     private func saveSelectionState() throws {
-        guard let path = fileURL?.path else { return }
-        if let hash = path.sha256Hash {
-            let data = try PropertyListEncoder().encode(selectionState)
-            UserDefaults.standard.set(data, forKey: hash)
-        }
+        guard let path = fileURL?.path,
+              let hash = path.sha256Hash else { return }
+        let data = try PropertyListEncoder().encode(selectionState)
+        UserDefaults.standard.set(data, forKey: hash)
     }
 
     override func close() {
@@ -370,13 +365,5 @@ extension WorkspaceDocument {
     }
     func targetDidClear() {
         self.targets.removeAll()
-    }
-}
-
-extension String {
-    var sha256Hash: String? {
-        guard let data = self.data(using: .utf8) else { return nil }
-        let hash = SHA256.hash(data: data)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
     }
 }

--- a/CodeEdit/Extensions/String+SHA256.swift
+++ b/CodeEdit/Extensions/String+SHA256.swift
@@ -9,6 +9,7 @@ import Foundation
 import CryptoKit
 
 extension String {
+    /// Returns a SHA256 hash string of a string or nil
     var sha256Hash: String? {
         guard let data = self.data(using: .utf8) else { return nil }
         let hash = SHA256.hash(data: data)

--- a/CodeEdit/Extensions/String+SHA256.swift
+++ b/CodeEdit/Extensions/String+SHA256.swift
@@ -1,0 +1,17 @@
+//
+//  String+SHA256.swift
+//  CodeEdit
+//
+//  Created by Debdut Karmakar on 6/9/22.
+//
+
+import Foundation
+import CryptoKit
+
+extension String {
+    var sha256Hash: String? {
+        guard let data = self.data(using: .utf8) else { return nil }
+        let hash = SHA256.hash(data: data)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>601e98c51c1347f0f24eea3a87416a8c10bbc5d4</string>
+	<string>cde35bdfc4817417c9ea0f964ca9da086aeb7301</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>fcf901ea0a512e03d13bfd6b4689dfdbd12f14e7</string>
+	<string>601e98c51c1347f0f24eea3a87416a8c10bbc5d4</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>8c06736911ffddf5ae690561773f658efbafbe5b</string>
+	<string>fcf901ea0a512e03d13bfd6b4689dfdbd12f14e7</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/TabBar/src/Documentation.docc/Adding New Tab Type.md
+++ b/CodeEditModules/Modules/TabBar/src/Documentation.docc/Adding New Tab Type.md
@@ -59,7 +59,11 @@ The same is for closing tabs using ``WorkspaceDocument.closeTab(item:)`` method.
 Closing multiple tabs at once is handled by common functions, so there are no changes
 required for them.
 
-Also, because previously opened tabs are persisted in `.codeedit/selection.json`,
+``WorkspaceDocument.close`` calls ``WorkspaceDocument.saveSelectionState`` to persist Workspace Selection State to UserDefaults.
+
+``WorkspaceDocument.read`` calls ``WorkspaceDocument.readSelectionState`` to retrieve Workspace Selection State from UserDefaults.
+
+Also, because previously opened tabs are persisted in UserDefaults,
 they should be recovered some way later. To recover new tab types you need to add
 a case for ``WorkspaceDocument.read`` to let it know how to recover your new tab type.
 


### PR DESCRIPTION
# Description

We don't need to clutter user project directories by saving workspace config in `.codeedit/selection.json`, so I moved UI preferences to UserDefaults.

# Related Issue

* #513 

# Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

NA
