### PR TITLE
Update tab state when renaming file

### DIFF
--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -172,7 +172,7 @@ extension OutlineViewController: NSOutlineViewDelegate {
 
         let frameRect = NSRect(x: 0, y: 0, width: tableColumn.width, height: rowHeight)
 
-        return OutlineTableViewCell(frame: frameRect, item: item as? Item)
+        return OutlineTableViewCell(frame: frameRect, item: item as? Item, delegate: self)
     }
 
     func outlineViewSelectionDidChange(_ notification: Notification) {
@@ -292,5 +292,15 @@ extension OutlineViewController: NSMenuDelegate {
             }
         }
         menu.update()
+    }
+}
+
+// MARK: - OutlineTableViewCellDelegate
+
+extension OutlineViewController: OutlineTableViewCellDelegate {
+    func moveFile(file: Item, to destination: URL) {
+        workspace?.closeTab(item: .codeEditor(file.id))
+        file.move(to: destination)
+        workspace?.openTab(item: file)
     }
 }

--- a/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Model/FileItem.swift
@@ -284,7 +284,10 @@ public extension WorkspaceClient {
             guard !FileItem.fileManger.fileExists(atPath: newLocation.path) else { return }
             do {
                 try FileItem.fileManger.moveItem(at: self.url, to: newLocation)
-            } catch { fatalError(error.localizedDescription) }
+                self.url = newLocation
+            } catch {
+                fatalError(error.localizedDescription)
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

This PR updates the tab state when renaming a file. Right now the tab name will keep the previous name. This updates it so the tab updates it’s name and becomes a temporary tab.

# Related Issue

I found this while working on 706, the root problem with that issue has been resolved but this is an auxiliary change.
<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #706 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
