### PR TITLE
Removed the ability to open a folder as a tab from the breadcrumbs menu.

### DIFF
--- a/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsMenu.swift
+++ b/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsMenu.swift
@@ -84,6 +84,9 @@ final class BreadcrumbsMenuItem: NSMenuItem {
         )?.withSymbolConfiguration(.init(paletteColors: [NSColor(color)]))
         self.image = image
         representedObject = fileItem
+        if fileItem.isFolder == true {
+            self.action = nil
+        }
     }
 
     @available(*, unavailable)

--- a/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsMenu.swift
+++ b/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsMenu.swift
@@ -84,7 +84,7 @@ final class BreadcrumbsMenuItem: NSMenuItem {
         )?.withSymbolConfiguration(.init(paletteColors: [NSColor(color)]))
         self.image = image
         representedObject = fileItem
-        if fileItem.isFolder == true {
+        if fileItem.isFolder {
             self.action = nil
         }
     }


### PR DESCRIPTION
# Description

In the breadcrumb menu, the NSMenuItem action-method is removed (set to nil), if the item is a folder. 
As a result, folders are not clickable and do not open a new tab.

# Related Issue

* #869

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/82230675/208755191-f9931e69-40a3-4a03-a297-c8b7c67f78b1.mov