### PR TITLE
feat // theme adjusting to appearance

### DIFF
--- a/CodeEditModules/Modules/AppPreferences/src/Model/Theme/ThemePreferences.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/Theme/ThemePreferences.swift
@@ -32,6 +32,12 @@ public extension AppPreferences {
     /// The global settings for themes
     struct ThemePreferences: Codable {
 
+        /// The name of the currently selected dark theme
+        public var selectedDarkTheme: String?
+
+        /// The name of the currently selected light theme
+        public var selectedLightTheme: String?
+
         /// The name of the currently selected theme
         public var selectedTheme: String?
 

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
@@ -16,7 +16,29 @@ import SwiftUI
 /// ```
 public final class ThemeModel: ObservableObject {
 
+    /// Retrieves system apperance settings
+    @Environment(\.colorScheme)
+       var colorScheme
+
     public static let shared: ThemeModel = .init()
+
+    /// Selected 'light' theme
+    /// Used for auto-switching theme to match macOS system appearance
+    @Published
+    public var selectedLightTheme: Theme? {
+        didSet {
+            AppPreferencesModel.shared.preferences.theme.selectedLightTheme = selectedLightTheme?.name
+        }
+    }
+
+    /// Selected 'dark' theme
+    /// Used for auto-switching theme to match macOS system appearance
+    @Published
+    public var selectedDarkTheme: Theme? {
+        didSet {
+            AppPreferencesModel.shared.preferences.theme.selectedDarkTheme = selectedDarkTheme?.name
+        }
+    }
 
     /// The selected appearance in the sidebar.
     /// - **0**: dark mode themes
@@ -144,7 +166,20 @@ public final class ThemeModel: ObservableObject {
                 // if there already is a selected theme in `preferences.json` select this theme
                 // otherwise take the first in the list
                 self.selectedTheme = self.themes.first { $0.name == prefs.theme.selectedTheme } ?? self.themes.first
+
+                // take any previously selected theme and set it to correct light/dark theme variable
+                setDarkLightThemes()
             }
+        }
+    }
+
+    /// This function stores  'dark' and 'light' themes into `ThemePreferences` if user happens to select a theme
+    func setDarkLightThemes() {
+        if self.selectedTheme?.appearance == .dark {
+            self.selectedDarkTheme = self.selectedTheme
+        }
+        if self.selectedTheme?.appearance == .light {
+            self.selectedLightTheme = self.selectedTheme
         }
     }
 

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/ThemePreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/ThemePreferencesView.swift
@@ -47,6 +47,9 @@ public struct ThemePreferencesView: View {
         .onAppear {
             try? themeModel.loadThemes()
         }
+        .onChange(of: themeModel.selectedTheme) {_ in
+            themeModel.setDarkLightThemes()
+        }
     }
 
     private var frame: some View {

--- a/CodeEditModules/Modules/WelcomeModule/src/WelcomeView.swift
+++ b/CodeEditModules/Modules/WelcomeModule/src/WelcomeView.swift
@@ -20,6 +20,7 @@ public struct WelcomeView: View {
     @State var isHovering: Bool = false
     @State var isHoveringClose: Bool = false
     @StateObject private var prefs: AppPreferencesModel = .shared
+    @StateObject private var themeModel: ThemeModel = .shared
 
     private let openDocument: (URL?, @escaping () -> Void) -> Void
     private let newDocument: () -> Void
@@ -84,6 +85,17 @@ public struct WelcomeView: View {
         return nil
     }
 
+    /// Set saved dark/light theme from `ThemeModel`,  based on system apperaance 
+    private func mirrorThemeToSystemAppearance() {
+        if AppPreferencesModel.shared.preferences.theme.mirrorSystemAppearance {
+            if colorScheme == .dark {
+                themeModel.selectedTheme = themeModel.selectedDarkTheme
+            } else {
+                themeModel.selectedTheme = themeModel.selectedLightTheme
+            }
+        }
+    }
+
     /// Get program and operating system information
     private func copyInformation() {
         var copyString = "CodeEdit: \(appVersion) (\(appBuild))\n"
@@ -141,6 +153,7 @@ public struct WelcomeView: View {
                             subtitle: NSLocalizedString("Create a new file", bundle: .module, comment: "")
                         )
                         .onTapGesture {
+                            mirrorThemeToSystemAppearance()
                             newDocument()
                             dismissWindow()
                         }


### PR DESCRIPTION
# Description
This theme allows the user to toggle a checkbox to sync dark/light themes with dark/light/auto MacOS system appearance. 

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #714 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Demo
https://streamable.com/myx0t5
<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

# Note
I wanted to initialize `selectedDarkTheme` and `selectedLightTheme` to `lightThemes[0]` and `darkThemes[0]` if the user has never selected a theme before (think first CodeEdit launch). However, my dark and light theme values were still somehow preserved even after running a clean build. I'd like to know if you have a similar experience to this.