### PR TITLE
Implement Basic CLI (#17)

### DIFF
--- a/CodeEdit.xcworkspace/contents.xcworkspacedata
+++ b/CodeEdit.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:CodeEditCli">
+   </FileRef>
+   <FileRef
       location = "group:CodeEditModules">
    </FileRef>
    <FileRef

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -40,6 +40,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         checkForFilesToOpen()
 
         DispatchQueue.main.async {
+            var needToHandleOpen = true
+            
             if NSApp.windows.isEmpty {
                 if let projects = UserDefaults.standard.array(forKey: AppDelegate.recoverWorkspacesKey) as? [String],
                    !projects.isEmpty {
@@ -51,9 +53,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
                             document?.windowControllers.first?.synchronizeWindowTitleWithDocumentName()
                         }
                     }
-                    return
+                    
+                    needToHandleOpen = false
                 }
-
+            }
+            
+            for index in 0..<CommandLine.arguments.count {
+                if CommandLine.arguments[index] == "--open" && (index + 1) < CommandLine.arguments.count {
+                    let path = CommandLine.arguments[index+1]
+                    let url = URL(fileURLWithPath: path)
+                    
+                    CodeEditDocumentController.shared.reopenDocument(for: url, withContentsOf: url, display: true) { document, _, _ in
+                        document?.windowControllers.first?.synchronizeWindowTitleWithDocumentName()
+                    }
+                    
+                    needToHandleOpen = false
+                }
+            }
+            
+            if needToHandleOpen {
                 self.handleOpen()
             }
         }

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -45,6 +45,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>63d66022e9e2ca0fbe9b447c5e24e61dc1f8a024</string>
+	<string>6fe7e341334cd457ea527c908ff2f5c43a064d98</string>
 </dict>
 </plist>

--- a/CodeEditCli/.gitignore
+++ b/CodeEditCli/.gitignore
@@ -1,0 +1,1 @@
+.swiftpm/

--- a/CodeEditCli/Package.swift
+++ b/CodeEditCli/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.5
+
+import PackageDescription
+
+import PackageDescription
+
+let package = Package(
+    name: "CodeEditCli",
+    products: [
+        .executable(name: "CodeEditCli", targets: ["CodeEditCli"])
+    ],
+    dependencies: [],
+    targets: [
+        .executableTarget(
+            name: "CodeEditCli"
+        ),
+    ]
+)

--- a/CodeEditCli/Sources/CodeEditCli/main.swift
+++ b/CodeEditCli/Sources/CodeEditCli/main.swift
@@ -1,0 +1,42 @@
+//
+//  CodeEditCli.swift
+//  
+//
+//  Created by Ben Koska on 14.06.22.
+//
+
+import Foundation
+
+func convertToAbsolutePath(_ path: String) -> String {
+    let nsString = NSString(string: path)
+    if nsString.isAbsolutePath {
+        return nsString.standardizingPath
+    }
+    
+    return String(URL(string: path, relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))?.pathComponents.joined(separator: "/").dropFirst(1) ?? "")
+}
+
+func openApp(paths: [String]? = nil) {
+    let task = Process()
+    task.launchPath = "/usr/bin/open" // This should be the same on all installations of MacOS
+    
+    task.arguments = ["-a", "CodeEdit"]
+    
+    if let paths = paths {
+        task.arguments?.append("--args")
+        for path in paths {
+            task.arguments?.append("--open")
+            task.arguments?.append(convertToAbsolutePath(path))
+        }
+    }
+    
+    task.launch()
+}
+
+let args = CommandLine.arguments
+
+if args.count < 2 {
+    openApp()
+} else {
+    openApp(paths: Array(args.dropFirst(1)))
+}


### PR DESCRIPTION
# Description

- Ability to open folders on launch of App by specifying `--open {folder}` via the command-line args
- Created a simple command-line tool to open CodeEdit via the command line

Usage:
`codeedit` - Launches the app
`codeedit {path}` - Launches the app and opens the given path(s)

Paths may either be relative (such as ., .. or ../modules) or absolute (such as ~/Desktop or /Users/.../Desktop/)

# Related Issue

* #17 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] I documented my code
- [ ] Review requested

# Screenshots

No new UI features implemented.
