### PR TITLE
Fixes 714: Theme does not sync with system appearance

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>18b0517a3532b3780575e044648e1eca525c320e</string>
+	<string>f41ffa79d66ee2ba1e65740b73577641b8ce7f1b</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>00451a977cd15389c08e62a618669f8ce7163ec9</string>
+	<string>722f3692a922a7b7d15cd05f6a470a949aacc0c0</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>6a38108184942fc30d6ab28024eea92e95b38b22</string>
+	<string>18b0517a3532b3780575e044648e1eca525c320e</string>
 </dict>
 </plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,6 +1240,6 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>722f3692a922a7b7d15cd05f6a470a949aacc0c0</string>
+	<string>6a38108184942fc30d6ab28024eea92e95b38b22</string>
 </dict>
 </plist>

--- a/CodeEditModules/Modules/AppPreferences/src/Model/Theme/ThemePreferences.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/Theme/ThemePreferences.swift
@@ -32,6 +32,12 @@ public extension AppPreferences {
     /// The global settings for themes
     struct ThemePreferences: Codable {
 
+        /// The name of the currently selected dark theme
+        public var selectedDarkTheme: String = "codeedit-xcode-dark"
+        
+        /// The name of the currently selected light theme
+        public var selectedLightTheme: String = "codeedit-xcode-light"
+        
         /// The name of the currently selected theme
         public var selectedTheme: String?
 
@@ -39,7 +45,7 @@ public extension AppPreferences {
         public var useThemeBackground: Bool = true
 
         /// Automatically change theme based on system appearance
-        public var mirrorSystemAppearance: Bool = false
+        public var mirrorSystemAppearance: Bool = true
 
         /// Dictionary of themes containing overrides
         ///
@@ -74,11 +80,13 @@ public extension AppPreferences {
         /// Explicit decoder init for setting default values when key is not present in `JSON`
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.selectedDarkTheme = try container.decodeIfPresent(String.self, forKey: .selectedDarkTheme) ?? selectedDarkTheme
+            self.selectedLightTheme = try container.decodeIfPresent(String.self, forKey: .selectedLightTheme) ?? selectedLightTheme
             self.selectedTheme = try container.decodeIfPresent(String.self, forKey: .selectedTheme)
             self.useThemeBackground = try container.decodeIfPresent(Bool.self, forKey: .useThemeBackground) ?? true
             self.mirrorSystemAppearance = try container.decodeIfPresent(
                 Bool.self, forKey: .mirrorSystemAppearance
-            ) ?? false
+            ) ?? true
             self.overrides = try container.decodeIfPresent([String: ThemeOverrides].self, forKey: .overrides) ?? [:]
         }
     }

--- a/CodeEditModules/Modules/AppPreferences/src/Model/Theme/ThemePreferences.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Model/Theme/ThemePreferences.swift
@@ -34,10 +34,10 @@ public extension AppPreferences {
 
         /// The name of the currently selected dark theme
         public var selectedDarkTheme: String = "codeedit-xcode-dark"
-        
+
         /// The name of the currently selected light theme
         public var selectedLightTheme: String = "codeedit-xcode-light"
-        
+
         /// The name of the currently selected theme
         public var selectedTheme: String?
 
@@ -80,8 +80,12 @@ public extension AppPreferences {
         /// Explicit decoder init for setting default values when key is not present in `JSON`
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.selectedDarkTheme = try container.decodeIfPresent(String.self, forKey: .selectedDarkTheme) ?? selectedDarkTheme
-            self.selectedLightTheme = try container.decodeIfPresent(String.self, forKey: .selectedLightTheme) ?? selectedLightTheme
+            self.selectedDarkTheme = try container.decodeIfPresent(
+                String.self, forKey: .selectedDarkTheme
+            ) ?? selectedDarkTheme
+            self.selectedLightTheme = try container.decodeIfPresent(
+                String.self, forKey: .selectedLightTheme
+            ) ?? selectedLightTheme
             self.selectedTheme = try container.decodeIfPresent(String.self, forKey: .selectedTheme)
             self.useThemeBackground = try container.decodeIfPresent(Bool.self, forKey: .useThemeBackground) ?? true
             self.mirrorSystemAppearance = try container.decodeIfPresent(

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
@@ -171,11 +171,12 @@ public final class ThemeModel: ObservableObject {
                 
                 // For selecting the default theme, doing it correctly on startup requires some more logic
                 let userSelectedTheme = self.themes.first { $0.name == prefs.theme.selectedTheme }
+                let systemAppearance = NSAppearance.currentDrawing().name
                 if userSelectedTheme != nil {
                     self.selectedTheme = userSelectedTheme
                 } else {
-                    print(colorScheme == .dark)
-                    if colorScheme == .dark {
+                    print(systemAppearance == .aqua)
+                    if systemAppearance == .darkAqua {
                         self.selectedTheme = self.selectedDarkTheme
                     } else {
                         self.selectedTheme = self.selectedLightTheme

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
@@ -17,7 +17,7 @@ import SwiftUI
 public final class ThemeModel: ObservableObject {
 
     public static let shared: ThemeModel = .init()
-    
+
     /// Selected 'light' theme
     /// Used for auto-switching theme to match macOS system appearance
     @Published
@@ -63,7 +63,7 @@ public final class ThemeModel: ObservableObject {
     public var selectedTheme: Theme? {
         didSet {
             AppPreferencesModel.shared.preferences.theme.selectedTheme = selectedTheme?.name
-            setDarkLightThemes()
+            updateAppearanceTheme()
         }
     }
 
@@ -162,9 +162,14 @@ public final class ThemeModel: ObservableObject {
 
                 // if there already is a selected theme in `preferences.json` select this theme
                 // otherwise take the first in the list
-                self.selectedDarkTheme = self.darkThemes.first { $0.name == prefs.theme.selectedDarkTheme } ?? self.darkThemes.first
-                self.selectedLightTheme = self.lightThemes.first { $0.name == prefs.theme.selectedLightTheme } ?? self.lightThemes.first
-                
+                self.selectedDarkTheme = self.darkThemes.first {
+                    $0.name == prefs.theme.selectedDarkTheme
+                } ?? self.darkThemes.first
+
+                self.selectedLightTheme = self.lightThemes.first {
+                    $0.name == prefs.theme.selectedLightTheme
+                } ?? self.lightThemes.first
+
                 // For selecting the default theme, doing it correctly on startup requires some more logic
                 let userSelectedTheme = self.themes.first { $0.name == prefs.theme.selectedTheme }
                 let systemAppearance = NSAppearance.currentDrawing().name
@@ -180,9 +185,9 @@ public final class ThemeModel: ObservableObject {
             }
         }
     }
-    
+
     /// This function stores  'dark' and 'light' themes into `ThemePreferences` if user happens to select a theme
-    func setDarkLightThemes() {
+    private func updateAppearanceTheme() {
         if self.selectedTheme?.appearance == .dark {
             self.selectedDarkTheme = self.selectedTheme
         } else if self.selectedTheme?.appearance == .light {

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
@@ -18,10 +18,6 @@ public final class ThemeModel: ObservableObject {
 
     public static let shared: ThemeModel = .init()
     
-    /// Retrieves system apperance settings
-    @Environment(\.colorScheme)
-    var colorScheme: ColorScheme
-    
     /// Selected 'light' theme
     /// Used for auto-switching theme to match macOS system appearance
     @Published

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
@@ -171,7 +171,6 @@ public final class ThemeModel: ObservableObject {
                 if userSelectedTheme != nil {
                     self.selectedTheme = userSelectedTheme
                 } else {
-                    print(systemAppearance == .aqua)
                     if systemAppearance == .darkAqua {
                         self.selectedTheme = self.selectedDarkTheme
                     } else {

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
@@ -17,6 +17,28 @@ import SwiftUI
 public final class ThemeModel: ObservableObject {
 
     public static let shared: ThemeModel = .init()
+    
+    /// Retrieves system apperance settings
+    @Environment(\.colorScheme)
+    var colorScheme: ColorScheme
+    
+    /// Selected 'light' theme
+    /// Used for auto-switching theme to match macOS system appearance
+    @Published
+    public var selectedLightTheme: Theme? {
+        didSet {
+            AppPreferencesModel.shared.preferences.theme.selectedLightTheme = selectedLightTheme?.name ?? "Broken"
+        }
+    }
+
+    /// Selected 'dark' theme
+    /// Used for auto-switching theme to match macOS system appearance
+    @Published
+    public var selectedDarkTheme: Theme? {
+        didSet {
+            AppPreferencesModel.shared.preferences.theme.selectedDarkTheme = selectedDarkTheme?.name ?? "Broken"
+        }
+    }
 
     /// The selected appearance in the sidebar.
     /// - **0**: dark mode themes
@@ -45,6 +67,7 @@ public final class ThemeModel: ObservableObject {
     public var selectedTheme: Theme? {
         didSet {
             AppPreferencesModel.shared.preferences.theme.selectedTheme = selectedTheme?.name
+            setDarkLightThemes()
         }
     }
 
@@ -143,8 +166,31 @@ public final class ThemeModel: ObservableObject {
 
                 // if there already is a selected theme in `preferences.json` select this theme
                 // otherwise take the first in the list
-                self.selectedTheme = self.themes.first { $0.name == prefs.theme.selectedTheme } ?? self.themes.first
+                self.selectedDarkTheme = self.darkThemes.first { $0.name == prefs.theme.selectedDarkTheme } ?? self.darkThemes.first
+                self.selectedLightTheme = self.lightThemes.first { $0.name == prefs.theme.selectedLightTheme } ?? self.lightThemes.first
+                
+                // For selecting the default theme, doing it correctly on startup requires some more logic
+                let userSelectedTheme = self.themes.first { $0.name == prefs.theme.selectedTheme }
+                if userSelectedTheme != nil {
+                    self.selectedTheme = userSelectedTheme
+                } else {
+                    print(colorScheme == .dark)
+                    if colorScheme == .dark {
+                        self.selectedTheme = self.selectedDarkTheme
+                    } else {
+                        self.selectedTheme = self.selectedLightTheme
+                    }
+                }
             }
+        }
+    }
+    
+    /// This function stores  'dark' and 'light' themes into `ThemePreferences` if user happens to select a theme
+    func setDarkLightThemes() {
+        if self.selectedTheme?.appearance == .dark {
+            self.selectedDarkTheme = self.selectedTheme
+        } else if self.selectedTheme?.appearance == .light {
+            self.selectedLightTheme = self.selectedTheme
         }
     }
 

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/ThemePreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/ThemePreferencesView.swift
@@ -33,6 +33,18 @@ public struct ThemePreferencesView: View {
                     "Automatically change theme based on system appearance",
                     isOn: $prefs.preferences.theme.mirrorSystemAppearance
                 )
+                .onChange(of: prefs.preferences.theme.mirrorSystemAppearance) { value in
+                    if (value) {
+                        if colorScheme == .dark {
+                            themeModel.selectedTheme = themeModel.selectedDarkTheme
+                        } else {
+                            themeModel.selectedTheme = themeModel.selectedLightTheme
+                        }
+                    } else {
+                        themeModel.selectedTheme = themeModel.themes.first { $0.name == prefs.preferences.theme.selectedTheme }
+                    }
+                }
+                
                 Spacer()
                 Button("Get More Themes...") {}
                     .disabled(true)

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/ThemePreferencesView.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/ThemePreferencesView.swift
@@ -34,17 +34,19 @@ public struct ThemePreferencesView: View {
                     isOn: $prefs.preferences.theme.mirrorSystemAppearance
                 )
                 .onChange(of: prefs.preferences.theme.mirrorSystemAppearance) { value in
-                    if (value) {
+                    if value {
                         if colorScheme == .dark {
                             themeModel.selectedTheme = themeModel.selectedDarkTheme
                         } else {
                             themeModel.selectedTheme = themeModel.selectedLightTheme
                         }
                     } else {
-                        themeModel.selectedTheme = themeModel.themes.first { $0.name == prefs.preferences.theme.selectedTheme }
+                        themeModel.selectedTheme = themeModel.themes.first {
+                            $0.name == prefs.preferences.theme.selectedTheme
+                        }
                     }
                 }
-                
+
                 Spacer()
                 Button("Get More Themes...") {}
                     .disabled(true)

--- a/CodeEditModules/Modules/CodeFile/src/CodeFileView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFileView.swift
@@ -80,6 +80,11 @@ public struct CodeFileView: View {
             guard let theme = newValue else { return }
             self.selectedTheme = theme
         }
+        .onChange(of: colorScheme) { newValue in
+            if prefs.preferences.theme.mirrorSystemAppearance {
+                ThemeModel.shared.selectedTheme = newValue == .dark ? ThemeModel.shared.selectedDarkTheme! : ThemeModel.shared.selectedLightTheme!
+            }
+        }
         .onChange(of: prefs.preferences.textEditing.font) { _ in
             font = NSFont(
                 name: prefs.preferences.textEditing.font.name,

--- a/CodeEditModules/Modules/CodeFile/src/CodeFileView.swift
+++ b/CodeEditModules/Modules/CodeFile/src/CodeFileView.swift
@@ -82,7 +82,9 @@ public struct CodeFileView: View {
         }
         .onChange(of: colorScheme) { newValue in
             if prefs.preferences.theme.mirrorSystemAppearance {
-                ThemeModel.shared.selectedTheme = newValue == .dark ? ThemeModel.shared.selectedDarkTheme! : ThemeModel.shared.selectedLightTheme!
+                ThemeModel.shared.selectedTheme = newValue == .dark
+                    ? ThemeModel.shared.selectedDarkTheme!
+                    : ThemeModel.shared.selectedLightTheme!
             }
         }
         .onChange(of: prefs.preferences.textEditing.font) { _ in


### PR DESCRIPTION
# Description

There was an unimplemented feature where the codeeditor should sync with the system preferences theme. This PR implements that feature.

This PR builds up on #755 And could be closed.

Commits:
- CodeFileEditor is now also synced to the system appearance when enabled

# Related Issue

* #714 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots


https://user-images.githubusercontent.com/1364843/192274921-791e6b31-9895-4bd6-a260-db8d7c2aff53.mp4
