### PR TITLE
[chore]: Added additional `SwiftLint` configurations

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,7 @@ opt_in_rules:
   - missing_docs
   - implicit_return
   - modifier_order
+  - convenience_type
 
 custom_rules:
   spaces_over_tabs:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,6 +18,7 @@ opt_in_rules:
   - contains_over_first_not_nil
   - missing_docs
   - implicit_return
+  - modifier_order
 
 custom_rules:
   spaces_over_tabs:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,6 +15,7 @@ identifier_name:
 opt_in_rules:
   - empty_count
   - contains_over_first_not_nil
+  - missing_docs
 
 custom_rules:
   spaces_over_tabs:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,8 +14,10 @@ identifier_name:
 
 opt_in_rules:
   - empty_count
+  - closure_spacing
   - contains_over_first_not_nil
   - missing_docs
+  - implicit_return
 
 custom_rules:
   spaces_over_tabs:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,7 +17,7 @@ opt_in_rules:
   - closure_spacing
   - contains_over_first_not_nil
   - missing_docs
-  - implicit_return
+#  - implicit_return
   - modifier_order
   - convenience_type
 

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -69,7 +69,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
-        return true
+        true
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
@@ -83,7 +83,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {
-        return false
+        false
     }
 
     func handleOpen() {
@@ -102,7 +102,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         let projects: [String] = CodeEditDocumentController.shared.documents
             .map { doc in
-                return (doc as? WorkspaceDocument)?.fileURL?.path
+                (doc as? WorkspaceDocument)?.fileURL?.path
             }
             .filter { $0 != nil }
             .map { $0! }

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -20,7 +20,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
     var quickOpenPanel: OverlayPanel?
 
     private var splitViewController: NSSplitViewController! {
-        get { return contentViewController as? NSSplitViewController }
+        get { contentViewController as? NSSplitViewController }
         set { contentViewController = newValue }
     }
 
@@ -94,7 +94,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
     // MARK: - Toolbar
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        return [
+        [
             .toggleFirstSidebarItem,
             .sidebarTrackingSeparator,
             .branchPicker,
@@ -105,7 +105,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
     }
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        return [
+        [
             .toggleFirstSidebarItem,
             .sidebarTrackingSeparator,
             .flexibleSpace,
@@ -198,7 +198,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
     private func getSelectedCodeFile() -> CodeFileDocument? {
         guard let id = workspace?.selectionState.selectedId else { return nil }
         guard let item = workspace?.selectionState.openFileItems.first(where: { item in
-            return item.tabID == id
+            item.tabID == id
         }) else { return nil }
         guard let file = workspace?.selectionState.openedCodeFiles[item] else { return nil }
         return file

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -192,7 +192,7 @@ import TabBar
 
         guard let openFileItemIdx = selectionState
             .openFileItems
-            .firstIndex(where: { $0.tabID == id}) else { return }
+            .firstIndex(where: { $0.tabID == id }) else { return }
         selectionState.openFileItems.remove(at: openFileItemIdx)
     }
 
@@ -227,11 +227,11 @@ import TabBar
     ]
 
     override class var autosavesInPlace: Bool {
-        return false
+        false
     }
 
     override var isDocumentEdited: Bool {
-        return false
+        false
     }
 
     override func makeWindowControllers() {
@@ -316,7 +316,7 @@ import TabBar
         // initialize extensions
         do {
             try ExtensionsManager.shared?.load { extensionID in
-                return CodeEditAPI(extensionId: extensionID, workspace: self)
+                CodeEditAPI(extensionId: extensionID, workspace: self)
             }
         } catch let error {
             Swift.print(error)

--- a/CodeEdit/Extensions/CodeEditAPI.swift
+++ b/CodeEdit/Extensions/CodeEditAPI.swift
@@ -13,7 +13,7 @@ final class CodeEditAPI: ExtensionAPI {
      var workspace: WorkspaceDocument
 
      var workspaceURL: URL {
-         return workspace.fileURL!
+         workspace.fileURL!
      }
 
      init(extensionId: String, workspace: WorkspaceDocument) {

--- a/CodeEdit/Extensions/NSTableView+Background.swift
+++ b/CodeEdit/Extensions/NSTableView+Background.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 extension NSTableView {
     /// Allows to set a lists background color in SwiftUI
-    open override func viewDidMoveToWindow() {
+    override open func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
 
         backgroundColor = NSColor.clear

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>054a920f2ab81318a4898e1cd534e87b5c1a8fd7</string>
+	<string>154a0a8e75ef3b61ff2e607021a66806e57f5f05</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>395f4e3aa614db8fe692c4651301aa429e023e3f</string>
+	<string>851de93bf08a96b91077c4fecaa44cbf45a5ca19</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>851de93bf08a96b91077c4fecaa44cbf45a5ca19</string>
+	<string>6a45b8a2f14c2809ea52887938b42f9b3566e6b8</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>154a0a8e75ef3b61ff2e607021a66806e57f5f05</string>
+	<string>395f4e3aa614db8fe692c4651301aa429e023e3f</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>24edd296df33f3bece8b2079fd2eebf4a5f86c36</string>
+	<string>b6b97a40b9872143b9771e80886065acb8e0f01b</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>6a45b8a2f14c2809ea52887938b42f9b3566e6b8</string>
+	<string>24edd296df33f3bece8b2079fd2eebf4a5f86c36</string>
 </dict>
 </plist>

--- a/CodeEdit/InspectorSidebar/InspectorSidebar.swift
+++ b/CodeEdit/InspectorSidebar/InspectorSidebar.swift
@@ -27,7 +27,7 @@ struct InspectorSidebar: View {
     var body: some View {
         VStack {
             if let item = workspace.selectionState.openFileItems.first(where: { file in
-                return file.tabID == workspace.selectionState.selectedId
+                file.tabID == workspace.selectionState.selectedId
             }) {
                 if let codeFile = workspace.selectionState.openedCodeFiles[item] {
                     switch selection {

--- a/CodeEdit/InspectorSidebar/InspectorSidebarToolbar.swift
+++ b/CodeEdit/InspectorSidebar/InspectorSidebarToolbar.swift
@@ -122,7 +122,7 @@ struct InspectorSidebarToolbarTop: View {
         }
 
         func dropUpdated(info: DropInfo) -> DropProposal? {
-            return DropProposal(operation: .move)
+            DropProposal(operation: .move)
         }
 
         func performDrop(info: DropInfo) -> Bool {

--- a/CodeEdit/InspectorSidebar/Views/HistoryItem.swift
+++ b/CodeEdit/InspectorSidebar/Views/HistoryItem.swift
@@ -16,7 +16,7 @@ struct HistoryItem: View {
 
     private var showPopup: Binding<Bool> {
         Binding<Bool> {
-            return selection == commit
+            selection == commit
         } set: { newValue in
             if newValue {
                 selection = commit

--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigator.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigator.swift
@@ -17,11 +17,11 @@ struct FindNavigator: View {
     private var searchText: String = ""
 
     private var foundFilesCount: Int {
-        state.searchResult.filter {!$0.hasKeywordInfo}.count
+        state.searchResult.filter { !$0.hasKeywordInfo }.count
     }
 
     private var foundResultsCount: Int {
-        state.searchResult.filter {$0.hasKeywordInfo}.count
+        state.searchResult.filter { $0.hasKeywordInfo }.count
     }
 
     init(state: WorkspaceDocument.SearchState) {

--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorModeSelector.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorModeSelector.swift
@@ -23,7 +23,7 @@ struct FindNavigatorModeSelector: View {
     }
 
     private func getMenuList(_ index: Int) -> [SearchModeModel] {
-        return index == 0 ? SearchModeModel.SearchModes : selectedMode[index - 1].children
+        index == 0 ? SearchModeModel.SearchModes : selectedMode[index - 1].children
     }
 
     private func onSelectMenuItem(_ index: Int, searchMode: SearchModeModel) {
@@ -107,11 +107,11 @@ struct FindNavigatorModeSelector: View {
 
 extension Array {
     var second: Element? {
-        return self.count > 1 ? self[1] : nil
+        self.count > 1 ? self[1] : nil
     }
 
     var third: Element? {
-        return self.count > 2 ? self[2] : nil
+        self.count > 2 ? self[2] : nil
     }
 }
 

--- a/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultList.swift
+++ b/CodeEdit/NavigatorSidebar/FindNavigator/FindNavigatorResultList.swift
@@ -22,11 +22,11 @@ struct FindNavigatorResultList: View {
     }
 
     private var foundFiles: [SearchResultModel] {
-        state.searchResult.filter {!$0.hasKeywordInfo}
+        state.searchResult.filter { !$0.hasKeywordInfo }
     }
 
     private func getResultWith(_ file: WorkspaceClient.FileItem) -> [SearchResultModel] {
-        state.searchResult.filter {$0.file == file && $0.hasKeywordInfo}
+        state.searchResult.filter { $0.file == file && $0.hasKeywordInfo }
     }
 
     var body: some View {

--- a/CodeEdit/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
+++ b/CodeEdit/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
@@ -139,7 +139,7 @@ struct NavigatorSidebarToolbarTop: View {
         }
 
         func dropUpdated(info: DropInfo) -> DropProposal? {
-            return DropProposal(operation: .move)
+            DropProposal(operation: .move)
         }
 
         func performDrop(info: DropInfo) -> Bool {

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineView.swift
@@ -42,7 +42,7 @@ struct OutlineView: NSViewControllerRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        return Coordinator(workspace)
+        Coordinator(workspace)
     }
 
     class Coordinator: NSObject {

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -156,11 +156,11 @@ extension OutlineViewController: NSOutlineViewDataSource {
 extension OutlineViewController: NSOutlineViewDelegate {
     func outlineView(_ outlineView: NSOutlineView,
                      shouldShowCellExpansionFor tableColumn: NSTableColumn?, item: Any) -> Bool {
-        return true
+        true
     }
 
     func outlineView(_ outlineView: NSOutlineView, shouldShowOutlineCellForItem item: Any) -> Bool {
-        return true
+        true
     }
 
     func outlineView(_ outlineView: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
@@ -210,7 +210,7 @@ extension OutlineViewController: NSOutlineViewDelegate {
     }
 
     func outlineView(_ outlineView: NSOutlineView, heightOfRowByItem item: Any) -> CGFloat {
-        return rowHeight // This can be changed to 20 to match Xcodes row height.
+        rowHeight // This can be changed to 20 to match Xcodes row height.
     }
 
     func outlineViewItemDidExpand(_ notification: Notification) {

--- a/CodeEdit/TabBar/TabBarAccessory.swift
+++ b/CodeEdit/TabBar/TabBarAccessory.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// Accessory icon's view for tab bar.
 struct TabBarAccessoryIcon: View {
     /// Unifies icon font for tab bar accessories.
-    static private let iconFont = Font.system(size: 14, weight: .regular, design: .default)
+    private static let iconFont = Font.system(size: 14, weight: .regular, design: .default)
 
     private let icon: Image
     private let action: () -> Void

--- a/CodeEditModules/Modules/Acknowledgements/src/Model/AcknowledgementsModel.swift
+++ b/CodeEditModules/Modules/Acknowledgements/src/Model/AcknowledgementsModel.swift
@@ -26,7 +26,7 @@ final class AcknowledgementsModel: ObservableObject {
             if let bundlePath = Bundle.main.path(forResource: "Package.resolved", ofType: nil) {
                 let jsonData = try String(contentsOfFile: bundlePath).data(using: .utf8)
                 let parsedJSON = try JSONDecoder().decode(RootObject.self, from: jsonData!)
-                for dependency in parsedJSON.object.pins.sorted(by: {$0.package < $1.package}) {
+                for dependency in parsedJSON.object.pins.sorted(by: { $0.package < $1.package }) {
                     // Filter out Dependencies containing CodeEdit (case insensitive)
                     if dependency.package.range(
                         of: "[Cc]ode[Ee]dit",

--- a/CodeEditModules/Modules/Acknowledgements/src/ParsePackagesResolved.swift
+++ b/CodeEditModules/Modules/Acknowledgements/src/ParsePackagesResolved.swift
@@ -12,7 +12,7 @@ struct Dependency: Decodable {
     var repositoryLink: String
     var version: String
     var repositoryURL: URL {
-        return URL(string: repositoryLink)!
+        URL(string: repositoryLink)!
     }
 }
 

--- a/CodeEditModules/Modules/AppPreferences/src/Model/AppPreferencesModel.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/AppPreferencesModel.swift
@@ -71,7 +71,7 @@ public final class AppPreferencesModel: ObservableObject {
     ///
     /// Points to `~/.codeedit/`
     internal var baseURL: URL {
-        return filemanager
+        filemanager
             .homeDirectoryForCurrentUser
             .appendingPathComponent(".codeedit", isDirectory: true)
     }
@@ -80,7 +80,7 @@ public final class AppPreferencesModel: ObservableObject {
     ///
     /// Points to `~/.codeedit/preferences.json`
     private var preferencesURL: URL {
-        return baseURL
+        baseURL
             .appendingPathComponent("preferences")
             .appendingPathExtension("json")
     }

--- a/CodeEditModules/Modules/AppPreferences/src/Model/General/GeneralPreferences.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/General/GeneralPreferences.swift
@@ -169,8 +169,8 @@ public extension AppPreferences {
             set {
                 extensions = newValue
                     .components(separatedBy: ",")
-                    .map({$0.trimmingCharacters(in: .whitespacesAndNewlines)})
-                    .filter({!$0.isEmpty || string.count < newValue.count })
+                    .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+                    .filter({ !$0.isEmpty || string.count < newValue.count })
             }
         }
 

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Github/GithubEnterpriseLoginView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Github/GithubEnterpriseLoginView.swift
@@ -83,7 +83,7 @@ struct GithubEnterpriseLoginView: View {
         GithubAccount(config).me { response in
             switch response {
             case .success(let user):
-                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased()}) {
+                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased() }) {
                     print("Account with the username already exists!")
                 } else {
                     print(user)

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Github/GithubLoginView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Github/GithubLoginView.swift
@@ -108,7 +108,7 @@ struct GithubLoginView: View {
         GithubAccount(config).me { response in
             switch response {
             case .success(let user):
-                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased()}) {
+                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased() }) {
                     print("Account with the username already exists!")
                 } else {
                     print(user)

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitlabHostedLoginView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitlabHostedLoginView.swift
@@ -82,7 +82,7 @@ struct GitlabHostedLoginView: View {
         GitlabAccount(config).me { response in
             switch response {
             case .success(let user):
-                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased()}) {
+                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased() }) {
                     print("Account with the username already exists!")
                 } else {
                     print(user)

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitlabLoginView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitlabLoginView.swift
@@ -76,7 +76,7 @@ struct GitlabLoginView: View {
         GitlabAccount(config).me { response in
             switch response {
             case .success(let user):
-                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased()}) {
+                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased() }) {
                     print("Account with the username already exists!")
                 } else {
                     print(user)

--- a/CodeEditModules/Modules/CodeEditUI/src/OverlayPanel.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/OverlayPanel.swift
@@ -19,7 +19,7 @@ public final class OverlayPanel: NSPanel, NSWindowDelegate {
         self.isMovableByWindowBackground = true
     }
 
-    public override func standardWindowButton(_ button: NSWindow.ButtonType) -> NSButton? {
+    override public func standardWindowButton(_ button: NSWindow.ButtonType) -> NSButton? {
         let btn = super.standardWindowButton(button)
         btn?.isHidden = true
         return btn

--- a/CodeEditModules/Modules/CodeEditUI/src/PressActionsModifier.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/PressActionsModifier.swift
@@ -29,6 +29,12 @@ public struct PressActions: ViewModifier {
 }
 
 public extension View {
+
+    /// A custom view modifier for press actions with callbacks for `onPress` and `onRelease`.
+    /// - Parameters:
+    ///   - onPress: Action to perform once the view is pressed.
+    ///   - onRelease: Action to perform once the view press is released.
+    /// - Returns: some View
     func pressAction(onPress: @escaping (() -> Void), onRelease: @escaping (() -> Void)) -> some View {
         modifier(PressActions(onPress: {
             onPress()

--- a/CodeEditModules/Modules/CodeEditUtils/Tests/UnitTests_Extensions.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/Tests/UnitTests_Extensions.swift
@@ -83,17 +83,35 @@ final class CodeEditUtilsExtensionsUnitTests: XCTestCase {
 
     func testMD5GenerationCaseSensitive() throws {
         let testString = "CodeEdit"
-        let md5 = testString.md5(true)
+        let md5 = testString.md5(caseSensitive: true)
 
         let result = "8ba8c8fd0442f7bae4d441e2a3fda706"
         XCTAssertEqual(result, md5)
     }
 
     func testMD5Generation() throws {
-        let testString = "codeedit"
-        let md5 = testString.md5()
+        let testString = "CodeEdit"
+        let md5 = testString.md5(caseSensitive: false)
 
         let result = "4cdf122ff382a2d929eddc1a63473ec1"
+        XCTAssertEqual(result, md5)
+    }
+
+    // MARK: - STRING + SHA256
+
+    func testSHA256GenerationCaseSensitive() throws {
+        let testString = "CodeEdit"
+        let md5 = testString.sha256(caseSensitive: true)
+
+        let result = "52125689c088f1783e53c48db78a4fe7b3fa10b12d8fba205fcf054e5ef3789a"
+        XCTAssertEqual(result, md5)
+    }
+
+    func test256Generation() throws {
+        let testString = "CodeEdit"
+        let md5 = testString.sha256(caseSensitive: false)
+
+        let result = "7c3f327eab3860fc823a99623b348afbf1d7aebaec5d21289fbaeab0f6340e4a"
         XCTAssertEqual(result, md5)
     }
 

--- a/CodeEditModules/Modules/CodeEditUtils/src/Extensions/Color+HEX.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/src/Extensions/Color+HEX.swift
@@ -51,7 +51,7 @@ public extension Color {
 
     /// The alpha (opacity) component of the Color (0.0 - 1.0)
     var alphaComponent: Double {
-        return NSColor(self).alphaComponent
+        NSColor(self).alphaComponent
     }
 }
 

--- a/CodeEditModules/Modules/CodeEditUtils/src/Extensions/String/String+MD5.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/src/Extensions/String/String+MD5.swift
@@ -20,7 +20,7 @@ public extension String {
         var string = self
 
         // trim whitespaces & new lines if specifiedå
-        if trim { string = string.trimmingCharacters(in: .whitespacesAndNewlines)}
+        if trim { string = string.trimmingCharacters(in: .whitespacesAndNewlines) }
 
         // make string lowercased if not case sensitive
         if !caseSensitive { string = string.lowercased() }

--- a/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/CodeEditKeychain.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/CodeEditKeychain.swift
@@ -275,7 +275,7 @@ open class CodeEditKeychain {
 
     /// Returns the key with currently set prefix.
     func keyWithPrefix(_ key: String) -> String {
-        return "\(keyPrefix)\(key)"
+        "\(keyPrefix)\(key)"
     }
 
     func addAccessGroupWhenPresent(_ items: [String: Any]) -> [String: Any] {

--- a/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/CodeEditKeychain.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/CodeEditKeychain.swift
@@ -8,6 +8,8 @@
 import Foundation
 import Security
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 open class CodeEditKeychain {
 
     var lastQueryParameters: [String: Any]? // Used by the unit tests

--- a/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/KeychainSwiftAccessOptions.swift
+++ b/CodeEditModules/Modules/CodeEditUtils/src/KeyChain/KeychainSwiftAccessOptions.swift
@@ -66,7 +66,7 @@ public enum CodeEditKeychainAccessOptions {
     case accessibleWhenPasscodeSetThisDeviceOnly
 
     static var defaultOption: CodeEditKeychainAccessOptions {
-        return .accessibleWhenUnlocked
+        .accessibleWhenUnlocked
     }
 
     var value: String {

--- a/CodeEditModules/Modules/CodeFile/src/CodeEditor.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeEditor.swift
@@ -25,7 +25,7 @@ struct CodeEditor: NSViewRepresentable {
     private let highlightr = Highlightr()
 
     private var themeString: String {
-        return ThemeModel.shared.selectedTheme?.highlightrThemeString ?? ""
+        ThemeModel.shared.selectedTheme?.highlightrThemeString ?? ""
     }
 
     private var lineGutterColor: NSColor {

--- a/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
@@ -22,7 +22,7 @@ public final class CodeFileDocument: NSDocument, ObservableObject {
     // MARK: - NSDocument
 
     override public class var autosavesInPlace: Bool {
-        return true
+        true
     }
 
     override public func makeWindowControllers() {

--- a/CodeEditModules/Modules/CodeFile/src/Model/CodeLanguage.swift
+++ b/CodeEditModules/Modules/CodeFile/src/Model/CodeLanguage.swift
@@ -23,7 +23,7 @@ public struct CodeLanguage {
         let fileName = url.pathComponents.last?.lowercased()
         // This is to handle special file types without an extension (e.g., Makefile, Dockerfile)
         let fileNameOrExtension = fileExtension.isEmpty ? (fileName != nil ? fileName! : "") : fileExtension
-        if let lang = knownLanguages.first(where: { lang in lang.extensions.contains(fileNameOrExtension)}) {
+        if let lang = knownLanguages.first(where: { lang in lang.extensions.contains(fileNameOrExtension) }) {
             return lang
         } else {
             return .default

--- a/CodeEditModules/Modules/CodeFile/src/TextView/CodeEditorTextView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/TextView/CodeEditorTextView.swift
@@ -50,7 +50,7 @@ public final class CodeEditorTextView: NSTextView {
         return String(string[string.lineRange(for: swiftSelectedRange)])
     }
 
-    public override func insertNewline(_ sender: Any?) {
+    override public func insertNewline(_ sender: Any?) {
         // get line before newline
         let currentLine = self.currentLine
         let prefix = currentLine.prefix {
@@ -94,14 +94,14 @@ public final class CodeEditorTextView: NSTextView {
         super.moveBackward(self)
     }
 
-    public override func insertText(_ string: Any, replacementRange: NSRange) {
+    override public func insertText(_ string: Any, replacementRange: NSRange) {
         super.insertText(string, replacementRange: replacementRange)
         guard let string = string as? String
         else { return }
         self.autocompleteSymbols(string)
     }
 
-    public override func insertTab(_ sender: Any?) {
+    override public func insertTab(_ sender: Any?) {
         super.insertText(
             String(
                 repeating: " ",
@@ -123,7 +123,7 @@ public final class CodeEditorTextView: NSTextView {
     ///
     /// This is a basic view without any functionality, once we have most the items built
     /// we will start connecting the menu items to their respective actions.
-    public override func menu(for event: NSEvent) -> NSMenu? {
+    override public func menu(for event: NSEvent) -> NSMenu? {
         guard var menu = super.menu(for: event) else { return nil }
 
         menu = helpMenu(menu)

--- a/CodeEditModules/Modules/ExtensionsStore/src/API/ExtensionsStoreAPI.swift
+++ b/CodeEditModules/Modules/ExtensionsStore/src/API/ExtensionsStoreAPI.swift
@@ -17,7 +17,7 @@ public enum ExtensionsStoreAPIError: Error {
 // TODO: add authorization
 
 /// Structure to work with Extensions Store API
-public struct ExtensionsStoreAPI {
+public enum ExtensionsStoreAPI {
 
     static let base = URL(string: "https://codeedit.pkasila.net/api/")!
     static let agent = Agent()

--- a/CodeEditModules/Modules/ExtensionsStore/src/API/ExtensionsStoreAPI.swift
+++ b/CodeEditModules/Modules/ExtensionsStore/src/API/ExtensionsStoreAPI.swift
@@ -87,7 +87,7 @@ public struct ExtensionsStoreAPI {
 final class Agent {
     func run<T: Decodable>(_ request: URLRequest,
                            _ decoder: JSONDecoder = JSONDecoder()) -> AnyPublisher<Response<T>, Error> {
-        return URLSession.shared
+        URLSession.shared
             .dataTaskPublisher(for: request)
             .tryMap { result -> Response<T> in
                 let value = try decoder.decode(T.self, from: result.data)

--- a/CodeEditModules/Modules/ExtensionsStore/src/API/Response.swift
+++ b/CodeEditModules/Modules/ExtensionsStore/src/API/Response.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// TODO: DOCS (Pavel Kasila)
+// swiftlint:disable missing_docs
 public struct Response<T> {
     public let value: T
     public let response: URLResponse

--- a/CodeEditModules/Modules/ExtensionsStore/src/ExtensionsManager.swift
+++ b/CodeEditModules/Modules/ExtensionsStore/src/ExtensionsManager.swift
@@ -20,7 +20,7 @@ public final class ExtensionsManager {
 
     /// Shared instance of `ExtensionsManager`
     public static let shared: ExtensionsManager? = {
-        return try? ExtensionsManager()
+        try? ExtensionsManager()
     }()
 
     let dbQueue: DatabaseQueue
@@ -67,13 +67,13 @@ public final class ExtensionsManager {
     /// - Parameter url: workspace's URL
     public func close(url: URL) {
         loadedPlugins.filter { elem in
-            return elem.key.workspace == url
+            elem.key.workspace == url
         }.forEach { (key: PluginWorkspaceKey, _) in
             loadedPlugins.removeValue(forKey: key)
         }
 
         loadedLanguageServers.filter { elem in
-            return elem.key.workspace == url
+            elem.key.workspace == url
         }.forEach { (key: PluginWorkspaceKey, client: LSPClient) in
             client.close()
             loadedLanguageServers.removeValue(forKey: key)
@@ -86,7 +86,7 @@ public final class ExtensionsManager {
                                                         isDirectory: true),
             includingPropertiesForKeys: nil,
             options: .skipsPackageDescendants
-        ).first(where: {$0.pathExtension == ext}) else { return nil }
+        ).first(where: { $0.pathExtension == ext }) else { return nil }
 
         guard let bundle = Bundle(url: bundleURL) else { return nil }
 
@@ -268,13 +268,13 @@ public final class ExtensionsManager {
         loadedBundles.removeValue(forKey: entry.release)
 
         loadedPlugins.filter { elem in
-            return elem.key.releaseID == entry.release
+            elem.key.releaseID == entry.release
         }.forEach { (key: PluginWorkspaceKey, _) in
             loadedPlugins.removeValue(forKey: key)
         }
 
         loadedLanguageServers.filter { elem in
-            return elem.key.releaseID == entry.release
+            elem.key.releaseID == entry.release
         }.forEach { (key: PluginWorkspaceKey, client: LSPClient) in
             client.close()
             loadedLanguageServers.removeValue(forKey: key)

--- a/CodeEditModules/Modules/Feedback/src/Model/FeedbackModel.swift
+++ b/CodeEditModules/Modules/Feedback/src/Model/FeedbackModel.swift
@@ -120,7 +120,7 @@ public class FeedbackModel: ObservableObject {
                                  steps: String?,
                                  expectation: String?,
                                  actuallyHappened: String?) -> String {
-        return """
+        """
         **Description**
 
         \(description)

--- a/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/BitbucketAccount.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/BitbucketAccount.swift
@@ -22,6 +22,6 @@ public struct BitbucketAccount {
 
 extension Router {
     internal var URLRequest: Foundation.URLRequest? {
-        return request()
+        request()
     }
 }

--- a/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/BitbucketAccount.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/BitbucketAccount.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 public let bitbucketBaseURL = "https://api.bitbucket.org/2.0"
 public let bitbucketWebURL = "https://bitbucket.org/"
 

--- a/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/BitbucketOAuthConfiguration.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/BitbucketOAuthConfiguration.swift
@@ -26,7 +26,7 @@ public struct BitbucketOAuthConfiguration: Configuration {
     }
 
     public func authenticate() -> URL? {
-        return OAuthRouter.authorize(self).URLRequest?.url
+        OAuthRouter.authorize(self).URLRequest?.url
     }
 
     fileprivate func basicAuthenticationString() -> String {

--- a/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Model/BitbucketRepositories.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Model/BitbucketRepositories.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 open class BitbucketRepositories: Codable {
     open var id: String
     open var owner: BitbucketUser

--- a/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Model/BitbucketUser.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Model/BitbucketUser.swift
@@ -8,6 +8,8 @@
 import Foundation
 import SwiftUI
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 open class BitbucketUser: Codable {
     open var id: String?
     open var login: String?

--- a/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Routers/BitbucketRepositoryRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Routers/BitbucketRepositoryRouter.swift
@@ -19,11 +19,11 @@ public enum BitbucketRepositoryRouter: Router {
     }
 
     public var method: HTTPMethod {
-        return .GET
+        .GET
     }
 
     public var encoding: HTTPEncoding {
-        return .url
+        .url
     }
 
     public var params: [String: Any] {

--- a/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Routers/BitbucketUserRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Routers/BitbucketUserRouter.swift
@@ -19,11 +19,11 @@ public enum BitbucketUserRouter: Router {
     }
 
     public var method: HTTPMethod {
-        return .GET
+        .GET
     }
 
     public var encoding: HTTPEncoding {
-        return .url
+        .url
     }
 
     public var path: String {
@@ -36,6 +36,6 @@ public enum BitbucketUserRouter: Router {
     }
 
     public var params: [String: Any] {
-        return [:]
+        [:]
     }
 }

--- a/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Routers/TokenRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Routers/TokenRouter.swift
@@ -19,11 +19,11 @@ public enum TokenRouter: Router {
     }
 
     public var method: HTTPMethod {
-        return .POST
+        .POST
     }
 
     public var encoding: HTTPEncoding {
-        return .form
+        .form
     }
 
     public var params: [String: Any] {

--- a/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Token.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Token.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 public extension BitbucketAccount {
 
     func refreshToken(

--- a/CodeEditModules/Modules/Git/src/Accounts/Github/GithubAccount.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Github/GithubAccount.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
+
 public let githubBaseURL = "https://api.github.com"
 public let githubWebURL = "https://github.com"
 

--- a/CodeEditModules/Modules/Git/src/Accounts/Github/GithubConfiguration.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Github/GithubConfiguration.swift
@@ -66,7 +66,7 @@ public struct OAuthConfiguration: Configuration {
     }
 
     public func authenticate() -> URL? {
-        return GithubOAuthRouter.authorize(self).URLRequest?.url
+        GithubOAuthRouter.authorize(self).URLRequest?.url
     }
 
     public func authorize(

--- a/CodeEditModules/Modules/Git/src/Accounts/Github/Model/Files.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Github/Model/Files.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 public typealias Files = [String: File]
 
 open class File: Codable {

--- a/CodeEditModules/Modules/Git/src/Accounts/Github/Model/Review.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Github/Model/Review.swift
@@ -10,6 +10,8 @@ import Foundation
 import FoundationNetworking
 #endif
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 public struct Review {
     public let body: String
     public let commitID: String

--- a/CodeEditModules/Modules/Git/src/Accounts/Github/PreviewHeader.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Github/PreviewHeader.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
+
 /// Some APIs provide additional data for new (preview) APIs if a custom header is added to the request.
 ///
 /// - Note: Preview APIs are subject to change.

--- a/CodeEditModules/Modules/Git/src/Accounts/Github/PublicKey.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Github/PublicKey.swift
@@ -10,6 +10,8 @@ import Foundation
 import FoundationNetworking
 #endif
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 public extension GithubAccount {
     func postPublicKey(_ session: GitURLSession = URLSession.shared,
                        publicKey: String,

--- a/CodeEditModules/Modules/Git/src/Accounts/Github/Routers/GithubRepositoryRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Github/Routers/GithubRepositoryRouter.swift
@@ -21,11 +21,11 @@ enum GithubRepositoryRouter: Router {
     }
 
     var method: HTTPMethod {
-        return .GET
+        .GET
     }
 
     var encoding: HTTPEncoding {
-        return .url
+        .url
     }
 
     var params: [String: Any] {

--- a/CodeEditModules/Modules/Git/src/Accounts/Github/Routers/GithubUserRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Github/Routers/GithubUserRouter.swift
@@ -19,11 +19,11 @@ enum GithubUserRouter: Router {
     }
 
     var method: HTTPMethod {
-        return .GET
+        .GET
     }
 
     var encoding: HTTPEncoding {
-        return .url
+        .url
     }
 
     var path: String {
@@ -36,6 +36,6 @@ enum GithubUserRouter: Router {
     }
 
     var params: [String: Any] {
-        return [:]
+        [:]
     }
 }

--- a/CodeEditModules/Modules/Git/src/Accounts/Gitlab/GitlabAccount.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Gitlab/GitlabAccount.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 public let gitlabBaseURL = "https://gitlab.com/api/v4/"
 public let gitlabWebURL = "https://gitlab.com/"
 

--- a/CodeEditModules/Modules/Git/src/Accounts/Gitlab/GitlabConfiguration.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Gitlab/GitlabConfiguration.swift
@@ -30,6 +30,6 @@ public struct PrivateTokenConfiguration: Configuration {
     }
 
     public var accessTokenFieldName: String {
-        return "private_token"
+        "private_token"
     }
 }

--- a/CodeEditModules/Modules/Git/src/Accounts/Gitlab/GitlabOAuthConfiguration.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Gitlab/GitlabOAuthConfiguration.swift
@@ -27,7 +27,7 @@ public struct GitlabOAuthConfiguration: Configuration {
     }
 
     public func authenticate() -> URL? {
-        return GitlabOAuthRouter.authorize(self, redirectURI).URLRequest?.url
+        GitlabOAuthRouter.authorize(self, redirectURI).URLRequest?.url
     }
 
     public func authorize(_ session: GitURLSession = URLSession.shared,

--- a/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/CommitRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/CommitRouter.swift
@@ -26,11 +26,11 @@ enum CommitRouter: Router {
     }
 
     var method: HTTPMethod {
-        return .GET
+        .GET
     }
 
     var encoding: HTTPEncoding {
-        return .url
+        .url
     }
 
     var params: [String: Any] {

--- a/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/ProjectRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/ProjectRouter.swift
@@ -99,11 +99,11 @@ enum ProjectRouter: Router {
     }
 
     var method: HTTPMethod {
-        return .GET
+        .GET
     }
 
     var encoding: HTTPEncoding {
-        return .url
+        .url
     }
 
     var params: [String: Any] {

--- a/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/UserRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/UserRouter.swift
@@ -17,11 +17,11 @@ enum UserRouter: Router {
     }
 
     var method: HTTPMethod {
-        return .GET
+        .GET
     }
 
     var encoding: HTTPEncoding {
-        return .url
+        .url
     }
 
     var path: String {
@@ -32,6 +32,6 @@ enum UserRouter: Router {
     }
 
     var params: [String: Any] {
-        return [:]
+        [:]
     }
 }

--- a/CodeEditModules/Modules/Git/src/Accounts/Networking/JSONPostRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Networking/JSONPostRouter.swift
@@ -12,6 +12,8 @@ import Foundation
 import FoundationNetworking
 #endif
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 public protocol JSONPostRouter: Router {
 
     func postJSON<T>(

--- a/CodeEditModules/Modules/Git/src/Accounts/Networking/Router.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Networking/Router.swift
@@ -9,6 +9,8 @@
 
 import Foundation
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 public enum HTTPMethod: String {
     case GET, POST, PUT, PATCH, DELETE
 }

--- a/CodeEditModules/Modules/Git/src/Accounts/Networking/Router.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Networking/Router.swift
@@ -39,19 +39,19 @@ public protocol Configuration {
 
 public extension Configuration {
     var accessTokenFieldName: String? {
-        return "access_token"
+        "access_token"
     }
 
     var authorizationHeader: String? {
-        return nil
+        nil
     }
 
     var errorDomain: String? {
-        return "com.codeedit.models.accounts.networking"
+        "com.codeedit.models.accounts.networking"
     }
 
     var customHeaders: [HTTPHeader]? {
-        return nil
+        nil
     }
 }
 
@@ -197,7 +197,7 @@ public extension Router {
         _ session: GitURLSession = URLSession.shared,
         expectedResultType: T.Type,
         completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
-        return load(session, expectedResultType: expectedResultType, completion: completion)
+        load(session, expectedResultType: expectedResultType, completion: completion)
     }
 
     func load<T: Codable>(

--- a/CodeEditModules/Modules/Git/src/Accounts/Networking/Session.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Networking/Session.swift
@@ -48,13 +48,13 @@ extension URLSession: GitURLSession {
     public func dataTask(
         with request: URLRequest,
         completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void) -> URLSessionDataTaskProtocol {
-            return (dataTask(with: request, completionHandler: completionHandler) as URLSessionDataTask)
+            (dataTask(with: request, completionHandler: completionHandler) as URLSessionDataTask)
         }
 
     public func uploadTask(
         with request: URLRequest,
         fromData bodyData: Data?,
         completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
-            return uploadTask(with: request, from: bodyData, completionHandler: completionHandler)
+            uploadTask(with: request, from: bodyData, completionHandler: completionHandler)
         }
 }

--- a/CodeEditModules/Modules/Git/src/Accounts/Networking/Session.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Networking/Session.swift
@@ -12,6 +12,8 @@ import Foundation
 import FoundationNetworking
 #endif
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 public protocol GitURLSession {
 
     func dataTask(

--- a/CodeEditModules/Modules/Git/src/Accounts/Utils/Time.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Utils/Time.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 public enum Time {
 
     /**

--- a/CodeEditModules/Modules/Git/src/Client/Interface.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Interface.swift
@@ -7,6 +7,9 @@
 import Foundation
 import Combine
 
+// TODO: DOCS (Marco Carnevali)
+// swiftlint:disable missing_docs
+
 public struct GitClient {
     public var getCurrentBranchName: () throws -> String
     public var getBranches: (Bool) throws -> [String]

--- a/CodeEditModules/Modules/Git/src/Client/Live.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Live.swift
@@ -9,6 +9,8 @@ import Foundation
 import ShellClient
 import Combine
 
+// TODO: DOCS (Marco Carnevali)
+// swiftlint:disable missing_docs
 public extension GitClient {
     // swiftlint:disable function_body_length
     static func `default`(

--- a/CodeEditModules/Modules/Git/src/Client/Live.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Live.swift
@@ -190,7 +190,7 @@ public extension GitClient {
 private extension Collection {
     /// Returns the element at the specified index if it is within bounds, otherwise nil.
     subscript (safe index: Index) -> Element? {
-        return indices.contains(index) ? self[index] : nil
+        indices.contains(index) ? self[index] : nil
     }
 }
 

--- a/CodeEditModules/Modules/Git/src/Clone/CheckoutBranch.swift
+++ b/CodeEditModules/Modules/Git/src/Clone/CheckoutBranch.swift
@@ -8,6 +8,8 @@
 import Foundation
 import SwiftUI
 
+// TODO: DOCS (Aleksi Puttonen)
+// swiftlint:disable missing_docs
 public extension CheckoutBranchView {
     func getBranches() -> [String] {
         guard let url = URL(string: repoPath) else {

--- a/CodeEditModules/Modules/Git/src/Clone/CheckoutBranchView.swift
+++ b/CodeEditModules/Modules/Git/src/Clone/CheckoutBranchView.swift
@@ -40,7 +40,7 @@ public struct CheckoutBranchView: View {
                         context[.trailing]
                     }
                     Menu {
-                        ForEach(getBranches().filter {!$0.contains("HEAD")}, id: \.self) { branch in
+                        ForEach(getBranches().filter { !$0.contains("HEAD") }, id: \.self) { branch in
                             Button {
                                     guard selectedBranch != branch else { return }
                                     selectedBranch = branch

--- a/CodeEditModules/Modules/Git/src/Clone/GitCloneView.swift
+++ b/CodeEditModules/Modules/Git/src/Clone/GitCloneView.swift
@@ -211,7 +211,7 @@ extension GitCloneView {
         do {
             let branches = try GitClient.default(directoryURL: dirUrl,
                                   shellClient: shellClient).getBranches(true)
-            let filtered = branches.filter {!$0.contains("HEAD")}
+            let filtered = branches.filter { !$0.contains("HEAD") }
             if filtered.count > 1 {
                 showCheckout = true
             }

--- a/CodeEditModules/Modules/Search/src/Model/SearchModeModel.swift
+++ b/CodeEditModules/Modules/Search/src/Model/SearchModeModel.swift
@@ -80,7 +80,7 @@ public struct SearchModeModel {
 
 extension SearchModeModel: Equatable {
     public static func == (lhs: SearchModeModel, rhs: SearchModeModel) -> Bool {
-        return lhs.title == rhs.title
+        lhs.title == rhs.title
             && lhs.children == rhs.children
             && lhs.needSelectionHightlight == rhs.needSelectionHightlight
     }

--- a/CodeEditModules/Modules/Search/src/Model/SearchModeModel.swift
+++ b/CodeEditModules/Modules/Search/src/Model/SearchModeModel.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// TODO: DOCS (Ziyuan Zhao)
+// swiftlint:disable missing_docs
 public struct SearchModeModel {
     public let title: String
     public let children: [SearchModeModel]

--- a/CodeEditModules/Modules/Search/src/Model/SearchResultModel.swift
+++ b/CodeEditModules/Modules/Search/src/Model/SearchResultModel.swift
@@ -27,6 +27,6 @@ public struct SearchResultModel: Hashable {
     }
 
     public var hasKeywordInfo: Bool {
-        return lineNumber != nil && lineContent != nil && keywordRange != nil
+        lineNumber != nil && lineContent != nil && keywordRange != nil
     }
 }

--- a/CodeEditModules/Modules/ShellClient/src/Interface.swift
+++ b/CodeEditModules/Modules/ShellClient/src/Interface.swift
@@ -6,6 +6,8 @@
 //
 import Combine
 
+// TODO: DOCS (Marco Carnevali)
+// swiftlint:disable missing_docs
 public struct ShellClient {
     public var runLive: (_ args: String...) -> AnyPublisher<String, Never>
     public var run: (_ args: String...) throws -> String

--- a/CodeEditModules/Modules/ShellClient/src/Live.swift
+++ b/CodeEditModules/Modules/ShellClient/src/Live.swift
@@ -7,6 +7,8 @@
 import Foundation
 import Combine
 
+// TODO: DOCS (Marco Carnevali)
+// swiftlint:disable missing_docs
 public extension ShellClient {
     static func live() -> Self {
         func generateProcessAndPipe(_ args: [String]) -> (Process, Pipe) {

--- a/CodeEditModules/Modules/ShellClient/src/Mocks.swift
+++ b/CodeEditModules/Modules/ShellClient/src/Mocks.swift
@@ -6,6 +6,7 @@
 //
 import Combine
 
+// swiftlint:disable missing_docs
 public extension ShellClient {
     static func always(_ output: String) -> Self {
         Self(

--- a/CodeEditModules/Modules/StatusBar/src/Model/CursorLocation.swift
+++ b/CodeEditModules/Modules/StatusBar/src/Model/CursorLocation.swift
@@ -11,6 +11,8 @@ import Foundation
 ///
 /// - Note: Not yet implemented
 public struct CursorLocation {
+    /// The current line the cursor is located at.
     public var line: Int
+    /// The current column the cursor is located at.
     public var column: Int
 }

--- a/CodeEditModules/Modules/StatusBar/src/Model/StatusBarTabType.swift
+++ b/CodeEditModules/Modules/StatusBar/src/Model/StatusBarTabType.swift
@@ -15,6 +15,6 @@ public enum StatusBarTabType: String, CaseIterable, Identifiable {
 
     public var id: String { self.rawValue }
     public static var allOptions: [String] {
-        return StatusBarTabType.allCases.map(\.rawValue.capitalized)
+        StatusBarTabType.allCases.map(\.rawValue.capitalized)
     }
 }

--- a/CodeEditModules/Modules/WelcomeModule/src/RecentProjectItem.swift
+++ b/CodeEditModules/Modules/WelcomeModule/src/RecentProjectItem.swift
@@ -10,7 +10,7 @@ import WorkspaceClient
 
 extension String {
     func abbreviatingWithTildeInPath() -> String {
-        return (self as NSString).abbreviatingWithTildeInPath
+        (self as NSString).abbreviatingWithTildeInPath
     }
 }
 

--- a/CodeEditModules/Modules/WelcomeModule/src/WelcomeView.swift
+++ b/CodeEditModules/Modules/WelcomeModule/src/WelcomeView.swift
@@ -39,11 +39,11 @@ public struct WelcomeView: View {
     }
 
     private var appVersion: String {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
     }
 
     private var appBuild: String {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
     }
 
     /// Get the MacOS version & build
@@ -193,7 +193,7 @@ public struct WelcomeView: View {
                     HStack {
                         Spacer()
                         Toggle("Show this window when CodeEdit launches", isOn: .init(get: {
-                            return prefs.preferences.general.reopenBehavior == .welcome
+                            prefs.preferences.general.reopenBehavior == .welcome
                         }, set: { new in
                             prefs.preferences.general.reopenBehavior = new ? .welcome : .openPanel
                         }))

--- a/CodeEditModules/Modules/WorkspaceClient/src/Interface.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Interface.swift
@@ -8,6 +8,8 @@
 import Combine
 import Foundation
 
+// TODO: DOCS (Marco Carnevali)
+// swiftlint:disable missing_docs
 public struct WorkspaceClient {
 
     public var folderURL: () -> URL?

--- a/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
@@ -8,6 +8,8 @@
 import Combine
 import Foundation
 
+// TODO: DOCS (Marco Carnevali)
+// swiftlint:disable missing_docs
 public extension WorkspaceClient {
     // swiftlint:disable:next function_body_length
     static func `default`(

--- a/CodeEditModules/Modules/WorkspaceClient/src/Mocks.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Mocks.swift
@@ -8,6 +8,8 @@
 import Combine
 import Foundation
 
+// TODO: DOCS (Marco Carnevali)
+// swiftlint:disable missing_docs
 public extension WorkspaceClient {
     static var empty = Self(
         folderURL: { nil },

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -205,11 +205,11 @@ extension WorkspaceClient.FileItem: Hashable {
 
 extension WorkspaceClient.FileItem: Comparable {
     public static func == (lhs: WorkspaceClient.FileItem, rhs: WorkspaceClient.FileItem) -> Bool {
-        return lhs.id == rhs.id
+        lhs.id == rhs.id
     }
 
     public static func < (lhs: WorkspaceClient.FileItem, rhs: WorkspaceClient.FileItem) -> Bool {
-        return lhs.url.lastPathComponent < rhs.url.lastPathComponent
+        lhs.url.lastPathComponent < rhs.url.lastPathComponent
     }
 }
 

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -214,6 +214,9 @@ extension WorkspaceClient.FileItem: Comparable {
 }
 
 public extension Array where Element: Hashable {
+
+    // TODO: DOCS (Marco Carnevali)
+    // swiftlint:disable:next missing_docs
     func difference(from other: [Element]) -> [Element] {
         let thisSet = Set(self)
         let otherSet = Set(other)

--- a/CodeEditModules/Modules/WorkspaceClient/src/UI/FileIcon.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/UI/FileIcon.swift
@@ -11,7 +11,7 @@ import SwiftUI
 // swiftlint:disable missing_docs
 // swiftlint:disable function_body_length
 // swiftlint:disable cyclomatic_complexity
-public struct FileIcon {
+public enum FileIcon {
 
     // swiftlint:disable identifier_name
     public enum FileType: String {

--- a/CodeEditModules/Modules/WorkspaceClient/src/UI/FileIcon.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/UI/FileIcon.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+// TODO: DOCS (Nanashi Li)
+// swiftlint:disable missing_docs
 // swiftlint:disable function_body_length
 // swiftlint:disable cyclomatic_complexity
 public struct FileIcon {


### PR DESCRIPTION
# Description

Added a couple of new `SwiftLint` rules. In particular:
- [`missing_docs`](https://realm.github.io/SwiftLint/missing_docs.html)
- ~~[`implicit_return`](https://realm.github.io/SwiftLint/implicit_return.html)~~
- [`closure_spacing`](https://realm.github.io/SwiftLint/closure_spacing.html) 
- [`modifier_order`](https://realm.github.io/SwiftLint/modifier_order.html) 
- [`convenience_type`](https://realm.github.io/SwiftLint/convenience_type.html)

## Missing Docs

Docs are important for maintaining a large codebase. In order to enforce documentation the `missing_docs` rule was added. This will require documentation comments on `public` and `open` declarations. 

> It would be even better to go further and expand this to `internal` and `private` declarations as well. Also inherited types are currently excluded by default.

### Currently Missing

Currently there are a bunch of documentation blocks missing in our source code. Warnings are disabled using `// swiftlint:disable missing_docs` for these declarations. 

They are also marked with a `// TODO: DOCS (FILE_OWNER)` where `FILE_OWNER` is the name of the initial file creator. Please have a look at your files and add missing docs in a future PR!

In particular I found missing docs for files created by:
- @MarcoCarnevali 
- @pkasila 
- Aleksi Puttonen
- @RayZhao1998 
- @nanashili 

To find them all just search the project for text containing `TODO: DOCS`.

## ~~Implicit Returns~~

~~Swift supports implicit return of values in certain cases where the only statement is a return statement. This rule enforces this behavior.~~

```swift
var someBoolean: Bool {
    return true // ❌ return is not needed
}

var someBoolean: Bool {
    true // ✅ implicit return
}
```

## Closure Spacing

In order to enhance readability closure brackets should have a spacing around its statements.

```swift
// ❌ without spacing
someArray.sorted(by: {$0 < $1})
// ✅ with spacing
someArray.sorted(by: { $0 < $1 })
```

## Modifier Order

This is used to have a consistent modifier (`private/public`, `static`, `override`, …) order throughout the project.

## Convenience Type

In some cases we need to create types to bundle some `static` properties into groups. These should always be enums since they cannot be instantiated.

```swift
// ❌ only static properties, but structs can be instantiated.
// Instantiating this type makes no sense.
struct APIKeys {
    static let service1 = "SUPER_SECRET_APIKEY"
    static let service2 = "SUPER_SECRET_APIKEY"
    ...
}

// ✅ using a case-less enum which cannot be instantiated.
enum APIKeys {
    static let service1 = "SUPER_SECRET_APIKEY"
    static let service2 = "SUPER_SECRET_APIKEY"
    ...
}
```

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

