### PR TITLE
Update sindresorhus/Preferences dependency to 2.6.0

### DIFF
--- a/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/sindresorhus/Preferences.git",
         "state": {
           "branch": null,
-          "revision": "ffeaaad1def45d0625720dc1adae3789cd9c167d",
-          "version": "2.5.0"
+          "revision": "2651cd144615009242c994b087508fef99e9275c",
+          "version": "2.6.0"
         }
       },
       {

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>0dbc0fce793f80730fe17b6bf0b0fbb8c189232a</string>
+	<string>872d305bc31313f9acdd39de5ec8c2f00016a885</string>
 </dict>
 </plist>

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -101,7 +101,7 @@ let package = Package(
         .package(
             name: "Preferences",
             url: "https://github.com/sindresorhus/Preferences.git",
-            from: "2.5.0"
+            from: "2.6.0"
         ),
         .package(
             name: "CodeEditKit",


### PR DESCRIPTION
The git tag for 2.5.0 doesn't exist anymore and creates issues when building.

# Description

This simply just updates the dependency for `sindresorhus/Preferences` to 2.6.0 since the 2.5.0 tag doesn't exist anymore.

# Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] I documented my code (N/A)
- [ ] Review requested
