### PR TITLE
Project sidebar loading optimisation

### DIFF
--- a/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
@@ -36,7 +36,6 @@ public extension WorkspaceClient {
                     var subItems: [FileItem]?
 
                     if isDir.boolValue {
-                        // TODO: Possibly optimize to loading avoid cache dirs and/or large folders
                         // Recursively fetch subdirectories and files if the path points to a directory
                         subItems = try loadFiles(fromURL: itemURL)
                     }
@@ -156,7 +155,7 @@ public extension WorkspaceClient {
             if directory != nil {
                 flattenedFileItems[directory!.relativePath]?.watcher?.cancel()
             } else {
-                for (index, item) in flattenedFileItems.values.enumerated() {
+                for item in flattenedFileItems.values {
                     item.watcher?.cancel()
                 }
             }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
@@ -141,15 +141,11 @@ public extension WorkspaceClient {
                 anotherInstanceRan = !(somethingChanged ?? false) ? 0 : anotherInstanceRan - 1
             }
             subject.send(workspaceItem.children ?? [])
-            startListeningToDirectory()
             isRunning = false
             anotherInstanceRan = 0
             // reload data in outline view controller through the main thread
             DispatchQueue.main.async { onRefresh() }
         }
-
-        // no longer functional. Directory listening code has been moved to the FileItem.
-        func startListeningToDirectory() {}
 
         func stopListeningToDirectory(directory: URL? = nil) {
             if directory != nil {
@@ -164,9 +160,7 @@ public extension WorkspaceClient {
         return Self(
             folderURL: { folderURL },
             getFiles: subject
-                .handleEvents(receiveSubscription: { _ in
-                    startListeningToDirectory()
-                }, receiveCancel: {
+                .handleEvents(receiveCancel: {
                     stopListeningToDirectory()
                 })
                 .receive(on: RunLoop.main)
@@ -178,28 +172,5 @@ public extension WorkspaceClient {
                 return item
             }
         )
-    }
-}
-
-extension URL {
-    var attributes: [FileAttributeKey: Any]? {
-        do {
-            return try FileManager.default.attributesOfItem(atPath: path)
-        } catch let error as NSError {
-            print("FileAttribute error: \(error)")
-        }
-        return nil
-    }
-
-    var fileSize: UInt64 {
-        return attributes?[.size] as? UInt64 ?? UInt64(0)
-    }
-
-    var fileSizeString: String {
-        return ByteCountFormatter.string(fromByteCount: Int64(fileSize), countStyle: .file)
-    }
-
-    var creationDate: Date? {
-        return attributes?[.creationDate] as? Date
     }
 }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -38,7 +38,6 @@ public extension WorkspaceClient {
 
         public func activateWatcher() -> Bool {
             let descriptor = open(self.url.path, O_EVTONLY)
-            print("Activating watcher \(descriptor) for \(self.title)")
             guard descriptor > 0 else { return false }
             let source = DispatchSource.makeFileSystemObjectSource(
                 fileDescriptor: descriptor,
@@ -111,7 +110,6 @@ public extension WorkspaceClient {
         /// Image(systemName: item.systemImage)
         /// ```
         public var systemImage: String {
-            print("Image accessed for \(self.title)")
             switch children {
             case nil:
                 return FileIcon.fileIcon(fileType: fileType)

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -114,7 +114,9 @@ public extension WorkspaceClient {
             case nil:
                 return FileIcon.fileIcon(fileType: fileType)
             case let .some(children):
-                if self.watcher == nil { self.activateWatcher() }
+                if self.watcher == nil && !self.activateWatcher() {
+                    return "questionmark.folder"
+                }
                 return folderIcon(children)
             }
         }


### PR DESCRIPTION
# Description

TL;DR, I optimised the project navigator code so that dispatch sources (AKA watchers, the thing that listens for changes within folders) are only applied to visible folders, greatly reducing the number of watchers that need to be created. This reduces the chance of bumping into the macOS file opening limit (eg. 2559 on my system).

More details: When a folder is compressed, the watcher still stays activated. This is to avoid repeatedly creating and cancelling watchers, using up a lot of RAM. In the (now rare) case that there are no more `open` calls left (meaning more than 2559 items have been opened), the icon goes from `folder` or `folder.fill` to `questionmark.folder` to indicate that it is not being watched. 

- [CodeEditModules/Modules/WorkspaceClient/src/Live.swift](https://github.com/CodeEditApp/CodeEdit/compare/main...KaiTheRedNinja:project-sidebar-loading-optimisation?expand=1#diff-c2648ae02aa199976b709a4a4697fce7cc427394e8bfe787dd1439fd68fdf802)
  - Moved file watching function to FileItem
  - Removed functionality of `startListeningToDirectory`
- [CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift](https://github.com/CodeEditApp/CodeEdit/compare/main...KaiTheRedNinja:project-sidebar-loading-optimisation?expand=1#diff-36567e2ccad007c9513fbeaf771729619fe2ab185cebff08fe8a467a16b1a984)
  - Moved file watching function from WorkspaceClient
  - Added functionality to add a watcher if the `image` property is accessed, meaning that the fileItem is being displayed in the sidebar. 

# Related Issue

* #677
* #351

# Checklist

- [x] Clean up code
- [x] Test on large project
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots
example of a NextJS project (with node modules) successfully opened in CodeEdit, with enough `open` calls left to open a few tabs. Only the 13 folders visible here have watchers attached to them, making about 29 watchers in total (CodeEdit itself requires about 16 files open for miscellaneous purposes), well below the 2559 item file limit of my system.
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/88234730/178643157-17e2cc4e-9714-4527-a1cd-d321ed311f65.png">
