### PR TITLE
add uuid to FileItem

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>b8b2a2ba654cd9ea62e232809227515afc5d0236</string>
+	<string>0cfd746f96d1ce6c61e8942b262492aa02a583be</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/CodeEditUI/src/HelpButton.swift
+++ b/CodeEditModules/Modules/CodeEditUI/src/HelpButton.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// A Button representing a system Help button displaying a question mark symbol.
 public struct HelpButton: View {
 
-    private var action : () -> Void
+    private var action: () -> Void
 
     /// Initializes the ``HelpButton`` with an action closure
     /// - Parameter action: A closure that gets called once the button is pressed.

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -33,6 +33,8 @@ public extension WorkspaceClient {
 
         public typealias ID = String
 
+        private let uuid: UUID
+
         public var watcher: DispatchSourceFileSystemObject?
         static var watcherCode: () -> Void = {}
 
@@ -58,6 +60,7 @@ public extension WorkspaceClient {
             self.url = url
             self.children = children
             id = url.relativePath
+            uuid = UUID()
         }
 
         public required init(from decoder: Decoder) throws {
@@ -65,6 +68,7 @@ public extension WorkspaceClient {
             id = try values.decode(String.self, forKey: .id)
             url = try values.decode(URL.self, forKey: .url)
             children = try values.decode([FileItem]?.self, forKey: .children)
+            uuid = UUID()
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -284,9 +288,7 @@ public extension WorkspaceClient {
 
 extension WorkspaceClient.FileItem: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-        hasher.combine(url)
-        hasher.combine(children)
+        hasher.combine(uuid)
     }
 }
 


### PR DESCRIPTION
# Description

add UUID to avoid `Duplicate keys of type 'FileItem' were found in a Dictionary`


if i click on items after duplicate or rename then i get this:

```
Fatal error: Duplicate keys of type 'FileItem' were found in a Dictionary.
This usually means either that the type violates Hashable's requirements, or
that members of such a dictionary were mutated after insertion.
2022-09-03 01:52:01.217894+0200 CodeEdit[26505:6295470] Fatal error: Duplicate keys of type 'FileItem' were found in a Dictionary.
This usually means either that the type violates Hashable's requirements, or
that members of such a dictionary were mutated after insertion.
```

# Discussion

- Since there is already an `id` -> maybe it is better to change the `id` to an `UUID`? 
	- needed changes:
		-  remove id from encoder / decoder 
		- change the `==` function to compare the url instead of id
	- note: `id` is used on some places as dictionary keys
		- Live.swift - `flattenedFileItems[String: FileItem]`
		- OutlineViewController.swift
		- QuickOpenView.swift

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->

- Add duplicate file functionality #736
- 🐞 Crashes on save #628
- 🐞 Crash on opening renamed file #706



# Checklist

<!--- Add things that are not yet implemented above -->
- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [ ] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
