### PR TITLE
Use truncatingMiddle lineBreakMode for project outline cells.

### DIFF
--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -29,6 +29,7 @@ final class OutlineTableViewCell: NSTableCellView {
         self.label.delegate = self
         self.label.layer?.cornerRadius = 10.0
         self.label.font = .labelFont(ofSize: fontSize)
+        self.label.lineBreakMode = .byTruncatingMiddle
 
         self.addSubview(label)
         self.textField = label


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->
This PR uses `.truncatingMiddle` `lineBreakMode` for project outline cells. This helps display ellipsis on the middle of long file names.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [ ] Review requested

# Screenshots

![project-online-truncate-middle](https://user-images.githubusercontent.com/8158163/180604932-fe45630d-02b7-4be3-b106-943501ad2227.png)
