### PR TITLE
Enforces code style for enum case bindings.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,6 +20,7 @@ opt_in_rules:
 #  - implicit_return
   - modifier_order
   - convenience_type
+  - pattern_matching_keywords
 
 custom_rules:
   spaces_over_tabs:

--- a/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Routers/BitbucketRepositoryRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Bitbucket/Routers/BitbucketRepositoryRouter.swift
@@ -48,7 +48,7 @@ public enum BitbucketRepositoryRouter: Router {
             } else {
                 return "repositories"
             }
-        case .readRepository(_, let owner, let name):
+        case let .readRepository(_, owner, name):
             return "repositories/\(owner)/\(name)"
         }
     }

--- a/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/CommitRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/CommitRouter.swift
@@ -16,12 +16,11 @@ enum CommitRouter: Router {
 
     var configuration: Configuration? {
         switch self {
-        case .readCommits(let config, nil, nil, nil, nil): return config
-        case .readCommit(let config, nil, nil): return config
-        case .readCommitDiffs(let config, nil, nil): return config
-        case .readCommitComments(let config, nil, nil): return config
-        case .readCommitStatuses(let config, nil, nil, nil, nil, nil, nil): return config
-        default: return nil
+        case let .readCommits(config, _, _, _, _): return config
+        case let .readCommit(config, _, _): return config
+        case let .readCommitDiffs(config, _, _): return config
+        case let .readCommitComments(config, _, _): return config
+        case let .readCommitStatuses(config, _, _, _, _, _, _): return config
         }
     }
 
@@ -35,33 +34,31 @@ enum CommitRouter: Router {
 
     var params: [String: Any] {
         switch self {
-        case .readCommits(nil, nil, let refName, let since, let until):
+        case let .readCommits(_, _, refName, since, until):
             return ["ref_name": refName, "since": since, "until": until]
-        case .readCommit(nil, nil, nil):
+        case .readCommit:
             return [:]
-        case .readCommitDiffs(nil, nil, nil):
+        case .readCommitDiffs:
             return [:]
-        case .readCommitComments(nil, nil, nil):
+        case .readCommitComments:
             return [:]
-        case .readCommitStatuses(nil, nil, nil, let ref, let stage, let name, let all):
+        case let .readCommitStatuses(_, _, _, ref, stage, name, all):
             return ["ref": ref, "stage": stage, "name": name, "all": String(all)]
-        default: return [:]
         }
     }
 
     var path: String {
         switch self {
-        case .readCommits(nil, let id, nil, nil, nil):
+        case let .readCommits(_, id, _, _, _):
             return "project/\(id)/repository/commits"
-        case .readCommit(nil, let id, let sha):
+        case let .readCommit(_, id, sha):
             return "project/\(id)/repository/commits/\(sha)"
-        case .readCommitDiffs(nil, let id, let sha):
+        case let .readCommitDiffs(_, id, sha):
             return "project/\(id)/repository/commits/\(sha)/diff"
-        case .readCommitComments(nil, let id, let sha):
+        case let .readCommitComments(_, id, sha):
             return "project/\(id)/repository/commits/\(sha)/comments"
-        case .readCommitStatuses(nil, let id, let sha, nil, nil, nil, nil):
+        case let .readCommitStatuses(_, id, sha, _, _, _, _):
             return "project/\(id)/repository/commits/\(sha)/statuses"
-        default: return ""
         }
     }
 }

--- a/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/GitlabOAuthRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/GitlabOAuthRouter.swift
@@ -47,12 +47,12 @@ enum GitlabOAuthRouter: Router {
 
     var params: [String: Any] {
         switch self {
-        case .authorize(let config, let redirectURI):
+        case let .authorize(config, redirectURI):
             return [
                 "client_id": config.token as AnyObject,
                 "response_type": "code" as AnyObject,
                 "redirect_uri": redirectURI as AnyObject]
-        case .accessToken(let config, let code, let rediredtURI):
+        case let .accessToken(config, code, rediredtURI):
             return [
                 "client_id": config.token as AnyObject,
                 "client_secret": config.secret as AnyObject,

--- a/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/ProjectRouter.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Gitlab/Routers/ProjectRouter.swift
@@ -108,16 +108,16 @@ enum ProjectRouter: Router {
 
     var params: [String: Any] {
         switch self {
-        case .readAuthenticatedProjects(
+        case let .readAuthenticatedProjects(
             _,
-            let page,
-            let perPage,
-            let archived,
-            let visibility,
-            let orderBy,
-            let sort,
-            let search,
-            let simple):
+            page,
+            perPage,
+            archived,
+            visibility,
+            orderBy,
+            sort,
+            search,
+            simple):
             return [
                 "page": page,
                 "per_page": perPage,
@@ -127,16 +127,16 @@ enum ProjectRouter: Router {
                 "sort": sort,
                 "search": search,
                 "simple": String(simple)]
-        case .readVisibleProjects(
+        case let .readVisibleProjects(
             _,
-            let page,
-            let perPage,
-            let archived,
-            let visibility,
-            let orderBy,
-            let sort,
-            let search,
-            let simple):
+            page,
+            perPage,
+            archived,
+            visibility,
+            orderBy,
+            sort,
+            search,
+            simple):
             return [
                 "page": page,
                 "per_page": perPage,
@@ -146,15 +146,16 @@ enum ProjectRouter: Router {
                 "sort": sort,
                 "search": search,
                 "simple": String(simple)]
-        case .readOwnedProjects(
-            _, let page,
-            let perPage,
-            let archived,
-            let visibility,
-            let orderBy,
-            let sort,
-            let search,
-            let simple):
+        case let .readOwnedProjects(
+            _,
+            page,
+            perPage,
+            archived,
+            visibility,
+            orderBy,
+            sort,
+            search,
+            simple):
             return [
                 "page": page,
                 "per_page": perPage,
@@ -164,16 +165,16 @@ enum ProjectRouter: Router {
                 "sort": sort,
                 "search": search,
                 "simple": String(simple)]
-        case .readStarredProjects(
+        case let .readStarredProjects(
             _,
-            let page,
-            let perPage,
-            let archived,
-            let visibility,
-            let orderBy,
-            let sort,
-            let search,
-            let simple):
+            page,
+            perPage,
+            archived,
+            visibility,
+            orderBy,
+            sort,
+            search,
+            simple):
             return [
                 "page": page,
                 "per_page": perPage,
@@ -183,16 +184,16 @@ enum ProjectRouter: Router {
                 "sort": sort,
                 "search": search,
                 "simple": String(simple)]
-        case .readAllProjects(
+        case let .readAllProjects(
             _,
-            let page,
-            let perPage,
-            let archived,
-            let visibility,
-            let orderBy,
-            let sort,
-            let search,
-            let simple):
+            page,
+            perPage,
+            archived,
+            visibility,
+            orderBy,
+            sort,
+            search,
+            simple):
             return [
                 "page": page,
                 "per_page": perPage,
@@ -204,7 +205,7 @@ enum ProjectRouter: Router {
                 "simple": String(simple)]
         case .readSingleProject:
             return [:]
-        case .readProjectEvents(_, _, let page, let perPage):
+        case let .readProjectEvents(_, _, page, perPage):
             return ["per_page": perPage, "page": page]
         case .readProjectHooks:
             return [:]
@@ -231,7 +232,7 @@ enum ProjectRouter: Router {
             return "projects/\(id)/events"
         case .readProjectHooks(_, let id):
             return "projects/\(id)/hooks"
-        case .readProjectHook(_, let id, let hookId):
+        case let .readProjectHook(_, id, hookId):
             return "projects/\(id)/hooks/\(hookId)"
         }
     }


### PR DESCRIPTION
# Description

This PR enforces code style for enum case bindings.

1. Uses `_` instead of `nil` for enum case matching patterns to resolve Xcode 14 warnings.
2. Updates enum case binding code to use single `let` keyword and add rule `pattern_matching_keywords` to `.swiftlint.yml` to ensure code consistency.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [ ] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
