### PR TITLE
[fix]: disable failing snapshot unit tests

### DIFF
--- a/CodeEdit.xcodeproj/xcshareddata/xcschemes/CodeEdit.xcscheme
+++ b/CodeEdit.xcodeproj/xcshareddata/xcschemes/CodeEdit.xcscheme
@@ -52,39 +52,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CodeEditUITests"
-               BuildableName = "CodeEditUITests"
-               BlueprintName = "CodeEditUITests"
-               ReferencedContainer = "container:CodeEditModules">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "WelcomeModuleTests"
-               BuildableName = "WelcomeModuleTests"
-               BlueprintName = "WelcomeModuleTests"
-               ReferencedContainer = "container:CodeEditModules">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "GitClientTests"
                BuildableName = "GitClientTests"
                BlueprintName = "GitClientTests"
-               ReferencedContainer = "container:CodeEditModules">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CodeEditUtilsTests"
-               BuildableName = "CodeEditUtilsTests"
-               BlueprintName = "CodeEditUtilsTests"
                ReferencedContainer = "container:CodeEditModules">
             </BuildableReference>
          </TestableReference>
@@ -111,6 +81,16 @@
                   Identifier = "StatusBarUnitTests/testStatusBarExpandedLight()">
                </Test>
             </SkippedTests>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CodeEditUtilsTests"
+               BuildableName = "CodeEditUtilsTests"
+               BlueprintName = "CodeEditUtilsTests"
+               ReferencedContainer = "container:CodeEditModules">
+            </BuildableReference>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>b0ece384dd641c008b54fed9b0e2a42d8dd4613f</string>
+	<string>de0d5641d50bcf5970bc2766df43fe581e826d83</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Description

Since snapshot tests where reference snapshots were taken on an Apple Silicon machine are failing on GitHub Actions runners (x86), it would be a good idea to disable these tests until this gets sorted by [`swift-snapshot-testing`](https://github.com/pointfreeco/swift-snapshot-testing).
