### PR TITLE
Allow special characters to be used in file names

### DIFF
--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -92,9 +92,8 @@ extension OutlineTableViewCell: NSTextFieldDelegate {
     func validateFileName(for newName: String) -> Bool {
         guard newName != fileItem.fileName else { return true }
 
-        guard newName != "" &&
-               !newName.isValidFilename &&
-               !WorkspaceClient.FileItem.fileManger.fileExists(atPath:
+        guard newName != "" && newName.isValidFilename &&
+              !WorkspaceClient.FileItem.fileManger.fileExists(atPath:
                     fileItem.url.deletingLastPathComponent().appendingPathComponent(newName).path)
         else { return false }
 
@@ -104,8 +103,8 @@ extension OutlineTableViewCell: NSTextFieldDelegate {
 
 extension String {
     var isValidFilename: Bool {
-        let regex = ".*[^A-Za-z0-9 ].*"
+        let regex = ".*[^A-Za-z0-9 .].*"
         let testString = NSPredicate(format: "SELF MATCHES %@", regex)
-        return testString.evaluate(with: self.components(separatedBy: ".").joined(separator: ""))
+        return !testString.evaluate(with: self)
     }
 }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -106,6 +106,6 @@ extension String {
     var isValidFilename: Bool {
         let regex = ".*[^A-Za-z0-9 ].*"
         let testString = NSPredicate(format: "SELF MATCHES %@", regex)
-        return testString.evaluate(with: self)
+        return testString.evaluate(with: self.components(separatedBy: ".").joined(separator: ""))
     }
 }

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -103,7 +103,7 @@ extension OutlineTableViewCell: NSTextFieldDelegate {
 
 extension String {
     var isValidFilename: Bool {
-        let regex = ".*[^A-Za-z0-9 .].*"
+        let regex = "[^:]"
         let testString = NSPredicate(format: "SELF MATCHES %@", regex)
         return !testString.evaluate(with: self)
     }


### PR DESCRIPTION
# Description

Edited the `isValidFilename` get variable to allow strings to contain special characters

# Related Issue

* #351 

# Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
