### PR TITLE
[chore]: update dependencies

### DIFF
--- a/.github/scripts/test_app.sh
+++ b/.github/scripts/test_app.sh
@@ -9,6 +9,7 @@ elif [ $1 = "arm" ]; then
 fi
 
 echo "Building with arch: ${ARCH}"
+swiftlint --version
 
 export LC_CTYPE=en_US.UTF-8
 

--- a/.github/scripts/test_app.sh
+++ b/.github/scripts/test_app.sh
@@ -16,4 +16,5 @@ export LC_CTYPE=en_US.UTF-8
 set -o pipefail && arch -"${ARCH}" xcodebuild -workspace CodeEdit.xcworkspace \
            -scheme CodeEdit \
            -destination "platform=OS X,arch=${ARCH}" \
+           -skipPackagePluginValidation \
            clean test | xcpretty

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build CodeEdit
         env:
           APPLE_TEAM_ID:  ${{ secrets.APPLE_TEAM_ID }}
-        run: xcodebuild -workspace CodeEdit.xcworkspace -scheme CodeEdit -configuration Release -derivedDataPath "$RUNNER_TEMP/DerivedData" -archivePath "$RUNNER_TEMP/CodeEdit.xcarchive" DEVELOPMENT_TEAM=$APPLE_TEAM_ID archive
+        run: xcodebuild -workspace CodeEdit.xcworkspace -scheme CodeEdit -configuration Release -derivedDataPath "$RUNNER_TEMP/DerivedData" -archivePath "$RUNNER_TEMP/CodeEdit.xcarchive" -skipPackagePluginValidation DEVELOPMENT_TEAM=$APPLE_TEAM_ID archive
       - name: Create CodeEdit.dmg
         run: |
           REV=$(git rev-parse --short HEAD)

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -632,7 +632,6 @@
 				B658FB2927DA9E0F00EA4DBD /* Frameworks */,
 				B658FB2A27DA9E0F00EA4DBD /* Resources */,
 				2B18499A27F8A7A0005119F0 /* Mark // swiftlint:disable:all as errors | Run Script */,
-				2BA119D327E5274D00A996FF /* SwiftLint Run Script */,
 				04ADA0CC27E6043B00BF00B2 /* Add TODO/FIXME as warnings | Run Script */,
 				04C3255A2801B43A00C8DA2D /* Embed Frameworks */,
 				2BE487F528245162003F3F64 /* Embed Foundation Extensions */,
@@ -640,6 +639,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				287136B3292A408700E9F5F4 /* PBXTargetDependency */,
 				2BE487F328245162003F3F64 /* PBXTargetDependency */,
 			);
 			name = CodeEdit;
@@ -745,6 +745,7 @@
 			packageReferences = (
 				2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */,
 				2801BB88290D5A8E00EBF552 /* XCRemoteSwiftPackageReference "CodeEditKit" */,
+				287136B1292A407E00E9F5F4 /* XCRemoteSwiftPackageReference "SwiftLintPlugin" */,
 			);
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
 			projectDirPath = "";
@@ -837,25 +838,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "TAGS=\"\\/\\/ swiftlint:disable all\"\necho \"searching ${SRCROOT} for ${TAGS}\"\nfind \"${SRCROOT}\" \\( -name \"*.swift\" \\) -print0 | xargs -0 egrep --with-filename --line-number --only-matching \"($TAGS).*\\$\" | perl -p -e \"s/($TAGS)/ error: Usage of \\$1 is prohibited/\"\n";
-		};
-		2BA119D327E5274D00A996FF /* SwiftLint Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "SwiftLint Run Script";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint >/dev/null; then\n  swiftlint --strict\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		FDF7C12027FAE90F0039BA76 /* Copy Package.resolved into Project Directory */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -978,6 +960,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		287136B3292A408700E9F5F4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 287136B2292A408700E9F5F4 /* SwiftLint */;
+		};
 		2BE487F328245162003F3F64 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 2BE487EB28245162003F3F64 /* OpenWithCodeEdit */;
@@ -1426,6 +1412,14 @@
 				version = 0.1.0;
 			};
 		};
