### PR TITLE
Add preferences option to toggle auto-save.

### DIFF
--- a/CodeEdit/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Documents/WorkspaceDocument.swift
@@ -383,11 +383,11 @@ import TabBar
 
     /// Determines the windows should be closed.
     ///
-    /// This method iterates all editied documents If there are any editied documents.
+    /// This method iterates all edited documents If there are any edited documents.
     ///
     /// A panel giving the user the choice of canceling, discarding changes, or saving is presented while iteration.
     ///
-    /// If the user chooses cancel on the panel, iteration is breaked.
+    /// If the user chooses cancel on the panel, iteration is broken.
     ///
     /// In the last step, `shouldCloseSelector` is called with true if all documents are clean, otherwise false
     ///

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>515c9ebc3ea3e756957a2ca8e199c41888ff233e</string>
+	<string>00451a977cd15389c08e62a618669f8ce7163ec9</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/AppPreferences/src/Model/General/GeneralPreferences.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/General/GeneralPreferences.swift
@@ -50,6 +50,9 @@ public extension AppPreferences {
         /// The reveal file in navigator when focus changes behavior of the app.
         public var revealFileOnFocusChange: Bool = false
 
+        /// Auto save behavior toggle
+        public var isAutoSaveOn: Bool = true
+
         /// Default initializer
         public init() {}
 
@@ -109,6 +112,10 @@ public extension AppPreferences {
                 Bool.self,
                 forKey: .revealFileOnFocusChange
             ) ?? false
+            self.isAutoSaveOn = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .isAutoSaveOn
+            ) ?? true
         }
         // swiftlint:enable function_body_length
     }

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/GeneralPreferences/GeneralPreferencesView.swift
@@ -50,6 +50,7 @@ public struct GeneralPreferencesView: View {
                 openInCodeEditToggle
                 revealFileOnFocusChangeToggle
                 shellCommandSection
+                autoSaveSection
             }
         }
     }
@@ -247,6 +248,14 @@ private extension GeneralPreferencesView {
                     .padding(.horizontal, 10)
             })
             .buttonStyle(.bordered)
+        }
+    }
+
+    var autoSaveSection: some View {
+        PreferencesSection("Auto Save Behavior", hideLabels: false) {
+            Toggle("Automatically save changes to disk",
+                   isOn: $prefs.preferences.general.isAutoSaveOn)
+            .toggleStyle(.checkbox)
         }
     }
 

--- a/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFile.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 import UniformTypeIdentifiers
 import QuickLookUI
+import AppPreferences
 
 public enum CodeFileError: Error {
     case failedToDecode
@@ -56,7 +57,13 @@ public final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem
     // MARK: - NSDocument
 
     override public class var autosavesInPlace: Bool {
-        true
+        AppPreferencesModel.shared.preferences.general.isAutoSaveOn
+    }
+
+    override public var autosavingFileType: String? {
+        AppPreferencesModel.shared.preferences.general.isAutoSaveOn
+            ? fileType
+            : nil
     }
 
     override public func makeWindowControllers() {


### PR DESCRIPTION
# Description

I added preferences option to toggle auto-save.

Some changes are automatically saved when auto-save is on.

A panel giving user a chance to choose saving, discarding or cancel is presented before closing window or tab when auto-save is off.

Please check this behavior via video I added below.

(fixes #603)

# Related Issue

* #603 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide]
- [x] My changes generate no new warnings
I disabled file_length warning of WorkspaceDocument since type_body_length is already disabled.
If this isn't acceptable, I will fix to remove `// swiftlint:disable file_length`
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

I uploaded video to describe this behavior as the video size is too large to embed into this issue.
https://youtu.be/eOA_N7HdB_g
