### PR TITLE
feat: multiple project actions

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1240,7 +1240,7 @@
 		</dict>
 	</array>
 	<key>GitHash</key>
-	<string>92d4bf7f3ea8f1aa861dd6ad1c106f9e38ddd59a</string>
+	<string>60629cc064e28818af5782ea3287a78a0dd176b7</string>
 	<key>SUEnableInstallerLauncherService</key>
 	<true/>
 	<key>SUFeedURL</key>

--- a/CodeEditModules/Modules/WelcomeModule/src/RecentProjectsView.swift
+++ b/CodeEditModules/Modules/WelcomeModule/src/RecentProjectsView.swift
@@ -11,7 +11,8 @@ import CodeEditUI
 
 public struct RecentProjectsView: View {
     @State private var recentProjectPaths: [String]
-    @State private var selectedProjectPath: String? = ""
+    @State private var selectedProjectPaths = Set<String>()
+    @State private var lastSelectedProjectPath = String()
 
     var mgr = KeybindingManager.shared
     private let openDocument: (URL?, @escaping () -> Void) -> Void
@@ -38,11 +39,19 @@ public struct RecentProjectsView: View {
     func contextMenuShowInFinder(projectPath: String) -> some View {
         Group {
             Button(NSLocalizedString("Show in Finder", bundle: .module, comment: "")) {
-                guard let url = URL(string: "file://\(projectPath)") else {
-                    return
+                if selectedProjectPaths.contains(projectPath) {
+                    self.selectedProjectPaths.forEach { projectPath in
+                        guard let url = URL(string: "file://\(projectPath)") else {
+                            return
+                        }
+                        NSWorkspace.shared.activateFileViewerSelecting([url])
+                    }
+                } else {
+                    guard let url = URL(string: "file://\(projectPath)") else {
+                        return
+                    }
+                    NSWorkspace.shared.activateFileViewerSelecting([url])
                 }
-
-                NSWorkspace.shared.activateFileViewerSelecting([url])
             }
         }
     }
@@ -60,7 +69,13 @@ public struct RecentProjectsView: View {
     func contextMenuDelete(projectPath: String) -> some View {
         Group {
             Button(NSLocalizedString("Remove from Recent Projects", bundle: .module, comment: "")) {
-                deleteFromRecent(item: projectPath)
+                if selectedProjectPaths.contains(projectPath) {
+                    self.selectedProjectPaths.forEach { projectPath in
+                        deleteFromRecent(item: projectPath)
+                    }
+                } else {
+                    deleteFromRecent(item: projectPath)
+                }
             }
         }
     }
@@ -74,6 +89,28 @@ public struct RecentProjectsView: View {
             self.recentProjectPaths,
             forKey: "recentProjectPaths"
         )
+    }
+    
+    func deleteProject(projectPath: String) {
+        self.selectedProjectPaths.forEach { projectPath in
+            deleteFromRecent(item: projectPath)
+        }
+    }
+    
+    func openProject(projectPath: String) {
+        if selectedProjectPaths.contains(projectPath) {
+            selectedProjectPaths.forEach { projectPath in
+                openDocument(
+                    URL(fileURLWithPath: projectPath),
+                    dismissWindow
+                )
+            }
+        } else {
+            openDocument(
+                URL(fileURLWithPath: projectPath),
+                dismissWindow
+            )
+        }
     }
 
     /// Update recent projects, and remove ones that no longer exist
@@ -94,32 +131,47 @@ public struct RecentProjectsView: View {
     public var body: some View {
         VStack(alignment: !recentProjectPaths.isEmpty ? .leading : .center, spacing: 10) {
             if !recentProjectPaths.isEmpty {
-                List(recentProjectPaths, id: \.self, selection: $selectedProjectPath) { projectPath in
+                List(recentProjectPaths, id: \.self, selection: $selectedProjectPaths) { projectPath in
                     ZStack {
                         RecentProjectItem(projectPath: projectPath)
                             .frame(width: 300)
-                            .gesture(TapGesture(count: 2).onEnded {
-                                openDocument(
-                                    URL(fileURLWithPath: projectPath),
-                                    dismissWindow
-                                )
+                            .highPriorityGesture(TapGesture(count: 2).onEnded {
+                                openProject(projectPath: projectPath)
                             })
-                            .simultaneousGesture(TapGesture().onEnded {
-                                selectedProjectPath = projectPath
+                            .gesture(TapGesture().onEnded {
+                                if NSEvent.modifierFlags.contains(.command){
+                                    self.lastSelectedProjectPath = projectPath
+                                    selectedProjectPaths.insert(projectPath)
+                                } else if NSEvent.modifierFlags.contains(.shift) {
+                                    if let lastIndex = recentProjectPaths.firstIndex(of: lastSelectedProjectPath), let currentIndex = recentProjectPaths.firstIndex(of: projectPath) {
+                                        if currentIndex > lastIndex {
+                                            let projectPaths = Array(recentProjectPaths[lastIndex..<currentIndex+1])
+                                            selectedProjectPaths = selectedProjectPaths.union(projectPaths)
+                                        } else {
+                                            let projectPaths = Array(recentProjectPaths[currentIndex..<lastIndex+1])
+                                            selectedProjectPaths = selectedProjectPaths.union(projectPaths)
+                                        }
+                                    }
+                                } else {
+                                    self.lastSelectedProjectPath = projectPath
+                                    selectedProjectPaths = [projectPath]
+                                }
                             })
                             .contextMenu {
                                 contextMenuShowInFinder(projectPath: projectPath)
-                                contextMenuCopy(path: projectPath)
-                                    .keyboardShortcut(mgr.named(with: "copy").keyboardShortcut)
+                                
+                                if !selectedProjectPaths.contains(projectPath) {
+                                    contextMenuCopy(path: projectPath)
+                                        .keyboardShortcut(mgr.named(with: "copy").keyboardShortcut)
+                                }
 
                                 Divider()
                                 contextMenuDelete(projectPath: projectPath)
                                     .keyboardShortcut(.init(.delete))
                             }
 
-                        if selectedProjectPath == projectPath {
                             Button("") {
-                                deleteFromRecent(item: projectPath)
+                                deleteProject(projectPath: projectPath)
                             }
                             .buttonStyle(.borderless)
                             .keyboardShortcut(.init(.delete))
@@ -131,15 +183,10 @@ public struct RecentProjectsView: View {
                             }
                             .buttonStyle(.borderless)
                             .keyboardShortcut(mgr.named(with: "copy").keyboardShortcut)
-                        }
+                        
 
                         Button("") {
-                            if let selectedProjectPath = selectedProjectPath {
-                                openDocument(
-                                    URL(fileURLWithPath: selectedProjectPath),
-                                    dismissWindow
-                                )
-                            }
+                            openProject(projectPath: projectPath)
                         }
                         .buttonStyle(.borderless)
                         .keyboardShortcut(.defaultAction)

--- a/CodeEditModules/Modules/WelcomeModule/src/RecentProjectsView.swift
+++ b/CodeEditModules/Modules/WelcomeModule/src/RecentProjectsView.swift
@@ -90,13 +90,13 @@ public struct RecentProjectsView: View {
             forKey: "recentProjectPaths"
         )
     }
-    
+
     func deleteProject(projectPath: String) {
         self.selectedProjectPaths.forEach { projectPath in
             deleteFromRecent(item: projectPath)
         }
     }
-    
+
     func openProject(projectPath: String) {
         if selectedProjectPaths.contains(projectPath) {
             selectedProjectPaths.forEach { projectPath in
@@ -139,11 +139,12 @@ public struct RecentProjectsView: View {
                                 openProject(projectPath: projectPath)
                             })
                             .gesture(TapGesture().onEnded {
-                                if NSEvent.modifierFlags.contains(.command){
+                                if NSEvent.modifierFlags.contains(.command) {
                                     self.lastSelectedProjectPath = projectPath
                                     selectedProjectPaths.insert(projectPath)
                                 } else if NSEvent.modifierFlags.contains(.shift) {
-                                    if let lastIndex = recentProjectPaths.firstIndex(of: lastSelectedProjectPath), let currentIndex = recentProjectPaths.firstIndex(of: projectPath) {
+                                    if let lastIndex = recentProjectPaths.firstIndex(of: lastSelectedProjectPath),
+                                       let currentIndex = recentProjectPaths.firstIndex(of: projectPath) {
                                         if currentIndex > lastIndex {
                                             let projectPaths = Array(recentProjectPaths[lastIndex..<currentIndex+1])
                                             selectedProjectPaths = selectedProjectPaths.union(projectPaths)
@@ -159,7 +160,7 @@ public struct RecentProjectsView: View {
                             })
                             .contextMenu {
                                 contextMenuShowInFinder(projectPath: projectPath)
-                                
+
                                 if !selectedProjectPaths.contains(projectPath) {
                                     contextMenuCopy(path: projectPath)
                                         .keyboardShortcut(mgr.named(with: "copy").keyboardShortcut)
@@ -183,7 +184,6 @@ public struct RecentProjectsView: View {
                             }
                             .buttonStyle(.borderless)
                             .keyboardShortcut(mgr.named(with: "copy").keyboardShortcut)
-                        
 
                         Button("") {
                             openProject(projectPath: projectPath)


### PR DESCRIPTION
# Description

added multiple project select feature. I have tried to map the features exactly as Xcode. feature include :
- allow multiple section of recent project 
- use command to select choice of multiple projects 
- use shift to select range of multiple projects
- delete selected projects together
- open selected projects to together
# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #386 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/53724307/193229457-53f92e97-2d10-4336-a839-ac7460b1bd7b.mov


<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
