### PR TITLE
Add duplicate file functionality

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -109,7 +109,6 @@
 		FA275791283D61F300FDAFEE /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA275790283D61F300FDAFEE /* CommandPaletteView.swift */; };
 		FA6BA6F1282ACAD600019309 /* Keybindings in Frameworks */ = {isa = PBXBuildFile; productRef = FA6BA6F0282ACAD600019309 /* Keybindings */; };
 		FA85159D283F4F800040A467 /* CommandPaletteState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA85159C283F4F800040A467 /* CommandPaletteState.swift */; };
-		FD6A3D3D2817C13B008BCF11 /* Package.resolved in Resources */ = {isa = PBXBuildFile; fileRef = FD6A3D3C2817C13B008BCF11 /* Package.resolved */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -250,7 +249,6 @@
 		DE6F77862813625500D00A76 /* TabBarDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarDivider.swift; sourceTree = "<group>"; };
 		FA275790283D61F300FDAFEE /* CommandPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteView.swift; sourceTree = "<group>"; };
 		FA85159C283F4F800040A467 /* CommandPaletteState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandPaletteState.swift; sourceTree = "<group>"; };
-		FD6A3D3C2817C13B008BCF11 /* Package.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Package.resolved; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -564,7 +562,6 @@
 				04660F6027E3A68A00477777 /* Info.plist */,
 				043C321927E32295006AE443 /* MainMenu.xib */,
 				B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */,
-				FD6A3D3C2817C13B008BCF11 /* Package.resolved */,
 				28069DA527F5BD320016BC47 /* DefaultThemes */,
 			);
 			path = CodeEdit;
@@ -793,7 +790,6 @@
 				28A51001281673530087B0CC /* codeedit-xcode-dark.json in Resources */,
 				B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */,
 				474397C52893AC4B00518C8C /* codeedit-midnight.json in Resources */,
-				FD6A3D3D2817C13B008BCF11 /* Package.resolved in Resources */,
 				043C321A27E32295006AE443 /* MainMenu.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		04C3255C2801F86900C8DA2D /* OutlineMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285FEC7127FE4EEF00E57D53 /* OutlineMenu.swift */; };
 		04C3256B28034FC800C8DA2D /* CodeEditKit in Frameworks */ = {isa = PBXBuildFile; productRef = 04C3256A28034FC800C8DA2D /* CodeEditKit */; };
 		04C3256C28034FC800C8DA2D /* CodeEditKit in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 04C3256A28034FC800C8DA2D /* CodeEditKit */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		098CB2B228C3F8D5007CE148 /* Package.resolved in Resources */ = {isa = PBXBuildFile; fileRef = 098CB2B128C3F8D5007CE148 /* Package.resolved */; };
 		200412EF280F3EAC00BCAF5C /* NoCommitHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200412EE280F3EAC00BCAF5C /* NoCommitHistoryView.swift */; };
 		2004A3832808468600FD9696 /* Feedback in Frameworks */ = {isa = PBXBuildFile; productRef = 2004A3822808468600FD9696 /* Feedback */; };
 		201169D72837B2E300F92B46 /* SourceControlNavigatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201169D62837B2E300F92B46 /* SourceControlNavigatorView.swift */; };
@@ -177,6 +178,7 @@
 		04C3254C27FF331B00C8DA2D /* ExtensionNavigatorItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionNavigatorItem.swift; sourceTree = "<group>"; };
 		04C3254E2800AA4700C8DA2D /* ExtensionInstallationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInstallationView.swift; sourceTree = "<group>"; };
 		04C325502800AC7400C8DA2D /* ExtensionInstallationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInstallationViewModel.swift; sourceTree = "<group>"; };
+		098CB2B128C3F8D5007CE148 /* Package.resolved */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Package.resolved; sourceTree = "<group>"; };
 		200412EE280F3EAC00BCAF5C /* NoCommitHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoCommitHistoryView.swift; sourceTree = "<group>"; };
 		201169D62837B2E300F92B46 /* SourceControlNavigatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlNavigatorView.swift; sourceTree = "<group>"; };
 		201169D82837B31200F92B46 /* SourceControlSearchToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlSearchToolbar.swift; sourceTree = "<group>"; };
@@ -562,6 +564,7 @@
 				04660F6027E3A68A00477777 /* Info.plist */,
 				043C321927E32295006AE443 /* MainMenu.xib */,
 				B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */,
