### PR TITLE
fix: fix #680 for could not find commit

### DIFF
--- a/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -240,7 +240,7 @@
         "repositoryURL": "https://github.com/mattmassicotte/tree-sitter-swift.git",
         "state": {
           "branch": "feature/spm",
-          "revision": "0305ffaa9df7266cf8f81d2a23f1b83888363288",
+          "revision": "79db1387dceb4b65175f194cc2b06507d2b4c26f",
           "version": null
         }
       },

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>037eed1d0c60b2023aaf0ad9558b8d851c6f4f29</string>
+	<string>bb373d99ddd7c91e31d6fd5a75d96db4fdbb9b3a</string>
 </dict>
 </plist>

--- a/Package.resolved
+++ b/Package.resolved
@@ -240,7 +240,7 @@
         "repositoryURL": "https://github.com/mattmassicotte/tree-sitter-swift.git",
         "state": {
           "branch": "feature/spm",
-          "revision": "0305ffaa9df7266cf8f81d2a23f1b83888363288",
+          "revision": "79db1387dceb4b65175f194cc2b06507d2b4c26f",
           "version": null
         }
       },


### PR DESCRIPTION
# Description

This will fix #680 for `could not find the commit 0305ffaa9df7266cf8f81d2a23f1b83888363288 in https://github.com/mattmassicotte/tree-sitter-swift.git`

# Related Issue
* #680