+		287136B1292A407E00E9F5F4 /* XCRemoteSwiftPackageReference "SwiftLintPlugin" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/lukepistrol/SwiftLintPlugin";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1474,6 +1468,11 @@
 		2864BAAD28117D7C002DBD1A /* TerminalEmulator */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TerminalEmulator;
+		};
+		287136B2292A408700E9F5F4 /* SwiftLint */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 287136B1292A407E00E9F5F4 /* XCRemoteSwiftPackageReference "SwiftLintPlugin" */;
+			productName = "plugin:SwiftLint";
 		};
 		28CE5E9F27E6493D0065D29C /* StatusBar */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
       "state" : {
-        "revision" : "271feca0ea37002441c73e7f16ee5600b6fc00b2",
-        "version" : "0.1.2"
+        "revision" : "6b412f6eb6f5d7bdfa91f2d92105b4d6dae12df3",
+        "version" : "0.1.3"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "088f048eeb522e93fb43c979757b20f9318e747d",
-        "version" : "0.1.3"
+        "revision" : "7e9bb803e6892d5cd5380edaf6bdefa24628edb1",
+        "version" : "0.1.5"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/STTextView.git",
       "state" : {
-        "revision" : "21bd12695d52b306e5b9074e61fc7ed63fbf1eff",
-        "version" : "0.1.1"
+        "revision" : "3df7ce1829a9277f427daa794e8a0d1aaeacfbb7",
+        "version" : "0.1.2"
       }
     },
     {

--- a/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -91,6 +91,15 @@
       }
     },
     {
+      "identity" : "swiftlintplugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
+      "state" : {
+        "branch" : "main",
+        "revision" : "ebd70f6ad4cfc0b9330373702dce886c422bc7c7"
+      }
+    },
+    {
       "identity" : "swiftterm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/migueldeicaza/SwiftTerm.git",

--- a/CodeEdit/Documents/CodeEditWindowController.swift
+++ b/CodeEdit/Documents/CodeEditWindowController.swift
@@ -149,7 +149,6 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         ]
     }
 
