### PR TITLE
add: FolderBlue color (#771)

### DIFF
--- a/CodeEdit/Assets.xcassets/Custom Colors/FolderBlue.colorset/Contents.json
+++ b/CodeEdit/Assets.xcassets/Custom Colors/FolderBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.945",
+          "green" : "0.671",
+          "red" : "0.075"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.871",
+          "green" : "0.702",
+          "red" : "0.322"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,7 +1240,7 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>7a96cf534b4118d9c5f69164c85f06e501b322d2</string>
+	<string>92d4bf7f3ea8f1aa861dd6ad1c106f9e38ddd59a</string>
 	<key>SUEnableInstallerLauncherService</key>
 	<true/>
 	<key>SUFeedURL</key>

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -134,7 +134,7 @@ final class OutlineTableViewCell: NSTableCellView {
         if item.children == nil && prefs.fileIconStyle == .color {
             return NSColor(item.iconColor)
         } else {
-            return .secondaryLabelColor
+            return NSColor(named: "FolderBlue")!
         }
     }
 }


### PR DESCRIPTION
closes #771 

added new color asset named `FolderBlue` to xcassets

| dark mode | light mode |
| ------------- | ------------- |
| <img width="100%" alt="dark" src="https://user-images.githubusercontent.com/53724307/193124295-5a6d47a4-fc41-48b8-8473-1724a1ba1ac2.png">  | <img width="100%" alt="light" src="https://user-images.githubusercontent.com/53724307/193124302-2a891612-3086-45f3-955b-8ded8e26794b.png">  |



