### PR TITLE
Make tabs and breadcrumbs inherit a common background color.

### DIFF
--- a/CodeEdit/Documents/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Documents/WorkspaceCodeFileView.swift
@@ -54,13 +54,11 @@ struct WorkspaceCodeFileView: View {
         _ codeFile: CodeFileDocument,
         for item: WorkspaceClient.FileItem
     ) -> some View {
-        CodeFileView(codeFile: codeFile)
-            .safeAreaInset(edge: .top, spacing: 0) {
-                VStack(spacing: 0) {
-                    BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
-                    Divider()
-                }
-            }
+        VStack(spacing: 0) {
+            BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
+            Divider()
+            CodeFileView(codeFile: codeFile)
+        }
     }
 
     @ViewBuilder
@@ -68,7 +66,10 @@ struct WorkspaceCodeFileView: View {
         _ otherFile: CodeFileDocument,
         for item: WorkspaceClient.FileItem
     ) -> some View {
-        ZStack {
+        VStack(spacing: 0) {
+            BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
+            Divider()
+
             if let url = otherFile.previewItemURL,
                let image = NSImage(contentsOf: url),
                otherFile.typeOfFile == .image {
@@ -83,11 +84,6 @@ struct WorkspaceCodeFileView: View {
                 }
             } else {
                 OtherFileView(otherFile)
-            }
-        }.safeAreaInset(edge: .top, spacing: 0) {
-            VStack(spacing: 0) {
-                BreadcrumbsView(file: item, tappedOpenFile: workspace.openTab(item:))
-                Divider()
             }
         }
     }

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -397,11 +397,6 @@ struct TabBar: View {
         }
         .background {
             if prefs.preferences.general.tabBarStyle == .xcode {
-                TabBarXcodeBackground()
-            }
-        }
-        .background {
-            if prefs.preferences.general.tabBarStyle == .xcode {
                 EffectView(
                     NSVisualEffectView.Material.titlebar,
                     blendingMode: NSVisualEffectView.BlendingMode.withinWindow

--- a/CodeEditModules/Modules/Breadcrumbs/src/BreadcrumbsView.swift
+++ b/CodeEditModules/Modules/Breadcrumbs/src/BreadcrumbsView.swift
@@ -43,14 +43,6 @@ public struct BreadcrumbsView: View {
             .padding(.horizontal, 10)
         }
         .frame(height: 28, alignment: .center)
-        .background {
-            EffectView(
-                colorScheme == .dark
-                ? NSVisualEffectView.Material.windowBackground
-                : NSVisualEffectView.Material.contentBackground,
-                blendingMode: NSVisualEffectView.BlendingMode.withinWindow
-            )
-        }
         .onAppear {
             fileInfo(self.file)
         }


### PR DESCRIPTION
# Description

I made tabs and breadcrumbs inherit a common background color.

As a result, the dividers in the toolbar doesn't show through to the editor background.

(fixes #710)

# Related Issue

* #710 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] I documented my code
- [x] Review requested

# Screenshots

| Dark  | Darker | Light |
| ------------- | ------------- | ------------- |
| ![スクリーンショット 2022-09-18 16 36 33](https://user-images.githubusercontent.com/25968819/190891893-38b5d101-f524-4990-aaa3-4c92cf706cf3.png)  | ![スクリーンショット 2022-09-18 16 36 01](https://user-images.githubusercontent.com/25968819/190891884-11614a64-5648-4346-9970-2cae5fe6209e.png)  |  ![スクリーンショット 2022-09-18 16 35 32](https://user-images.githubusercontent.com/25968819/190891876-80331497-ff6b-4d91-ab28-e635e8bd9103.png) |