-    // swiftlint:disable:next function_body_length
     func toolbar(
         _ toolbar: NSToolbar,
         itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,

--- a/CodeEdit/Documents/WorkspaceDocument+Search.swift
+++ b/CodeEdit/Documents/WorkspaceDocument+Search.swift
@@ -61,18 +61,18 @@ extension WorkspaceDocument {
             guard let filePaths = enumerator?.allObjects as? [URL] else { return }
 
             // TODO: Optimization
-            /// This could be optimized further by doing a couple things:
-            /// - Making sure strings and indexes are using UTF8 everywhere possible
-            ///   (this will increase matching speed and time taken to calculate byte offsets for string indexes)
-            /// - Lazily fetching file paths. Right now we do `enumerator.allObjects`, but using an actual
-            ///   enumerator object to lazily enumerate through files would drop time.
-            /// - Loop through each character instead of each line to find matches, then return the line if needed.
-            ///   This could help in cases when the file is one *massive* line (eg: a minified JS document).
-            ///   In that case this method would load that entire file into memory to find matches. To speed
-            ///   this up we could enumerate through each character instead of each line and when a match
-            ///   is found only copy a couple characters into the result object.
-            /// - Lazily load strings using `FileHandle.AsyncBytes`
-            ///   https://developer.apple.com/documentation/foundation/filehandle/3766681-bytes
+            // This could be optimized further by doing a couple things:
+            // - Making sure strings and indexes are using UTF8 everywhere possible
+            //   (this will increase matching speed and time taken to calculate byte offsets for string indexes)
+            // - Lazily fetching file paths. Right now we do `enumerator.allObjects`, but using an actual
+            //   enumerator object to lazily enumerate through files would drop time.
+            // - Loop through each character instead of each line to find matches, then return the line if needed.
+            //   This could help in cases when the file is one *massive* line (eg: a minified JS document).
+            //   In that case this method would load that entire file into memory to find matches. To speed
+            //   this up we could enumerate through each character instead of each line and when a match
+            //   is found only copy a couple characters into the result object.
+            // - Lazily load strings using `FileHandle.AsyncBytes`
+            //   https://developer.apple.com/documentation/foundation/filehandle/3766681-bytes
             filePaths.map { url in
                 WorkspaceClient.FileItem(url: url, children: nil)
             }.forEach { fileItem in

--- a/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineMenu.swift
+++ b/CodeEdit/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineMenu.swift
@@ -44,7 +44,6 @@ final class OutlineMenu: NSMenu {
         return mItem
     }
 
-    // swiftlint:disable function_body_length
     /// Setup the menu and disables certain items when `isFile` is false
     /// - Parameter isFile: A flag indicating that the item is a file instead of a directory
     private func setupMenu() {

--- a/CodeEdit/TabBar/TabBar.swift
+++ b/CodeEdit/TabBar/TabBar.swift
@@ -418,14 +418,14 @@ struct TabBar: View {
         HStack(spacing: 2) {
             TabBarAccessoryIcon(
                 icon: .init(systemName: "chevron.left"),
-                action: { /* TODO */ }
+                action: {} // TODO: Implement
             )
             .foregroundColor(.secondary)
             .buttonStyle(.plain)
             .help("Navigate back")
             TabBarAccessoryIcon(
                 icon: .init(systemName: "chevron.right"),
-                action: { /* TODO */ }
+                action: {} // TODO: Implement
             )
             .foregroundColor(.secondary)
             .buttonStyle(.plain)
@@ -445,21 +445,21 @@ struct TabBar: View {
         HStack(spacing: 2) {
             TabBarAccessoryIcon(
                 icon: .init(systemName: "ellipsis.circle"),
-                action: { /* TODO */ }
+                action: {} // TODO: Implement
             )
             .foregroundColor(.secondary)
             .buttonStyle(.plain)
             .help("Options")
             TabBarAccessoryIcon(
                 icon: .init(systemName: "arrow.left.arrow.right.square"),
-                action: { /* TODO */ }
+                action: {} // TODO: Implement
             )
             .foregroundColor(.secondary)
             .buttonStyle(.plain)
             .help("Enable Code Review")
             TabBarAccessoryIcon(
                 icon: .init(systemName: "square.split.2x1"),
-                action: { /* TODO */ }
+                action: {} // TODO: Implement
             )
             .foregroundColor(.secondary)
             .buttonStyle(.plain)

--- a/CodeEdit/TabBar/TabBarContextMenu.swift
+++ b/CodeEdit/TabBar/TabBarContextMenu.swift
@@ -33,6 +33,7 @@ struct TabBarContextMenu: ViewModifier {
     private var item: TabBarItemRepresentable
     private var isTemporary: Bool
 
+    // swiftlint:disable:next function_body_length
     func body(content: Content) -> some View {
         content.contextMenu(menuItems: {
             Group {

--- a/CodeEditModules/Modules/AppPreferences/src/Extensions/Loopable.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Extensions/Loopable.swift
@@ -36,7 +36,8 @@ extension Loopable {
         let mirror = Mirror(reflecting: self)
 
         guard let style = mirror.displayStyle, style == .struct || style == .class else {
-            throw NSError()
+            // TODO: Throw a proper error
+            throw NSError() // swiftlint:disable:this discouraged_direct_init
         }
 
         for (property, value) in mirror.children {

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/Theme.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/Theme.swift
@@ -329,7 +329,6 @@ public extension Theme {
             ]
         }
 
-        // swiftlint:disable function_body_length
         /// Allows to look up properties by their name
         ///
         /// **Example:**

--- a/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEditModules/Modules/AppPreferences/src/Sections/ThemePreferences/Model/ThemeModel.swift
@@ -122,7 +122,7 @@ public final class ThemeModel: ObservableObject {
     /// When overrides are found in `~/Library/Application Support/CodeEdit/.preferences.json`
     /// they are applied to the loaded themes without altering the original
     /// the files in `~/Library/Application Support/CodeEdit/themes/`.
-    public func loadThemes() throws {
+    public func loadThemes() throws { // swiftlint:disable:this function_body_length
         // remove all themes from memory
         themes.removeAll()
 
@@ -151,7 +151,8 @@ public final class ThemeModel: ObservableObject {
                       let editorColors = try theme.editor.allProperties() as? [String: Theme.Attributes]
                 else {
                     print("error")
-                    throw NSError()
+                    // TODO: Throw a proper error
+                    throw NSError() // swiftlint:disable:this discouraged_direct_init
                 }
 
                 // check if there are any overrides in `preferences.json`
@@ -288,7 +289,8 @@ public final class ThemeModel: ObservableObject {
                       let oTermColors = try originalTheme.terminal.allProperties() as? [String: Theme.Attributes],
                       let oEditColors = try originalTheme.editor.allProperties() as? [String: Theme.Attributes]
                 else {
-                    throw NSError()
+                    // TODO: Throw a proper error
+                    throw NSError() // swiftlint:disable:this discouraged_direct_init
                 }
 
                 // compare the properties and if there are differences, save to overrides

--- a/CodeEditModules/Modules/CodeEditExtension/src/ExtensionManager.swift
+++ b/CodeEditModules/Modules/CodeEditExtension/src/ExtensionManager.swift
@@ -100,10 +100,10 @@ public final class ExtensionManager {
         return nil
     }
 
+    // TODO: Reimplement this with XPC
     /// Opens the extension, reads and parses the manifest.json file
     /// - Parameter bundleURL: The URL of the bundle that should be loaded
     ///
-    // TODO: Reimplement this with XPC
     private func preload(_ bundleURL: URL) {
         guard let bundle = Bundle(url: bundleURL) else { return }
         guard bundle.bundleIdentifier != nil else { return }
@@ -125,9 +125,9 @@ public final class ExtensionManager {
         }
     }
 
+    // TODO: Reimplement this with XPC
     /// Triggers the build function of the extension and thereby activates the extesion
     ///
-    // TODO: Reimplement this with XPC
     private func load(_ bundle: Bundle, _ apiBuilder: (String) -> ExtensionAPI) {
         for bundle in loadedBundles {
             guard let bundleIdentifier = bundle.bundleIdentifier else { continue }

--- a/CodeEditModules/Modules/Git/src/Accounts/Networking/Router.swift
+++ b/CodeEditModules/Modules/Git/src/Accounts/Networking/Router.swift
@@ -119,8 +119,7 @@ public extension Router {
     /// Due to the complexity of the the urlQuery method we disabled lint for the this method
     /// only so that it doesn't complain... Note this level of complexity is needed to give us as
     /// much success rate as possible due to all git providers having different types of url schemes.
-    // swiftlint:disable:next cyclomatic_complexity
-    func urlQuery(_ parameters: [String: Any]) -> [URLQueryItem]? {
+    func urlQuery(_ parameters: [String: Any]) -> [URLQueryItem]? { // swiftlint:disable:this cyclomatic_complexity
         guard !parameters.isEmpty else { return nil }
 
         var components: [URLQueryItem] = []
@@ -177,7 +176,7 @@ public extension Router {
         case .form:
             let queryData = urlComponents.percentEncodedQuery?.data(using: String.Encoding.utf8)
 
-            /// clear the query items as they go into the body
+            // clear the query items as they go into the body
             urlComponents.queryItems = nil
 
             var mutableURLRequest = Foundation.URLRequest(url: urlComponents.url!)
@@ -351,7 +350,7 @@ private extension CharacterSet {
     /// https://github.com/Alamofire/Alamofire/blob/3.5rameterEncoding.swift#L220-L225
     static func URLQueryAllowedCharacterSet() -> CharacterSet {
 
-        /// does not include "?" or "/" due to RFC 3986 - Section 3.4
+        // does not include "?" or "/" due to RFC 3986 - Section 3.4
         let generalDelimitersToEncode = ":#[]@"
         let subDelimitersToEncode = "!$&'()*+,;="
 

--- a/CodeEditModules/Modules/Git/src/Client/Live.swift
+++ b/CodeEditModules/Modules/Git/src/Client/Live.swift
@@ -86,9 +86,8 @@ public extension GitClient {
                 }
         }
 
-        /// Gets the commit history log of the current file opened
-        /// in the workspace.
-
+        // Gets the commit history log of the current file opened
+        // in the workspace.
         func getCommitHistory(entries: Int?, fileLocalPath: String?) throws -> [Commit] {
             var entriesString = ""
             let fileLocalPath = fileLocalPath?.escapedWhiteSpaces() ?? ""

--- a/CodeEditModules/Modules/Search/src/Extensions/String+SafeOffset.swift
+++ b/CodeEditModules/Modules/Search/src/Extensions/String+SafeOffset.swift
@@ -17,38 +17,38 @@ extension String {
     ///   - limitedBy: An index to limit the offset by.
     /// - Returns: A `String.Index`
     func safeOffset(_ idx: String.Index, offsetBy offset: Int, limitedBy: String.Index) -> String.Index {
-        /// This is the odd case this method solves. Swift's
-        /// ``String.index(_:offsetBy:limitedBy:)``
-        /// will crash if the given index is equal to the offset, and
-        /// we try to go outside of the string's limits anyways.
+        // This is the odd case this method solves. Swift's
+        // ``String.index(_:offsetBy:limitedBy:)``
+        // will crash if the given index is equal to the offset, and
+        // we try to go outside of the string's limits anyways.
         if idx == limitedBy {
             return limitedBy
         } else if offset < 0 {
-            /// If the offset is going backwards, but the limit index
-            /// is ahead in the string we return the original index.
+            // If the offset is going backwards, but the limit index
+            // is ahead in the string we return the original index.
             if limitedBy > idx {
                 return idx
             }
 
-            //// Return the index offset by the given offset.
-            /// If this index is nil we return the limit index.
+            // Return the index offset by the given offset.
+            // If this index is nil we return the limit index.
             return index(idx,
                          offsetBy: offset,
                          limitedBy: limitedBy) ?? limitedBy
         } else if offset > 0 {
-            /// If the offset is going forwards, but the limit index
-            /// is behind in the string we return the original index.
+            // If the offset is going forwards, but the limit index
+            // is behind in the string we return the original index.
             if limitedBy < idx {
                 return idx
             }
 
-            /// Return the index offset by the given offset.
-            /// If this index is nil we return the limit index.
+            // Return the index offset by the given offset.
+            // If this index is nil we return the limit index.
             return index(idx,
                          offsetBy: offset,
                          limitedBy: limitedBy) ?? limitedBy
         } else {
-            /// The offset is 0, so we return the limit index.
+            // The offset is 0, so we return the limit index.
             return limitedBy
         }
     }
@@ -66,7 +66,7 @@ extension String {
         } else if offset > 0 {
             return safeOffset(idx, offsetBy: offset, limitedBy: self.endIndex)
         } else {
-            /// If the offset is 0 we return the original index.
+            // If the offset is 0 we return the original index.
             return idx
         }
     }

--- a/CodeEditModules/Modules/Search/src/Model/SearchResultMatchModel.swift
+++ b/CodeEditModules/Modules/Search/src/Model/SearchResultMatchModel.swift
@@ -52,8 +52,9 @@ public class SearchResultMatchModel: Hashable, Identifiable {
     /// Will only return 60 characters before and after the matched result.
     /// - Returns: The formatted `NSAttributedString`
     public func attributedLabel() -> NSAttributedString {
-        /// By default `NSTextView` will ignore any paragraph wrapping set to the label when it's
-        /// using an `NSAttributedString` so we need to set the wrap mode here.
+
+        // By default `NSTextView` will ignore any paragraph wrapping set to the label when it's
+        // using an `NSAttributedString` so we need to set the wrap mode here.
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineBreakMode = .byCharWrapping
 
@@ -70,11 +71,10 @@ public class SearchResultMatchModel: Hashable, Identifiable {
             .paragraphStyle: paragraphStyle
         ]
 
-        /// Set up the search result string with the matched search in bold.
-        ///
-        /// We also limit the result to 60 characters before and after the
-        /// match to reduce *massive* results in the search result list, and for
-        /// cases where a file may be formatted in one line (eg: a minimized JS file).
+        // Set up the search result string with the matched search in bold.
+        // We also limit the result to 60 characters before and after the
+        // match to reduce *massive* results in the search result list, and for
+        // cases where a file may be formatted in one line (eg: a minimized JS file).
         let lowerIndex = lineContent.safeOffset(keywordRange.lowerBound, offsetBy: -60)
         let upperIndex = lineContent.safeOffset(keywordRange.upperBound, offsetBy: 60)
         let prefix = String(lineContent[lowerIndex..<keywordRange.lowerBound])

--- a/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/Live.swift
@@ -19,9 +19,9 @@ public extension WorkspaceClient {
     ) throws -> Self {
         var flattenedFileItems: [String: FileItem] = [:]
 
-        /// Recursive loading of files into `FileItem`s
-        /// - Parameter url: The URL of the directory to load the items of
-        /// - Returns: `[FileItem]` representing the contents of the directory
+        // Recursive loading of files into `FileItem`s
+        // - Parameter url: The URL of the directory to load the items of
+        // - Returns: `[FileItem]` representing the contents of the directory
         func loadFiles(fromURL url: URL) throws -> [FileItem] {
             let directoryContents = try fileManager.contentsOfDirectory(at: url.resolvingSymlinksInPath(),
                                                                         includingPropertiesForKeys: nil)
@@ -68,10 +68,10 @@ public extension WorkspaceClient {
         var isRunning: Bool = false
         var anotherInstanceRan: Int = 0
 
-        /// Recursive function similar to `loadFiles`, but creates or deletes children of the
-        /// `FileItem` so that they are accurate with the file system, instead of creating an
-        /// entirely new `FileItem`, to prevent the `OutlineView` from going crazy with folding.
-        /// - Parameter fileItem: The `FileItem` to correct the children of
+        // Recursive function similar to `loadFiles`, but creates or deletes children of the
+        // `FileItem` so that they are accurate with the file system, instead of creating an
+        // entirely new `FileItem`, to prevent the `OutlineView` from going crazy with folding.
+        // - Parameter fileItem: The `FileItem` to correct the children of
         func rebuildFiles(fromItem fileItem: FileItem) throws -> Bool {
             var didChangeSomething = false
 

--- a/CodeEditModules/Modules/WorkspaceClient/src/UI/FileIcon.swift
+++ b/CodeEditModules/Modules/WorkspaceClient/src/UI/FileIcon.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 // TODO: DOCS (Nanashi Li)
 // swiftlint:disable missing_docs
-// swiftlint:disable function_body_length
 // swiftlint:disable cyclomatic_complexity
 public enum FileIcon {
 

--- a/CodeEditModules/Package.swift
+++ b/CodeEditModules/Package.swift
@@ -129,7 +129,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/CodeEditApp/CodeEditTextView.git",
-            exact: "0.1.3"
+            exact: "0.1.5"
         ),
     ],
     targets: [

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
       "state" : {
-        "revision" : "271feca0ea37002441c73e7f16ee5600b6fc00b2",
-        "version" : "0.1.2"
+        "revision" : "6b412f6eb6f5d7bdfa91f2d92105b4d6dae12df3",
+        "version" : "0.1.3"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "088f048eeb522e93fb43c979757b20f9318e747d",
-        "version" : "0.1.3"
+        "revision" : "7e9bb803e6892d5cd5380edaf6bdefa24628edb1",
+        "version" : "0.1.5"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/STTextView.git",
       "state" : {
-        "revision" : "21bd12695d52b306e5b9074e61fc7ed63fbf1eff",
-        "version" : "0.1.1"
+        "revision" : "3df7ce1829a9277f427daa794e8a0d1aaeacfbb7",
+        "version" : "0.1.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -91,6 +91,15 @@
       }
     },
     {
+      "identity" : "swiftlintplugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
+      "state" : {
+        "branch" : "main",
+        "revision" : "ebd70f6ad4cfc0b9330373702dce886c422bc7c7"
+      }
+    },
+    {
       "identity" : "swiftterm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/migueldeicaza/SwiftTerm.git",


### PR DESCRIPTION
- Update `CodeEditTextView` to `0.1.5`
- Fixes for `SwiftLint` version `0.50.0`
- as discussed in Discord: remove SwiftLint build run script and replace with a SwiftLint build-tool-plugin

> The Tests currently fail because the `macOS-12` runner is yet to be updated with `SwiftLint` version `0.50.0`. 

Maybe we should consider removing the run script phase for Xcode and use a Build Tool Plugin (https://github.com/lukepistrol/SwiftLintPlugin) instead which loads the binary directly and executes it. This would also mean new contributors don't need to install SwiftLint on their machines.