### PR TITLE
Add AppCast Jekyll Folder for building appcasts

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,3 +18,5 @@ template: |
   ## Changes
 
   $CHANGES
+  
+<!-- sparkle:edSignature=xxxxx -->

--- a/.github/workflows/appcast.yml
+++ b/.github/workflows/appcast.yml
@@ -1,0 +1,50 @@
+name: Build and publish a new appcast file
+
+on:
+  workflow_dispatch:
+  release:
+
+jobs:
+  jekyll:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout 🛎
+      uses: actions/checkout@v3
+      with:
+        # If you're using actions/checkout@v3 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        persist-credentials: false
+
+    - name: Cache 📦
+      uses: actions/cache@v3.0.8
+      with:
+        path: AppCast/vendor/bundle
+        key: ${{ runner.os }}-gems-v1.0-${{ hashFiles('AppCast/Gemfile') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+          
+    - name: Ruby ♦️
+      uses: actions/setup-ruby@v1.1.3
+      with:
+        ruby-version: '2.7'
+
+    - name: Bundler 💎
+      working-directory: AppCast
+      env:
+        BUNDLE_PATH: vendor/bundle
+      run: |
+        gem install bundler
+        bundle install
+
+    - name: Build 🛠
+      working-directory: AppCast
+      env:
+        BUNDLE_PATH: vendor/bundle
+        JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: bundle exec jekyll build
+      
+    - name: Publish 🚀
+      uses: JamesIves/github-pages-deploy-action@releases/v3
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: AppCast/_site

--- a/AppCast/.gitignore
+++ b/AppCast/.gitignore
@@ -1,0 +1,3 @@
+_site
+.sass-cache
+.jekyll-metadata

--- a/AppCast/Gemfile
+++ b/AppCast/Gemfile
@@ -1,0 +1,28 @@
+source "https://rubygems.org"
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "~> 3.9.0"
+
+gem "jekyll-github-metadata", group: :jekyll_plugins
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
+  gem "tzinfo", "~> 1.2"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
+
+# kramdown v2 ships without the gfm parser by default. If you're using
+# kramdown v1, comment out this line.
+gem "kramdown-parser-gfm"
+

--- a/AppCast/Gemfile.lock
+++ b/AppCast/Gemfile.lock
@@ -1,0 +1,93 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.7)
+    em-websocket (0.5.2)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
+    ffi (1.14.2)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    jekyll (3.9.0)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 0.7)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (>= 1.17, < 3)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 4)
+      safe_yaml (~> 1.0)
+    jekyll-github-metadata (2.13.0)
+      jekyll (>= 3.4, < 5.0)
+      octokit (~> 4.0, != 4.4.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.3.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.3)
+    listen (3.4.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.3.6)
+    multipart-post (2.1.1)
+    octokit (4.20.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (4.0.6)
+    rb-fsevent (0.10.4)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rexml (3.2.5)
+    rouge (3.26.0)
+    ruby2_keywords (0.0.2)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.10)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2020.6)
+      tzinfo (>= 1.0.0)
+    wdm (0.1.1)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-20
+
+DEPENDENCIES
+  jekyll (~> 3.9.0)
+  jekyll-github-metadata
+  kramdown-parser-gfm
+  tzinfo (~> 1.2)
+  tzinfo-data
+  wdm (~> 0.1.0)
+
+BUNDLED WITH
+   2.2.5