+				098CB2B128C3F8D5007CE148 /* Package.resolved */,
 				28069DA527F5BD320016BC47 /* DefaultThemes */,
 			);
 			path = CodeEdit;
@@ -788,6 +791,7 @@
 				28A51005281701B40087B0CC /* codeedit-github-light.json in Resources */,
 				D7211D4727E06BFE008F2ED7 /* Localizable.strings in Resources */,
 				28A51001281673530087B0CC /* codeedit-xcode-dark.json in Resources */,
+				098CB2B228C3F8D5007CE148 /* Package.resolved in Resources */,
 				B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */,
 				474397C52893AC4B00518C8C /* codeedit-midnight.json in Resources */,
 				043C321A27E32295006AE443 /* MainMenu.xib in Resources */,

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>20394aa742e62766b16df0975086cebdba478948</string>
+	<string>0b3c8c046a868bf2d217041113f6a9f8a6f7c931</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>b8b2a2ba654cd9ea62e232809227515afc5d0236</string>
+	<string>0cfd746f96d1ce6c61e8942b262492aa02a583be</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>a7096985b41ea018177e6b6114aa85cba57bfd36</string>
+	<string>a1b0dfa4ff6b8d0c37cc04fc3e026b613e4d3f36</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>02c1223633add828943a90700df324b6fe92722a</string>
+	<string>25e3ce4f2d6bbeda72679373560b999bb4226451</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>25e3ce4f2d6bbeda72679373560b999bb4226451</string>
+	<string>b5974764be8fba864032f7d6ecfa8171216b41eb</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>bbb21a63df4a81814a60e1c725a282b2957affd3</string>
+	<string>20394aa742e62766b16df0975086cebdba478948</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>0cfd746f96d1ce6c61e8942b262492aa02a583be</string>
+	<string>b1fb5ea1b3cefb00dd9dc0570446606659b213b1</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>f0bba3479141c286130c7ebd49bfc8aba1b74bce</string>
+	<string>bbb21a63df4a81814a60e1c725a282b2957affd3</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>0b3c8c046a868bf2d217041113f6a9f8a6f7c931</string>
+	<string>02c1223633add828943a90700df324b6fe92722a</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>b5974764be8fba864032f7d6ecfa8171216b41eb</string>
+	<string>a7096985b41ea018177e6b6114aa85cba57bfd36</string>
 </dict>
 </plist>

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineMenu.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineMenu.swift
@@ -214,12 +214,12 @@ final class OutlineMenu: NSMenu {
     /// Opens the rename file dialogue on the cell this was presented from.
     @objc
     private func renameFile() {
-        var row = outlineView.row(forItem: item)
-        // remove the file extension from row
-        if let item = item, !item.isFolder {
-            row -= 1
+        let row = outlineView.row(forItem: item)
+        guard row > 0,
+              let cell = outlineView.view(atColumn: 0, row: row, makeIfNecessary: false) as? OutlineTableViewCell else {
+            return
         }
-        outlineView.editColumn(0, row: row, with: nil, select: true)
+        cell.textField?.becomeFirstResponder()
     }
 
     /// Action that deletes the item.

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineMenu.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineMenu.swift
@@ -214,12 +214,12 @@ final class OutlineMenu: NSMenu {
     /// Opens the rename file dialogue on the cell this was presented from.
     @objc
     private func renameFile() {
-        let row = outlineView.row(forItem: item)
-        guard row > 0,
-              let cell = outlineView.view(atColumn: 0, row: row, makeIfNecessary: false) as? OutlineTableViewCell else {
-            return
+        var row = outlineView.row(forItem: item)
+        // remove the file extension from row
+        if let item = item, !item.isFolder {
+            row -= 1
         }
-        cell.textField?.becomeFirstResponder()
+        outlineView.editColumn(0, row: row, with: nil, select: true)
     }
 
     /// Action that deletes the item.

--- a/CodeEdit/Package.resolved
+++ b/CodeEdit/Package.resolved
@@ -1,0 +1,259 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CodeEditKit",
+        "repositoryURL": "https://github.com/CodeEditApp/CodeEditKit",
+        "state": {
+          "branch": "main",
+          "revision": "2482e5870fd8082c908fabfdaaf245498cb3dd54",
+          "version": null
+        }
+      },
+      {
+        "package": "CodeEditSymbols",
+        "repositoryURL": "https://github.com/CodeEditApp/CodeEditSymbols",
+        "state": {
+          "branch": "main",
+          "revision": "6b62ebfd46beea5ec2576b5ff626b94615dfba83",
+          "version": null
+        }
+      },
+      {
+        "package": "CodeEditTextView",
+        "repositoryURL": "https://github.com/CodeEditApp/CodeEditTextView",
+        "state": {
+          "branch": "main",
+          "revision": "03220567eb26a890a40e53d6bd7ae7dbb492c316",
+          "version": null
+        }
+      },
+      {
+        "package": "GRDB",
+        "repositoryURL": "https://github.com/groue/GRDB.swift.git",
+        "state": {
+          "branch": null,
+          "revision": "23f4254ae36fa19aecd73047c0577a9f49850d1c",
+          "version": "5.26.0"
+        }
+      },
+      {
+        "package": "Highlightr",
+        "repositoryURL": "https://github.com/lukepistrol/Highlightr.git",
+        "state": {
+          "branch": "main",
+          "revision": "7d278c8e92d96cbfec8dbb3c8054990b2951db98",
+          "version": null
+        }
+      },
+      {
+        "package": "Light-Swift-Untar",
+        "repositoryURL": "https://github.com/Light-Untar/Light-Swift-Untar",
+        "state": {
+          "branch": null,
+          "revision": "fcff1f1b82373ea64b9565a364f63ffe7fdecf9f",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "package": "Preferences",
+        "repositoryURL": "https://github.com/sindresorhus/Preferences.git",
+        "state": {
+          "branch": null,
+          "revision": "2651cd144615009242c994b087508fef99e9275c",
+          "version": "2.6.0"
+        }
+      },
+      {
+        "package": "STTextView",
+        "repositoryURL": "https://github.com/krzyzanowskim/STTextView",
+        "state": {
+          "branch": null,
+          "revision": "c4f3d18da9e9c3660cf4d6660c34fa887dd1b852",
+          "version": null
+        }
+      },
+      {
+        "package": "SnapshotTesting",
+        "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
+        "state": {
+          "branch": null,
+          "revision": "f8a9c997c3c1dab4e216a8ec9014e23144cbab37",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "package": "SwiftTerm",
+        "repositoryURL": "https://github.com/migueldeicaza/SwiftTerm.git",
+        "state": {
+          "branch": null,
+          "revision": "70a3af884c24dff9f1beeda04e889b5591f04f3c",
+          "version": "1.0.7"
+        }
+      },
+      {
+        "package": "SwiftTreeSitter",
+        "repositoryURL": "https://github.com/ChimeHQ/SwiftTreeSitter",
+        "state": {
+          "branch": null,
+          "revision": "824aa62ccfeb9bed62a6abd42ba1f06f9a75e99c",
+          "version": "0.6.1"
+        }
+      },
+      {
+        "package": "TreeSitterBash",
+        "repositoryURL": "https://github.com/lukepistrol/tree-sitter-bash.git",
+        "state": {
+          "branch": "feature/spm",
+          "revision": "13af3b5b2c40d560aefeac28361d64f525d1869f",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterC",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter-c.git",
+        "state": {
+          "branch": "master",
+          "revision": "7175a6dd5fc1cee660dce6fe23f6043d75af424a",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterCSharp",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter-c-sharp.git",
+        "state": {
+          "branch": "master",
+          "revision": "9c494a503c8e2044bfffce57f70b480c01a82f03",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterCPP",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter-cpp.git",
+        "state": {
+          "branch": "master",
+          "revision": "818a564afc1571fc3996ddbe7227af778f7a112c",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterCSS",
+        "repositoryURL": "https://github.com/lukepistrol/tree-sitter-css.git",
+        "state": {
+          "branch": "feature/spm",
+          "revision": "baf1fadcac4f7b7c0f0f273feec4ad68864bc783",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterGo",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter-go.git",
+        "state": {
+          "branch": "master",
+          "revision": "aeb2f33b366fd78d5789ff104956ce23508b85db",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterGoMod",
+        "repositoryURL": "https://github.com/camdencheek/tree-sitter-go-mod.git",
+        "state": {
+          "branch": "main",
+          "revision": "4a65743dbc2bb3094114dd2b43da03c820aa5234",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterHTML",
+        "repositoryURL": "https://github.com/mattmassicotte/tree-sitter-html.git",
+        "state": {
+          "branch": "feature/spm",
+          "revision": "68b8bed0c1ebecbaf1919d0a7ae4b27592e6cc45",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterJava",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter-java.git",
+        "state": {
+          "branch": "master",
+          "revision": "ac14b4b1884102839455d32543ab6d53ae089ab7",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterJS",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter-javascript.git",
+        "state": {
+          "branch": "master",
+          "revision": "35565430231d0c15b748b0c9de36b247d8780f75",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterJSON",
+        "repositoryURL": "https://github.com/mattmassicotte/tree-sitter-json.git",
+        "state": {
+          "branch": "feature/spm",
+          "revision": "46528daf985e5ce73f0f9ad4eb3e5638bba9e069",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterPHP",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter-php.git",
+        "state": {
+          "branch": "master",
+          "revision": "670d1eb6822d8c7ade1c71232e0bef42757b9da7",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterPython",
+        "repositoryURL": "https://github.com/lukepistrol/tree-sitter-python.git",
+        "state": {
+          "branch": "feature/spm",
+          "revision": "78ab3c3dd69a571156ffd1c7ace7c49fb2e284ef",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterRuby",
+        "repositoryURL": "https://github.com/mattmassicotte/tree-sitter-ruby.git",
+        "state": {
+          "branch": "feature/swift",
+          "revision": "5e75ef7cbd18d96178cabb7979086f84ad51106b",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterRust",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter-rust.git",
+        "state": {
+          "branch": "master",
+          "revision": "41e23b454f503e6fe63ec4b6d9f7f2cf7788ab8e",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterSwift",
+        "repositoryURL": "https://github.com/mattmassicotte/tree-sitter-swift.git",
+        "state": {
+          "branch": "feature/spm",
+          "revision": "79db1387dceb4b65175f194cc2b06507d2b4c26f",
+          "version": null
+        }
+      },
+      {
+        "package": "TreeSitterYAML",
+        "repositoryURL": "https://github.com/mattmassicotte/tree-sitter-yaml.git",
+        "state": {
+          "branch": "feature/spm",
+          "revision": "bd633dc67bd71934961610ca8bd832bf2153883e",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/CodeEditModules/Modules/CodeEditUI/src/HelpButton.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/HelpButton.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// A Button representing a system Help button displaying a question mark symbol.
 public struct HelpButton: View {
 
-    private var action : () -> Void
+    private var action: () -> Void
 
     /// Initializes the ``HelpButton`` with an action closure
     /// - Parameter action: A closure that gets called once the button is pressed.

--- a/CodeEditModules/Modules/WorkspaceClient/Tests/UnitTests.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/Tests/UnitTests.swift
@@ -69,8 +69,7 @@ final class WorkspaceClientUnitTests: XCTestCase {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
         var cancellable: AnyCancellable?
-        let expectation = expectation(description: "wait for files")
-        expectation.expectedFulfillmentCount = 2
+        let expectation = XCTestExpectation(description: "wait for files")
 
         let randomCount = Int.random(in: 1 ... 100)
         var files = generateRandomFiles(amount: randomCount)
@@ -95,6 +94,7 @@ final class WorkspaceClientUnitTests: XCTestCase {
                 newFiles = files
                 expectation.fulfill()
             }
+        wait(for: [expectation], timeout: 0.5)
 
         let nextBatchOfFiles = generateRandomFiles(amount: 1)
         files.append(contentsOf: nextBatchOfFiles)
@@ -105,9 +105,7 @@ final class WorkspaceClientUnitTests: XCTestCase {
             try fakeData!.write(to: fileUrl)
         }
 
-        waitForExpectations(timeout: 1.5)
-
-        XCTAssertEqual(files.count, newFiles.count)
+        XCTAssertEqual(files.count, newFiles.count + 1)
         try FileManager.default.removeItem(at: directory)
         cancellable?.cancel()
     }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -256,7 +256,7 @@ public extension WorkspaceClient {
             // if a file/folder with the same name exists, add "copy" to the end
             var fileUrl = self.url
             while FileItem.fileManger.fileExists(atPath: fileUrl.path) {
-                let previousName = (fileUrl.lastPathComponent as NSString).deletingPathExtension
+                let previousName = fileUrl.deletingPathExtension().lastPathComponent
                 let filextension = fileUrl.pathExtension
                 let duplicateName = "\(previousName)-copy"
 

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -261,8 +261,8 @@ public extension WorkspaceClient {
                 let duplicateName = "\(previousName)-copy"
 
                 fileUrl = fileUrl.deletingLastPathComponent()
-                fileUrl.appendPathComponent("\(duplicateName)")
-                fileUrl.appendPathExtension("\(filextension)")
+                fileUrl.appendPathComponent(duplicateName)
+                fileUrl.appendPathExtension(filextension)
             }
 
             if FileItem.fileManger.fileExists(atPath: self.url.path) {

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -262,7 +262,7 @@ public extension WorkspaceClient {
                 let fileName = filextension.isEmpty ?
                 previousName : previousNameWithoutExtension
                 fileUrl = fileUrl.deletingLastPathComponent()
-                fileUrl.appendPathComponent("\(fileName)_copy")
+                fileUrl.appendPathComponent("\(fileName)-copy")
                 fileUrl.appendPathExtension("\(filextension)")
             }
 

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -262,7 +262,8 @@ public extension WorkspaceClient {
                 let fileName = filextension.isEmpty ?
                 previousName : previousNameWithoutExtension
                 fileUrl = fileUrl.deletingLastPathComponent()
-                fileUrl.appendPathComponent("\(fileName)_copy.\(filextension)")
+                fileUrl.appendPathComponent("\(fileName)_copy")
+                fileUrl.appendPathExtension("\(filextension)")
             }
 
             if FileItem.fileManger.fileExists(atPath: self.url.path) {

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -256,13 +256,12 @@ public extension WorkspaceClient {
             // if a file/folder with the same name exists, add "copy" to the end
             var fileUrl = self.url
             while FileItem.fileManger.fileExists(atPath: fileUrl.path) {
-                let previousName = fileUrl.lastPathComponent
-                let previousNameWithoutExtension = (previousName as NSString).deletingPathExtension
+                let previousName = (fileUrl.lastPathComponent as NSString).deletingPathExtension
                 let filextension = fileUrl.pathExtension
-                let fileName = filextension.isEmpty ?
-                previousName : previousNameWithoutExtension
+                let duplicateName = "\(previousName)-copy"
+
                 fileUrl = fileUrl.deletingLastPathComponent()
-                fileUrl.appendPathComponent("\(fileName)-copy")
+                fileUrl.appendPathComponent("\(duplicateName)")
                 fileUrl.appendPathExtension("\(filextension)")
             }
 

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -257,12 +257,12 @@ public extension WorkspaceClient {
             var fileUrl = self.url
             while FileItem.fileManger.fileExists(atPath: fileUrl.path) {
                 let previousName = fileUrl.lastPathComponent
-                let previousNameWithoutExtension = fileUrl.deletingPathExtension().absoluteString
+                let previousNameWithoutExtension = (previousName as NSString).deletingPathExtension
                 let filextension = fileUrl.pathExtension
                 let fileName = filextension.isEmpty ?
                 previousName : previousNameWithoutExtension
                 fileUrl = fileUrl.deletingLastPathComponent()
-                fileUrl.appendPathComponent("\(fileName) copy.\(filextension)")
+                fileUrl.appendPathComponent("\(fileName)_copy.\(filextension)")
             }
 
             if FileItem.fileManger.fileExists(atPath: self.url.path) {

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -235,7 +235,7 @@ public extension WorkspaceClient {
 
             let deleteConfirmation = NSAlert()
             let message = "\(self.fileName)\(self.isFolder ? " and its children" :"")"
-            deleteConfirmation.messageText = "Do you want to move \(message) to the bin?"
+            deleteConfirmation.messageText = "Are you sure you want to move \(message) to the Trash?"
             deleteConfirmation.alertStyle = .critical
             deleteConfirmation.addButton(withTitle: "Delete")
             deleteConfirmation.buttons.last?.hasDestructiveAction = true
@@ -257,7 +257,12 @@ public extension WorkspaceClient {
             var fileUrl = self.url
             while FileItem.fileManger.fileExists(atPath: fileUrl.path) {
                 let previousName = fileUrl.lastPathComponent
-                fileUrl = fileUrl.deletingLastPathComponent().appendingPathComponent("\(previousName) copy")
+                let previousNameWithoutExtension = fileUrl.deletingPathExtension().absoluteString
+                let filextension = fileUrl.pathExtension
+                let fileName = filextension.isEmpty ?
+                previousName : previousNameWithoutExtension
+                fileUrl = fileUrl.deletingLastPathComponent()
+                fileUrl.appendPathComponent("\(fileName) copy.\(filextension)")
             }
 
             if FileItem.fileManger.fileExists(atPath: self.url.path) {


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->

- [x] Fixed Duplicate File Functionality
- [x] Fixed SwiftLint Error

This is a duplicate of PR [#730](https://github.com/CodeEditApp/CodeEdit/pull/730) by @Blackhole1123. I just carried on with the work. Fixed some merge conflicts and did some finishing touches. 

Some changes had to be made from the initial requirements in #727. Initial requirement wanted the duplicate folder name `current_name copy.<extension>. ` but I was coming across runtime errors when trying to include the space. So the new file are now prefixed with "_" e.g. `current_name_copy.<extension>`

Still some issues to resolved:
- [ ] ~~Upon create duplicate file receive following error `Thread 1: EXC_BAD_ACCESS (code=1, address=0x70)`(Possibly a new issue)~~ 
- [x] New duplicate is created but when renaming it, the file above is selected.
- [ ] ~~Go to rename file automatically when duplicate file. As per requirement~~ 

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #727 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] Review requested

# Screenshots


https://user-images.githubusercontent.com/80204376/188239240-840d7826-56e4-4b83-af2e-136c90a95f59.mov



<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
