### PR TITLE
Heed Apple Developer Documentation warning, & spelling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Once you are happy with your changes, submit a `Pull Request`.
 
 The pull request opens with a template loaded. Fill out all fields that are relevant.
 
-The `PR` should include follwing information:
+The `PR` should include following information:
 * A descriptive **title** on what changed.
 * A detailed **description** of changes.
 * If you made changes to the UI please add a **screenshot** or **video** as well.

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>0cfd746f96d1ce6c61e8942b262492aa02a583be</string>
+	<string>b0ece384dd641c008b54fed9b0e2a42d8dd4613f</string>
 </dict>
 </plist>

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineMenu.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineMenu.swift
@@ -219,7 +219,7 @@ final class OutlineMenu: NSMenu {
               let cell = outlineView.view(atColumn: 0, row: row, makeIfNecessary: false) as? OutlineTableViewCell else {
             return
         }
-        cell.textField?.becomeFirstResponder()
+        outlineView.window?.makeFirstResponder(cell.textField)
     }
 
     /// Action that deletes the item.


### PR DESCRIPTION
# Description

From apple developer documentation on `NSResponder.becomeFirstResponder() -> Bool`:

> Use the `NSWindow makeFirstResponder(_:)` method, not this method, to make an object the first responder. Never invoke this method directly.

We were invoking `becomeFirstResponder` directly, but I changed that call to use `makeFirstResponder` instead.

I've also changed "follwing" to "following" in the contribution guidelines.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code where necessary
- [ ] Review requested
