### PR TITLE
Removal of the .xcworkspace file

### DIFF
--- a/.github/scripts/test_app.sh
+++ b/.github/scripts/test_app.sh
@@ -13,7 +13,7 @@ swiftlint --version
 
 export LC_CTYPE=en_US.UTF-8
 
-set -o pipefail && arch -"${ARCH}" xcodebuild -workspace CodeEdit.xcworkspace \
+set -o pipefail && arch -"${ARCH}" xcodebuild \
            -scheme CodeEdit \
            -destination "platform=OS X,arch=${ARCH}" \
            -skipPackagePluginValidation \

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build CodeEdit
         env:
           APPLE_TEAM_ID:  ${{ secrets.APPLE_TEAM_ID }}
-        run: xcodebuild -workspace CodeEdit.xcworkspace -scheme CodeEdit -configuration Release -derivedDataPath "$RUNNER_TEMP/DerivedData" -archivePath "$RUNNER_TEMP/CodeEdit.xcarchive" -skipPackagePluginValidation DEVELOPMENT_TEAM=$APPLE_TEAM_ID archive
+        run: xcodebuild -scheme CodeEdit -configuration Release -derivedDataPath "$RUNNER_TEMP/DerivedData" -archivePath "$RUNNER_TEMP/CodeEdit.xcarchive" -skipPackagePluginValidation DEVELOPMENT_TEAM=$APPLE_TEAM_ID archive
       - name: Create CodeEdit.dmg
         run: |
           REV=$(git rev-parse --short HEAD)

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,7 +96,7 @@
       "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
       "state" : {
         "branch" : "main",
-        "revision" : "ebd70f6ad4cfc0b9330373702dce886c422bc7c7"
+        "revision" : "e4aaf65a9c6f64340125a2dc36c95436551b8d5e"
       }
     },
     {

--- a/CodeEdit.xcworkspace/contents.xcworkspacedata
+++ b/CodeEdit.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "container:CodeEdit.xcodeproj">
-   </FileRef>
-</Workspace>

--- a/CodeEdit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CodeEdit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/CodeEdit.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/CodeEdit.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PreviewsEnabled</key>
-	<false/>
-</dict>
-</plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "CodeEdit",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
# Description

Removed the .xcworkspace file and related data in .xcodeproj. Existing contributors might need to reopen the project via the .xcodeproj file.

See issue for any extra reasoning or details.

# Related Issue

* #878 

# Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