--- a/AppCast/_config.yml
+++ b/AppCast/_config.yml
@@ -1,0 +1,36 @@
+# Welcome to Jekyll!
+#
+# This config file is meant for settings that affect your whole blog, values
+# which you are expected to set up once and rarely edit after that. If you find
+# yourself editing this file very often, consider using Jekyll's data files
+# feature for the data you need to update frequently.
+#
+# For technical reasons, this file is *NOT* reloaded automatically when you use
+# 'bundle exec jekyll serve'. If you change this file, please restart the server process.
+
+# Site settings
+# These are used to personalize your new site. If you look in the HTML files,
+# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
+# You can create any custom variable you would like, and they will be accessible
+# in the templates via {{ site.myvariable }}.
+title: CodeEdit.app
+description: >- # this means to ignore newlines until "baseurl:"
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
+
+# Build settings
+markdown: kramdown
+plugins:
+  - "jekyll-github-metadata"
+
+# Exclude from processing.
+# The following items will not be processed, by default. Create a custom list
+# to override the default setting.
+# exclude:
+#   - Gemfile
+#   - Gemfile.lock
+#   - node_modules
+#   - vendor/bundle/
+#   - vendor/cache/
+#   - vendor/gems/
+#   - vendor/ruby/

--- a/AppCast/_includes/appcast.inc
+++ b/AppCast/_includes/appcast.inc
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>{{ site.github.project_title }}</title>
+        <description>Most recent changes with links to updates.</description>
+        <language>en</language>
+        {% for release in site.github.releases %}
+            {% unless release.draft %}
+                {% unless release.prerelease and page.release_only %}
+                    <item>
+                        <title>{{ release.name }}</title>
+                        <description><![CDATA[{{ release.body | markdownify }}]]></description>
+                        <pubDate>{{ release.published_at | date_to_rfc822 }}</pubDate>
+                        {% for asset in release.assets limit:1 %}
+                            {% assign signature = release.body | sparkle_signature %}
+
+                            {% assign build_nums = release.tag_name | replace_first:'v','' | replace_first:'b',',' | split:',' %}
+                            {% if build_nums.size == 2 %}
+                                {% assign version_number = build_nums[0] %}
+                                {% assign build_number = build_nums[1] %}
+
+                                <enclosure
+                                    url="{{ asset.browser_download_url }}"
+                                    sparkle:version="{{ build_number }}"
+                                    sparkle:shortVersionString="{{ version_number }}"
+                                    sparkle:edSignature="{{ signature }}"
+                                    length="{{ asset.size }}"
+                                    type="application/octet-stream" />
+                            {% else %}
+                                {% assign version = release.tag_name | remove_first:'v' %}
+
+                                <enclosure
+                                    url="{{ asset.browser_download_url }}"
+                                    sparkle:version="{{ version }}"
+                                    sparkle:edSignature="{{ signature }}"
+                                    length="{{ asset.size }}"
+                                    type="application/octet-stream" />
+                            {% endif %}
+                        {% endfor %}
+                    </item>
+                {% endunless %}
+            {% endunless %}
+        {% endfor %}
+    </channel>
+</rss>

--- a/AppCast/_plugins/signature_filter.rb
+++ b/AppCast/_plugins/signature_filter.rb
@@ -1,0 +1,12 @@
+module Jekyll
+  module SignatureFilter
+    def sparkle_signature(release_body)
+      regex = /<!-- sparkle:edSignature=(?<signature>.*) -->/m
+      signature = release_body.match(regex).named_captures["signature"]
+      raise "Didn't find a signature in the release body." if signature.empty?
+      signature
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::SignatureFilter)

--- a/AppCast/appcast.xml
+++ b/AppCast/appcast.xml
@@ -1,0 +1,4 @@
+---
+release_only: true
+---
+{%include appcast.inc %}

--- a/AppCast/appcast_pre.xml
+++ b/AppCast/appcast_pre.xml
@@ -1,0 +1,4 @@
+---
+release_only: false
+---
+{%include appcast.inc %}


### PR DESCRIPTION
# Description

This adds an AppCast folder that includes the code needed for a manual release process. 

1. On a "release" (Preview release or regular) the Jekyll website will get recreated
2. Will loop through releases, searching for a `sparkle:edSignature=` comment on the release
3. Will create `appcast.xml` and `appcast_pre.xml` based on those releases.

Note: All zip's/dmg will need be included in the release. This includes the proper signing and notarizing needed by Sparkle. 

The preface to making sure this works as it should is to get artifacts building properly which currently they are not. 

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #644 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
