### PR TITLE
Fix release drafter with bad spacing

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,4 +19,4 @@ template: |
 
   $CHANGES
   
-<!-- sparkle:edSignature=xxxxx -->
+  <!-- sparkle:edSignature=xxxxx -->


### PR DESCRIPTION
# Description

Yaml is invalid because of a missing tab. https://github.com/CodeEditApp/CodeEdit/actions/runs/3185183157
