### PR TITLE
Add Release Drafter Action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,18 @@
+categories:
+  - title: '🚀 Enhancements'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bugfix'
+  - title: '🧰 Maintenance'
+    label:
+      - 'chore'
+      - 'documentation'
+      - 'dependencies'
+template: |
+  <!-- Update Template --> 
+
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  # Allow running it manually in case we forget to label a PR before merging
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

In order to organize a release and gather all the changes, release-drafter easily converts all the PR merges and combines them into a nice release notes. 

`release-drafter.yml` includes options that convert a PR Label into the group categories. This can be edited by CodeEdit to how they want to use it. 

Draft releases are only visible to non regular users. Screenshot below is what Xcodes Draft release currently holds. 

![image](https://user-images.githubusercontent.com/1119565/190789921-65f0f268-8ba7-41ed-87ce-40a3f7f86c05.png)

These release notes can also be used in the future for Sparkle updates which show nicely when upgrading in the app. 

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
N/A

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [ ] My code builds and runs on my machine
- [ ] I documented my code
- [ ] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
