### PR TITLE
Fix multiple file writes on tab close with `NSData.write`

### DIFF
--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -201,7 +201,7 @@ import TabBar
             do {
                 guard let file = selectionState.openedCodeFiles.removeValue(forKey: item) else { throw NSError() }
                 guard let url  = file.fileURL else { throw NSError() }
-                
+
                 if file.typeOfFile == .text {
                     try NSData(data: file.data(ofType: "public.source-code")).write(to: url, atomically: true)
                 }
@@ -209,7 +209,7 @@ import TabBar
                 Swift.print("Failed to write file for item: ", item.url)
             }
         }
-        
+
         guard let idx = selectionState.openFileItems.firstIndex(of: item) else { return }
         selectionState.openFileItems.remove(at: idx)
     }

--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -198,12 +198,18 @@ import TabBar
     /// Removes the tab item from `openedCodeFiles`, `openedExtensions`, and `openFileItems`.
     private func closeFileTab(item: WorkspaceClient.FileItem) {
         defer {
-            let file = selectionState.openedCodeFiles.removeValue(forKey: item)
-            if file?.typeOfFile == .text {
-                file?.save(self)
+            do {
+                guard let file = selectionState.openedCodeFiles.removeValue(forKey: item) else { throw NSError() }
+                guard let url  = file.fileURL else { throw NSError() }
+                
+                if file.typeOfFile == .text {
+                    try NSData(data: file.data(ofType: "public.source-code")).write(to: url, atomically: true)
+                }
+            } catch {
+                Swift.print("Failed to write file for item: ", item.url)
             }
         }
-
+        
         guard let idx = selectionState.openFileItems.firstIndex(of: item) else { return }
         selectionState.openFileItems.remove(at: idx)
     }


### PR DESCRIPTION
# Description

Currently, when closing a tab, CodeEdit performs an automatic save action in order to preserve changes on the file (text documents only), this was previously achieved by doing `file.save`, however, something that I noticed is that the file was being written more than two times – some times it would be 3, other times 4, even 5 or 6 writes, randomly (see attached videos).

This PR replaces `file.save` with the `NSData.write` method, with `atomically` set to `true`, which gets reflected on the file consistently being altered 2 times (the expected behavior when doing atomic writing), solving the issue of the multiple and/or random writes to the file.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [ ] Review requested

# Screenshots

Before (using `file.save`):

https://user-images.githubusercontent.com/43397475/180612554-49c9e94a-083b-4106-a736-f1746c4fedf3.mov

After (using `NSData.write`):

https://user-images.githubusercontent.com/43397475/180612710-3c29e238-da67-475e-a3df-8e1a99dcdb47.mov
