### PR TITLE
Fix open unsupported Documents, support for open image files

### DIFF
--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -69,7 +69,9 @@ struct WorkspaceCodeFileView: View {
         for item: WorkspaceClient.FileItem
     ) -> some View {
         ZStack {
-            if let url = otherFile.previewItemURL, let image = NSImage(contentsOf: url), otherFile.typeOfFile == .image {
+            if let url = otherFile.previewItemURL,
+               let image = NSImage(contentsOf: url),
+               otherFile.typeOfFile == .image {
                 GeometryReader { proxy in
                     if image.size.width > proxy.size.width || image.size.height > proxy.size.height {
                         OtherFileView(otherFile)

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -54,11 +54,13 @@ struct WorkspaceCodeFileView: View {
         _ codeFile: CodeFileDocument,
         for item: WorkspaceClient.FileItem
     ) -> some View {
-        VStack(spacing: 0) {
-            BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
-            Divider()
-            CodeFileView(codeFile: codeFile)
-        }
+        CodeFileView(codeFile: codeFile)
+            .safeAreaInset(edge: .top, spacing: 0) {
+                VStack(spacing: 0) {
+                    BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
+                    Divider()
+                }
+            }
     }
 
     @ViewBuilder
@@ -66,28 +68,26 @@ struct WorkspaceCodeFileView: View {
         _ otherFile: CodeFileDocument,
         for item: WorkspaceClient.FileItem
     ) -> some View {
-        VStack(spacing: 0) {
-            BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
-            Divider()
-            if otherFile.typeOfFile == .image {
-                if let url = otherFile.previewItemURL, let image = NSImage(contentsOf: url) {
-                    GeometryReader { proxy in
-                        if image.size.width > proxy.size.width || image.size.height > proxy.size.height {
-                            OtherFileView(otherFile)
-                        } else {
-                            OtherFileView(otherFile)
-                                .frame(width: image.size.width, height: image.size.height)
-                                .position(x: proxy.frame(in: .local).midX, y: proxy.frame(in: .local).midY)
-                        }
+        ZStack {
+            if let url = otherFile.previewItemURL, let image = NSImage(contentsOf: url), otherFile.typeOfFile == .image {
+                GeometryReader { proxy in
+                    if image.size.width > proxy.size.width || image.size.height > proxy.size.height {
+                        OtherFileView(otherFile)
+                    } else {
+                        OtherFileView(otherFile)
+                            .frame(width: image.size.width, height: image.size.height)
+                            .position(x: proxy.frame(in: .local).midX, y: proxy.frame(in: .local).midY)
                     }
-                } else {
-                    OtherFileView(otherFile)
                 }
             } else {
                 OtherFileView(otherFile)
             }
+        }.safeAreaInset(edge: .top, spacing: 0) {
+            VStack(spacing: 0) {
+                BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
+                Divider()
+            }
         }
-
     }
 
     var body: some View {

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -33,14 +33,12 @@ The file is not displayed in the editor because it is either binary or uses an u
                 }
                 return file.tabID == workspace.selectionState.selectedId
             }) {
-                if let codeFile = workspace.selectionState.openedCodeFiles[item] {
-                    CodeFileView(codeFile: codeFile)
-                        .safeAreaInset(edge: .top, spacing: 0) {
-                            VStack(spacing: 0) {
-                                BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
-                                Divider()
-                            }
-                        }
+                if let fileItem = workspace.selectionState.openedCodeFiles[item] {
+                    if fileItem.typeOfFile == .image {
+                        imageFileVIew(fileItem, for: item)
+                    } else {
+                        codeFileView(fileItem, for: item)
+                    }
                 } else {
                     Text(unsupportFileMessage)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -60,6 +58,32 @@ The file is not displayed in the editor because it is either binary or uses an u
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func codeFileView(
+        _ codeFile: CodeFileDocument,
+        for item: WorkspaceClient.FileItem
+    ) -> some View {
+        CodeFileView(codeFile: codeFile)
+            .safeAreaInset(edge: .top, spacing: 0) {
+                VStack(spacing: 0) {
+                    BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
+                    Divider()
+                }
+            }
+    }
+
+    @ViewBuilder
+    private func imageFileVIew(
+        _ imageFile: CodeFileDocument,
+        for item: WorkspaceClient.FileItem
+    ) -> some View {
+        VStack(spacing: 0) {
+            BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
+            Divider()
+            ImageFileView(imageFile: imageFile)
+        }
     }
 
     var body: some View {

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -32,12 +32,9 @@ struct WorkspaceCodeFileView: View {
                 return file.tabID == workspace.selectionState.selectedId
             }) {
                 if let fileItem = workspace.selectionState.openedCodeFiles[item] {
-                    switch fileItem.typeOfFile {
-                    case UTType.image:
-                        imageFileView(fileItem, for: item)
-                    case UTType.text:
+                    if fileItem.typeOfFile == .text {
                         codeFileView(fileItem, for: item)
-                    default:
+                    } else {
                         otherFileView(fileItem, for: item)
                     }
                 }
@@ -57,24 +54,10 @@ struct WorkspaceCodeFileView: View {
         _ codeFile: CodeFileDocument,
         for item: WorkspaceClient.FileItem
     ) -> some View {
-        CodeFileView(codeFile: codeFile)
-            .safeAreaInset(edge: .top, spacing: 0) {
-                VStack(spacing: 0) {
-                    BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
-                    Divider()
-                }
-            }
-    }
-
-    @ViewBuilder
-    private func imageFileView(
-        _ imageFile: CodeFileDocument,
-        for item: WorkspaceClient.FileItem
-    ) -> some View {
         VStack(spacing: 0) {
             BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
             Divider()
-            ImageFileView(imageFile: imageFile)
+            CodeFileView(codeFile: codeFile)
         }
     }
 
@@ -86,8 +69,25 @@ struct WorkspaceCodeFileView: View {
         VStack(spacing: 0) {
             BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
             Divider()
-            OtherFileView(otherFile)
+            if otherFile.typeOfFile == .image {
+                if let url = otherFile.previewItemURL, let image = NSImage(contentsOf: url) {
+                    GeometryReader { proxy in
+                        if image.size.width > proxy.size.width || image.size.height > proxy.size.height {
+                            OtherFileView(otherFile)
+                        } else {
+                            OtherFileView(otherFile)
+                                .frame(width: image.size.width, height: image.size.height)
+                                .position(x: proxy.frame(in: .local).midX, y: proxy.frame(in: .local).midY)
+                        }
+                    }
+                } else {
+                    OtherFileView(otherFile)
+                }
+            } else {
+                OtherFileView(otherFile)
+            }
         }
+
     }
 
     var body: some View {

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -39,12 +39,21 @@ struct WorkspaceCodeFileView: View {
                             }
                         }
                 } else {
-                    Text("No Editor")
-                        .font(.system(size: 17))
-                        .foregroundColor(.secondary)
-                        .frame(minHeight: 0)
-                        .clipped()
+                    Text("The file is not displayed in the editor because it is either binary or uses an unsupported text encoding")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .safeAreaInset(edge: .top, spacing: 0) {
+                            VStack(spacing: 0) {
+                                BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
+                                Divider()
+                            }
+                        }
                 }
+            } else {
+                Text("No Editor")
+                    .font(.system(size: 17))
+                    .foregroundColor(.secondary)
+                    .frame(minHeight: 0)
+                    .clipped()
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -18,7 +18,6 @@ struct WorkspaceCodeFileView: View {
 The file is not displayed in the editor because it is either binary or uses an unsupported text encoding
 """
 
-
     @ObservedObject
     var workspace: WorkspaceDocument
 

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -11,12 +11,10 @@ import WorkspaceClient
 import StatusBar
 import Breadcrumbs
 import AppPreferences
+import UniformTypeIdentifiers
 
 struct WorkspaceCodeFileView: View {
     var windowController: NSWindowController
-    private let unsupportFileMessage = """
-The file is not displayed in the editor because it is either binary or uses an unsupported text encoding
-"""
 
     @ObservedObject
     var workspace: WorkspaceDocument
@@ -34,20 +32,14 @@ The file is not displayed in the editor because it is either binary or uses an u
                 return file.tabID == workspace.selectionState.selectedId
             }) {
                 if let fileItem = workspace.selectionState.openedCodeFiles[item] {
-                    if fileItem.typeOfFile == .image {
-                        imageFileVIew(fileItem, for: item)
-                    } else {
+                    switch fileItem.typeOfFile {
+                    case UTType.image:
+                        imageFileView(fileItem, for: item)
+                    case UTType.text:
                         codeFileView(fileItem, for: item)
+                    default:
+                        otherFileView(fileItem, for: item)
                     }
-                } else {
-                    Text(unsupportFileMessage)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .safeAreaInset(edge: .top, spacing: 0) {
-                            VStack(spacing: 0) {
-                                BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
-                                Divider()
-                            }
-                        }
                 }
             } else {
                 Text("No Editor")
@@ -75,7 +67,7 @@ The file is not displayed in the editor because it is either binary or uses an u
     }
 
     @ViewBuilder
-    private func imageFileVIew(
+    private func imageFileView(
         _ imageFile: CodeFileDocument,
         for item: WorkspaceClient.FileItem
     ) -> some View {
@@ -83,6 +75,18 @@ The file is not displayed in the editor because it is either binary or uses an u
             BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
             Divider()
             ImageFileView(imageFile: imageFile)
+        }
+    }
+
+    @ViewBuilder
+    private func otherFileView(
+        _ otherFile: CodeFileDocument,
+        for item: WorkspaceClient.FileItem
+    ) -> some View {
+        VStack(spacing: 0) {
+            BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
+            Divider()
+            OtherFileView(otherFile)
         }
     }
 

--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -14,6 +14,10 @@ import AppPreferences
 
 struct WorkspaceCodeFileView: View {
     var windowController: NSWindowController
+    private let unsupportFileMessage = """
+The file is not displayed in the editor because it is either binary or uses an unsupported text encoding
+"""
+
 
     @ObservedObject
     var workspace: WorkspaceDocument
@@ -39,7 +43,7 @@ struct WorkspaceCodeFileView: View {
                             }
                         }
                 } else {
-                    Text("The file is not displayed in the editor because it is either binary or uses an unsupported text encoding")
+                    Text(unsupportFileMessage)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .safeAreaInset(edge: .top, spacing: 0) {
                             VStack(spacing: 0) {

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -60,7 +60,6 @@ import TabBar
                 self.openExtension(item: plugin)
             }
 
-            
         } catch let err {
             Swift.print(err)
         }
@@ -98,13 +97,7 @@ import TabBar
             withContentsOf: item.url,
             ofType: "public.source-code"
         )
-        
-        
-//        if !selectionState.openFileItems.contains(item) {
-//            selectionState.openFileItems.append(item)
-
-            selectionState.openedCodeFiles[item] = codeFile
-//        }
+        selectionState.openedCodeFiles[item] = codeFile
         Swift.print("Opening file for item: ", item.url)
     }
 

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -92,10 +92,11 @@ import TabBar
         if !selectionState.openFileItems.contains(item) {
             selectionState.openFileItems.append(item)
         }
+        let pathExtention = item.url.pathExtension
         let codeFile = try CodeFileDocument(
             for: item.url,
             withContentsOf: item.url,
-            ofType: "public.source-code"
+            ofType: pathExtention
         )
         selectionState.openedCodeFiles[item] = codeFile
         Swift.print("Opening file for item: ", item.url)

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -48,7 +48,9 @@ import TabBar
     func openTab(item: TabBarItemRepresentable) {
         do {
             updateNewlyOpenedTabs(item: item)
-
+            if selectionState.selectedId != item.tabID {
+                selectionState.selectedId = item.tabID
+            }
             switch item.tabID {
             case .codeEditor:
                 guard let file = item as? WorkspaceClient.FileItem else { return }
@@ -58,9 +60,7 @@ import TabBar
                 self.openExtension(item: plugin)
             }
 
-            if selectionState.selectedId != item.tabID {
-                selectionState.selectedId = item.tabID
-            }
+            
         } catch let err {
             Swift.print(err)
         }
@@ -90,17 +90,21 @@ import TabBar
     }
 
     private func openFile(item: WorkspaceClient.FileItem) throws {
+        if !selectionState.openFileItems.contains(item) {
+            selectionState.openFileItems.append(item)
+        }
         let codeFile = try CodeFileDocument(
             for: item.url,
             withContentsOf: item.url,
             ofType: "public.source-code"
         )
-
-        if !selectionState.openFileItems.contains(item) {
-            selectionState.openFileItems.append(item)
+        
+        
+//        if !selectionState.openFileItems.contains(item) {
+//            selectionState.openFileItems.append(item)
 
             selectionState.openedCodeFiles[item] = codeFile
-        }
+//        }
         Swift.print("Opening file for item: ", item.url)
     }
 

--- a/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
@@ -24,6 +24,8 @@ public final class CodeFileDocument: NSDocument, ObservableObject {
     @Published
     var image: NSImage?
 
+    /* This is the main type of the document. For example, if the file is end with '.png', it will be an image, if the file is end with '.py', it will be a text file. If its neither image or text, this could be nil.
+    */
     public var typeOfFile: UTType? {
         guard let fileType = fileType, let type = UTType(filenameExtension: fileType) else {
             return nil

--- a/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
@@ -34,7 +34,6 @@ public final class CodeFileDocument: NSDocument, ObservableObject {
         if type.conforms(to: UTType.text) {
             return UTType.text
         }
-        // TODO: support more type of documents
         return nil
     }
 
@@ -76,7 +75,6 @@ public final class CodeFileDocument: NSDocument, ObservableObject {
         case .text:
             guard let content = String(data: data, encoding: .utf8) else { throw CodeFileError.failedToDecode }
             self.content = content
-            // TODO: support more type of documents
         default:
             guard let content = String(data: data, encoding: .utf8) else { throw CodeFileError.failedToDecode }
             self.content = content

--- a/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
@@ -82,6 +82,4 @@ public final class CodeFileDocument: NSDocument, ObservableObject {
             self.content = content
         }
     }
-
-
 }

--- a/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
@@ -52,11 +52,8 @@ public final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem
     /*
      This is the QLPreviewItemURL
      */
-    public var previewItemURL: URL {
-        guard let fileURL = self.fileURL else {
-            return URL(string: "")!
-        }
-        return fileURL
+    public var previewItemURL: URL? {
+        fileURL
     }
 
     // MARK: - NSDocument

--- a/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
@@ -24,7 +24,11 @@ public final class CodeFileDocument: NSDocument, ObservableObject {
     @Published
     var image: NSImage?
 
-    /* This is the main type of the document. For example, if the file is end with '.png', it will be an image, if the file is end with '.py', it will be a text file. If its neither image or text, this could be nil.
+    /*
+     This is the main type of the document.
+     For example, if the file is end with '.png', it will be an image,
+     if the file is end with '.py', it will be a text file.
+     If its neither image or text, this could be nil.
     */
     public var typeOfFile: UTType? {
         guard let fileType = fileType, let type = UTType(filenameExtension: fileType) else {

--- a/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
@@ -43,7 +43,7 @@ public final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem
         if type.conforms(to: UTType.image) {
             return UTType.image
         }
-        if type.conforms(to: UTType.text){
+        if type.conforms(to: UTType.text) {
             return UTType.text
         }
         return nil

--- a/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
@@ -84,18 +84,10 @@ public final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem
     /// This fuction is used for decoding files.
     /// It should not throw error as unsupported files can still be opened by QLPreviewView.
     override public func read(from data: Data, ofType _: String) throws {
-        guard let typeOfFile = self.typeOfFile else {
-            guard let content = String(data: data, encoding: .utf8) else { return }
-            self.content = content
-            return
-        }
         switch typeOfFile {
-        case .image:
+        case .some(.image):
             guard let image = NSImage(data: data) else { return }
             self.image = image
-        case .text:
-            guard let content = String(data: data, encoding: .utf8) else { return }
-            self.content = content
         default:
             guard let content = String(data: data, encoding: .utf8) else { return }
             self.content = content

--- a/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
@@ -23,9 +23,6 @@ public final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem
     @Published
     var content = ""
 
-    @Published
-    var image: NSImage?
-
     /*
      This is the main type of the document.
      For example, if the file is end with '.png', it will be an image,
@@ -84,13 +81,7 @@ public final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem
     /// This fuction is used for decoding files.
     /// It should not throw error as unsupported files can still be opened by QLPreviewView.
     override public func read(from data: Data, ofType _: String) throws {
-        switch typeOfFile {
-        case .some(.image):
-            guard let image = NSImage(data: data) else { return }
-            self.image = image
-        default:
-            guard let content = String(data: data, encoding: .utf8) else { return }
-            self.content = content
-        }
+        guard let content = String(data: data, encoding: .utf8) else { return }
+        self.content = content
     }
 }

--- a/CodeEditModules/Modules/CodeFile/src/Image/ImageFileView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/Image/ImageFileView.swift
@@ -9,24 +9,19 @@ import SwiftUI
 
 public struct ImageFileView: View {
 
-    @ObservedObject
-    private var imageFile: CodeFileDocument
+    private let image: NSImage?
 
-    public init(imageFile: CodeFileDocument) {
-        self.imageFile = imageFile
+    public init(image: NSImage?) {
+        self.image = image
     }
 
     public var body: some View {
         GeometryReader { proxy in
-            if let image = imageFile.image {
+            if let image = image {
                 if image.size.width > proxy.size.width || image.size.height > proxy.size.height {
-                    ScrollView {
-                        Image(nsImage: image)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: proxy.size.width)
-                    }
-                    .frame(maxHeight: .infinity)
+                    Image(nsImage: image)
+                        .resizable()
+                        .scaledToFit()
                 } else {
                     Image(nsImage: image)
                         .frame(width: proxy.size.width, height: proxy.size.height)

--- a/CodeEditModules/Modules/CodeFile/src/Image/ImageFileView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/Image/ImageFileView.swift
@@ -7,31 +7,33 @@
 
 import SwiftUI
 
-struct ImageFileView: View {
-    var body: some View {
-        Image("")
-            .resizable()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+public struct ImageFileView: View {
+
+    @ObservedObject
+    private var imageFile: CodeFileDocument
+
+    public init(imageFile: CodeFileDocument) {
+        self.imageFile = imageFile
     }
 
-    func loadImageFromDiskWith(fileName: String) -> NSImage? {
-
-        let documentDirectory = FileManager.SearchPathDirectory.documentDirectory
-        let userDomainMask = FileManager.SearchPathDomainMask.userDomainMask
-        let paths = NSSearchPathForDirectoriesInDomains(documentDirectory, userDomainMask, true)
-
-        if let dirPath = paths.first {
-            let imageUrl = URL(fileURLWithPath: dirPath).appendingPathComponent(fileName)
-            let image = NSImage(contentsOfFile: imageUrl.path)
-            return image
-
+    public var body: some View {
+        GeometryReader { proxy in
+            if let image = imageFile.image {
+                if image.size.width > proxy.size.width || image.size.height > proxy.size.height {
+                    ScrollView {
+                        Image(nsImage: image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: proxy.size.width)
+                    }
+                    .frame(maxHeight: .infinity)
+                } else {
+                    Image(nsImage: image)
+                        .frame(width: proxy.size.width, height: proxy.size.height)
+                }
+            } else {
+                EmptyView()
+            }
         }
-        return nil
-    }
-}
-
-struct ImageFileView_Previews: PreviewProvider {
-    static var previews: some View {
-        ImageFileView()
     }
 }

--- a/CodeEditModules/Modules/CodeFile/src/Other/OtherFileView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/Other/OtherFileView.swift
@@ -16,7 +16,6 @@ import QuickLookUI
 /// ```
 public struct OtherFileView: NSViewRepresentable {
 
-    @ObservedObject
     private var otherFile: CodeFileDocument
 
     /// Initialize the OtherFileView
@@ -29,11 +28,13 @@ public struct OtherFileView: NSViewRepresentable {
 
     public func makeNSView(context: Context) -> QLPreviewView {
         let qlPreviewView = QLPreviewView()
-        qlPreviewView.previewItem = otherFile
+        qlPreviewView.previewItem = otherFile.previewItemURL as QLPreviewItem
         return qlPreviewView
     }
 
+    /// Update preview file when file changed
     public func updateNSView(_ nsView: QLPreviewView, context: Context) {
-        
+        nsView.previewItem = otherFile.previewItemURL as QLPreviewItem
     }
+
 }

--- a/CodeEditModules/Modules/CodeFile/src/Other/OtherFileView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/Other/OtherFileView.swift
@@ -28,13 +28,18 @@ public struct OtherFileView: NSViewRepresentable {
 
     public func makeNSView(context: Context) -> QLPreviewView {
         let qlPreviewView = QLPreviewView()
-        qlPreviewView.previewItem = otherFile.previewItemURL as QLPreviewItem
+        if let previewItemURL = otherFile.previewItemURL {
+            qlPreviewView.previewItem = previewItemURL as QLPreviewItem
+        }
         return qlPreviewView
     }
 
     /// Update preview file when file changed
     public func updateNSView(_ nsView: QLPreviewView, context: Context) {
-        nsView.previewItem = otherFile.previewItemURL as QLPreviewItem
+        if let previewItemURL = otherFile.previewItemURL {
+            nsView.previewItem = previewItemURL as QLPreviewItem
+        }
+
     }
 
 }

--- a/CodeEditModules/Modules/CodeFile/src/Other/OtherFileView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/Other/OtherFileView.swift
@@ -1,0 +1,39 @@
+//
+//  OtherFileView.swift
+//  
+//
+//  Created by Shibo Tong on 10/7/2022.
+//
+
+import SwiftUI
+import QuickLookUI
+
+/// A SwiftUI Wrapper for `QLPreviewView`
+/// Mainly used for other unsupported files
+/// ## Usage
+/// ```swift
+/// OtherFileView(otherFile)
+/// ```
+public struct OtherFileView: NSViewRepresentable {
+
+    @ObservedObject
+    private var otherFile: CodeFileDocument
+
+    /// Initialize the OtherFileView
+    /// - Parameter otherFile: a file which contains URL to show preview
+    public init(
+        _ otherFile: CodeFileDocument
+    ) {
+        self.otherFile = otherFile
+    }
+
+    public func makeNSView(context: Context) -> QLPreviewView {
+        let qlPreviewView = QLPreviewView()
+        qlPreviewView.previewItem = otherFile
+        return qlPreviewView
+    }
+
+    public func updateNSView(_ nsView: QLPreviewView, context: Context) {
+        
+    }
+}


### PR DESCRIPTION
# Description

What's been implemented:

*make unsupported filed can be opened and show error message
*add support for opening image files (#674)

# Related Issue

* #674 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] UI support for Binary Files
- [x] support for images
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="738" alt="Screen Shot 2022-06-30 at 01 17 51" src="https://user-images.githubusercontent.com/44807628/176473576-0eeb927e-5c7b-4b9b-8a23-ec5fedf3317e.png">
<img width="741" alt="Screen Shot 2022-06-30 at 01 18 32" src="https://user-images.githubusercontent.com/44807628/176473587-97a298ce-94dd-4a12-ad96-d8131dfd4a36.png">

