### PR TITLE
Snap Sidebar To Width

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		2BE487F428245162003F3F64 /* OpenWithCodeEdit.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 2BE487EC28245162003F3F64 /* OpenWithCodeEdit.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		474397C52893AC4B00518C8C /* codeedit-midnight.json in Resources */ = {isa = PBXBuildFile; fileRef = 474397C42893AC4B00518C8C /* codeedit-midnight.json */; };
 		4E7F066629602E7B00BB3C12 /* CodeEditSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7F066529602E7B00BB3C12 /* CodeEditSplitViewController.swift */; };
+		4EE96ECB2960565E00FFBEA8 /* DocumentsUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE96ECA2960565E00FFBEA8 /* DocumentsUnitTests.swift */; };
+		4EE96ECE296059E000FFBEA8 /* NSHapticFeedbackPerformerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE96ECD296059E000FFBEA8 /* NSHapticFeedbackPerformerMock.swift */; };
 		581BFB672926431000D251EC /* WelcomeWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581BFB5A2926431000D251EC /* WelcomeWindowView.swift */; };
 		581BFB682926431000D251EC /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581BFB5B2926431000D251EC /* WelcomeView.swift */; };
 		581BFB692926431000D251EC /* WelcomeActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581BFB5C2926431000D251EC /* WelcomeActionView.swift */; };
@@ -431,6 +433,8 @@
 		2BE487F028245162003F3F64 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		474397C42893AC4B00518C8C /* codeedit-midnight.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "codeedit-midnight.json"; sourceTree = "<group>"; };
 		4E7F066529602E7B00BB3C12 /* CodeEditSplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditSplitViewController.swift; sourceTree = "<group>"; };
+		4EE96ECA2960565E00FFBEA8 /* DocumentsUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentsUnitTests.swift; sourceTree = "<group>"; };
+		4EE96ECD296059E000FFBEA8 /* NSHapticFeedbackPerformerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSHapticFeedbackPerformerMock.swift; sourceTree = "<group>"; };
 		581BFB5A2926431000D251EC /* WelcomeWindowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeWindowView.swift; sourceTree = "<group>"; };
 		581BFB5B2926431000D251EC /* WelcomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		581BFB5C2926431000D251EC /* WelcomeActionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeActionView.swift; sourceTree = "<group>"; };
@@ -910,6 +914,23 @@
 			path = OpenWithCodeEdit;
 			sourceTree = "<group>";
 		};
+		4EE96EC82960562000FFBEA8 /* Documents */ = {
+			isa = PBXGroup;
+			children = (
+				4EE96ECC296059D200FFBEA8 /* Mocks */,
+				4EE96ECA2960565E00FFBEA8 /* DocumentsUnitTests.swift */,
+			);
+			path = Documents;
+			sourceTree = "<group>";
+		};
+		4EE96ECC296059D200FFBEA8 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				4EE96ECD296059E000FFBEA8 /* NSHapticFeedbackPerformerMock.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		581BFB4B2926431000D251EC /* Welcome */ = {
 			isa = PBXGroup;
 			children = (
@@ -1371,6 +1392,7 @@
 		587B60FE293416C900D5CD8F /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				4EE96EC82960562000FFBEA8 /* Documents */,
 				583E527429361B39001AB554 /* CodeEditUI */,
 				583E526929361B39001AB554 /* Welcome */,
 				587B612C2934199800D5CD8F /* CodeFile */,
@@ -2745,6 +2767,8 @@
 				583E528C29361B39001AB554 /* CodeEditUITests.swift in Sources */,
 				587B60F82934124200D5CD8F /* WorkspaceClientTests.swift in Sources */,
 				587B61012934170A00D5CD8F /* UnitTests_Extensions.swift in Sources */,
+				4EE96ECB2960565E00FFBEA8 /* DocumentsUnitTests.swift in Sources */,
+				4EE96ECE296059E000FFBEA8 /* NSHapticFeedbackPerformerMock.swift in Sources */,
 				587B612E293419B700D5CD8F /* CodeFileTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		2BE487EF28245162003F3F64 /* FinderSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE487EE28245162003F3F64 /* FinderSync.swift */; };
 		2BE487F428245162003F3F64 /* OpenWithCodeEdit.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 2BE487EC28245162003F3F64 /* OpenWithCodeEdit.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		474397C52893AC4B00518C8C /* codeedit-midnight.json in Resources */ = {isa = PBXBuildFile; fileRef = 474397C42893AC4B00518C8C /* codeedit-midnight.json */; };
+		4E7F066629602E7B00BB3C12 /* CodeEditSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7F066529602E7B00BB3C12 /* CodeEditSplitViewController.swift */; };
 		581BFB672926431000D251EC /* WelcomeWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581BFB5A2926431000D251EC /* WelcomeWindowView.swift */; };
 		581BFB682926431000D251EC /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581BFB5B2926431000D251EC /* WelcomeView.swift */; };
 		581BFB692926431000D251EC /* WelcomeActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581BFB5C2926431000D251EC /* WelcomeActionView.swift */; };
@@ -429,6 +430,7 @@
 		2BE487EE28245162003F3F64 /* FinderSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderSync.swift; sourceTree = "<group>"; };
 		2BE487F028245162003F3F64 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		474397C42893AC4B00518C8C /* codeedit-midnight.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "codeedit-midnight.json"; sourceTree = "<group>"; };
+		4E7F066529602E7B00BB3C12 /* CodeEditSplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditSplitViewController.swift; sourceTree = "<group>"; };
 		581BFB5A2926431000D251EC /* WelcomeWindowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeWindowView.swift; sourceTree = "<group>"; };
 		581BFB5B2926431000D251EC /* WelcomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		581BFB5C2926431000D251EC /* WelcomeActionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeActionView.swift; sourceTree = "<group>"; };
@@ -1034,6 +1036,7 @@
 			children = (
 				043C321327E31FF6006AE443 /* CodeEditDocumentController.swift */,
 				04660F6927E51E5C00477777 /* CodeEditWindowController.swift */,
+				4E7F066529602E7B00BB3C12 /* CodeEditSplitViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -2542,6 +2545,7 @@
 				2072FA1C280D874000C7F8D4 /* IndentUsing.swift in Sources */,
 				58798284292ED0FB0085B254 /* TerminalEmulatorView.swift in Sources */,
 				B6EE989227E887C600CDD8AB /* InspectorSidebarToolbarTop.swift in Sources */,
+				4E7F066629602E7B00BB3C12 /* CodeEditSplitViewController.swift in Sources */,
 				587B9E8D29301D8F00AC7927 /* GitHubAccount.swift in Sources */,
 				201169E72837B5CA00F92B46 /* SourceControlModel.swift in Sources */,
 				58798265292EC4080085B254 /* ExtensionsStoreAPI.swift in Sources */,

--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -39,6 +39,11 @@ final class CodeEditSplitViewController: NSSplitViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewWillAppear() {
+        super.viewWillAppear()
+        splitView.setPosition(.snapWidth, ofDividerAt: .zero)
+    }
+
     // MARK: - NSSplitViewDelegate
 
     override func splitView(

--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -1,0 +1,57 @@
+//
+//  CodeEditSplitViewController.swift
+//  CodeEdit
+//
+//  Created by YAPRYNTSEV Aleksey on 31.12.2022.
+//
+
+import Cocoa
+
+private extension CGFloat {
+    static let snapWidth: CGFloat = 270
+
+    static let minSnapWidth: CGFloat = snapWidth - 10
+    static let maxSnapWidth: CGFloat = snapWidth + 10
+}
+
+final class CodeEditSplitViewController: NSSplitViewController {
+    // Properties
+    private var isSnapped: Bool = false {
+        willSet {
+            if newValue, newValue != isSnapped {
+                feedbackPerformer.perform(.alignment, performanceTime: .now)
+            }
+        }
+    }
+
+    // Dependencies
+    private let feedbackPerformer: NSHapticFeedbackPerformer
+
+    // MARK: - Initialization
+
+    init(feedbackPerformer: NSHapticFeedbackPerformer) {
+        self.feedbackPerformer = feedbackPerformer
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - NSSplitViewDelegate
+
+    override func splitView(
+        _ splitView: NSSplitView,
+        constrainSplitPosition proposedPosition: CGFloat,
+        ofSubviewAt dividerIndex: Int
+    ) -> CGFloat {
+        if (CGFloat.minSnapWidth...CGFloat.maxSnapWidth).contains(proposedPosition) {
+            isSnapped = true
+            return .snapWidth
+        } else {
+            isSnapped = false
+            return proposedPosition
+        }
+    }
+}

--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -16,7 +16,7 @@ private extension CGFloat {
 
 final class CodeEditSplitViewController: NSSplitViewController {
     // Properties
-    private var isSnapped: Bool = false {
+    private(set) var isSnapped: Bool = false {
         willSet {
             if newValue, newValue != isSnapped {
                 feedbackPerformer.perform(.alignment, performanceTime: .now)

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -65,14 +65,15 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
     }
 
     private func setupSplitView(with workspace: WorkspaceDocument) {
-        let splitVC = NSSplitViewController()
+        let feedbackPerformer = NSHapticFeedbackManager.defaultPerformer
+        let splitVC = CodeEditSplitViewController(feedbackPerformer: feedbackPerformer)
 
         let navigatorView = NavigatorSidebarView(workspace: workspace, windowController: self)
         let navigator = NSSplitViewItem(
             sidebarWithViewController: NSHostingController(rootView: navigatorView)
         )
         navigator.titlebarSeparatorStyle = .none
-        navigator.minimumThickness = 260
+        navigator.minimumThickness = 242
         navigator.collapseBehavior = .useConstraints
         splitVC.addSplitViewItem(navigator)
 

--- a/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
+++ b/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
@@ -73,6 +73,8 @@ struct NavigatorSidebarToolbarTop: View {
             selection = id
         } label: {
             getSafeImage(named: named, accesibilityDescription: title)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .help(title)
                 .onDrag {
                     if let index = icons.firstIndex(where: { $0.imageName == named }) {
@@ -85,7 +87,6 @@ struct NavigatorSidebarToolbarTop: View {
                 }
         }
         .buttonStyle(NavigatorToolbarButtonStyle(id: id, selection: selection, activeState: activeState))
-        .imageScale(scale)
     }
 
     private func getSafeImage(named: String, accesibilityDescription: String?) -> Image {
@@ -103,10 +104,9 @@ struct NavigatorSidebarToolbarTop: View {
 
         func makeBody(configuration: Configuration) -> some View {
             configuration.label
-                .font(.system(size: 15, weight: id == selection ? .semibold : .regular))
                 .symbolVariant(id == selection ? .fill : .none)
                 .foregroundColor(id == selection ? .accentColor : configuration.isPressed ? .primary : .secondary)
-                .frame(width: 15, height: 15, alignment: .center)
+                .frame(width: 15, height: 15)
                 .contentShape(Rectangle())
                 .opacity(activeState == .inactive ? 0.45 : 1)
         }

--- a/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
+++ b/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
@@ -35,30 +35,37 @@ struct NavigatorSidebarToolbarTop: View {
     }
 
     var body: some View {
-        HStack(spacing: 2) {
-            ForEach(icons) { icon in
-                makeIcon(named: icon.imageName, title: icon.title, id: icon.id)
-                    .opacity(draggingItem?.imageName == icon.imageName &&
-                             hasChangedLocation &&
-                             drugItemLocation != nil ? 0.0: icon.disabled ? 0.3 : 1.0)
-                    .onDrop(of: [.utf8PlainText],
-                            delegate: NavigatorSidebarDockIconDelegate(item: icon,
-                                                                        current: $draggingItem,
-                                                                        icons: $icons,
-                                                                        hasChangedLocation: $hasChangedLocation,
-                                                                        drugItemLocation: $drugItemLocation))
-                    .disabled(icon.disabled)
+        GeometryReader { proxy in
+            HStack(spacing: makeSpace(for: proxy.size)) {
+                ForEach(icons) { icon in
+                    makeIcon(named: icon.imageName, title: icon.title, id: icon.id)
+                        .opacity(draggingItem?.imageName == icon.imageName &&
+                                 hasChangedLocation &&
+                                 drugItemLocation != nil ? 0.0: icon.disabled ? 0.3 : 1.0)
+                        .onDrop(of: [.utf8PlainText],
+                                delegate: NavigatorSidebarDockIconDelegate(item: icon,
+                                                                            current: $draggingItem,
+                                                                            icons: $icons,
+                                                                            hasChangedLocation: $hasChangedLocation,
+                                                                            drugItemLocation: $drugItemLocation))
+                        .disabled(icon.disabled)
+                }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay(alignment: .top) {
+                Divider()
+            }
+            .overlay(alignment: .bottom) {
+                Divider()
+            }
+            .animation(.default, value: icons)
         }
-        .frame(height: 29, alignment: .center)
-        .frame(maxWidth: .infinity)
-        .overlay(alignment: .top) {
-            Divider()
-        }
-        .overlay(alignment: .bottom) {
-            Divider()
-        }
-        .animation(.default, value: icons)
+        .frame(maxWidth: .infinity, idealHeight: 29)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func makeSpace(for size: CGSize) -> CGFloat {
+        size.width < 270 ? 9 : 15
     }
 
     private func makeIcon(named: String, title: String, id: Int, scale: Image.Scale = .medium) -> some View {
@@ -66,16 +73,16 @@ struct NavigatorSidebarToolbarTop: View {
             selection = id
         } label: {
             getSafeImage(named: named, accesibilityDescription: title)
-            .help(title)
-            .onDrag {
-            if let index = icons.firstIndex(where: { $0.imageName == named }) {
-                draggingItem = icons[index]
-            }
-                return .init(object: NSString(string: named))
-            } preview: {
-                RoundedRectangle(cornerRadius: .zero)
-                    .frame(width: .zero)
-            }
+                .help(title)
+                .onDrag {
+                    if let index = icons.firstIndex(where: { $0.imageName == named }) {
+                        draggingItem = icons[index]
+                    }
+                    return .init(object: NSString(string: named))
+                } preview: {
+                    RoundedRectangle(cornerRadius: .zero)
+                        .frame(width: .zero)
+                }
         }
         .buttonStyle(NavigatorToolbarButtonStyle(id: id, selection: selection, activeState: activeState))
         .imageScale(scale)
@@ -96,10 +103,10 @@ struct NavigatorSidebarToolbarTop: View {
 
         func makeBody(configuration: Configuration) -> some View {
             configuration.label
-                .font(.system(size: 12, weight: id == selection ? .semibold : .regular))
+                .font(.system(size: 15, weight: id == selection ? .semibold : .regular))
                 .symbolVariant(id == selection ? .fill : .none)
                 .foregroundColor(id == selection ? .accentColor : configuration.isPressed ? .primary : .secondary)
-                .frame(width: 25, height: 25, alignment: .center)
+                .frame(width: 15, height: 15, alignment: .center)
                 .contentShape(Rectangle())
                 .opacity(activeState == .inactive ? 0.45 : 1)
         }

--- a/CodeEditTests/Features/Documents/DocumentsUnitTests.swift
+++ b/CodeEditTests/Features/Documents/DocumentsUnitTests.swift
@@ -1,0 +1,111 @@
+//
+//  DocumentsUnitTests.swift
+//  CodeEditTests
+//
+//  Created by YAPRYNTSEV Aleksey on 31.12.2022.
+//
+
+import XCTest
+@testable import CodeEdit
+
+final class DocumentsUnitTests: XCTestCase {
+    // Properties
+    private var splitViewController: CodeEditSplitViewController!
+    private var hapticFeedbackPerformerMock: NSHapticFeedbackPerformerMock!
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        super.setUp()
+        hapticFeedbackPerformerMock = .init()
+        splitViewController = .init(feedbackPerformer: hapticFeedbackPerformerMock)
+    }
+
+    override func tearDown() {
+        hapticFeedbackPerformerMock = nil
+        splitViewController = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func testSplitViewControllerSnappedWhenWidthInAppropriateRange() {
+        // Given
+        let position = (260...280).randomElement() ?? .zero
+
+        // When
+        let result = splitViewController.splitView(
+            splitViewController.splitView,
+            constrainSplitPosition: .init(position),
+            ofSubviewAt: .zero
+        )
+
+        // Then
+        XCTAssertEqual(result, 270)
+    }
+
+    func testSplitViewControllerStopSnappedWhenWidthIsLowerAppropriateRange() {
+        // Given
+        let position = (0..<260).randomElement() ?? .zero
+
+        // When
+        let result = splitViewController.splitView(
+            splitViewController.splitView,
+            constrainSplitPosition: .init(position),
+            ofSubviewAt: .zero
+        )
+
+        // Then
+        XCTAssertEqual(result, .init(position))
+    }
+
+    func testSplitViewControllerStopSnappedWhenWidthIsHigherAppropriateRange() {
+        // Given
+        let position = (281...500).randomElement() ?? .zero
+
+        // When
+        let result = splitViewController.splitView(
+            splitViewController.splitView,
+            constrainSplitPosition: .init(position),
+            ofSubviewAt: .zero
+        )
+
+        // Then
+        XCTAssertEqual(result, .init(position))
+    }
+
+    func testSplitViewControllerProducedHapticFeedback() {
+        // Given
+        let position = (260...280).randomElement() ?? .zero
+
+        // When
+        _ = splitViewController.splitView(
+            splitViewController.splitView,
+            constrainSplitPosition: .init(position),
+            ofSubviewAt: .zero
+        )
+
+        // Then
+        XCTAssertTrue(hapticFeedbackPerformerMock.invokedPerform)
+        XCTAssertEqual(hapticFeedbackPerformerMock.invokedPerformCount, 1)
+    }
+
+    func testSplitViewControllerProducedHapticFeedbackOnceWhenPlentyChangesOccur() {
+        // Given
+        let firstPosition = (260...280).randomElement() ?? .zero
+        let secondPosition = 300
+
+        // When
+        [firstPosition, secondPosition].forEach { position in
+            _ = splitViewController.splitView(
+                splitViewController.splitView,
+                constrainSplitPosition: .init(position),
+                ofSubviewAt: .zero
+            )
+        }
+
+        // Then
+        XCTAssertTrue(hapticFeedbackPerformerMock.invokedPerform)
+        XCTAssertEqual(hapticFeedbackPerformerMock.invokedPerformCount, 1)
+    }
+}

--- a/CodeEditTests/Features/Documents/Mocks/NSHapticFeedbackPerformerMock.swift
+++ b/CodeEditTests/Features/Documents/Mocks/NSHapticFeedbackPerformerMock.swift
@@ -1,0 +1,22 @@
+//
+//  NSHapticFeedbackPerformerMock.swift
+//  CodeEditTests
+//
+//  Created by YAPRYNTSEV Aleksey on 31.12.2022.
+//
+
+import Cocoa
+
+final class NSHapticFeedbackPerformerMock: NSObject, NSHapticFeedbackPerformer {
+
+    var invokedPerform = false
+    var invokedPerformCount = 0
+
+    func perform(
+        _ pattern: NSHapticFeedbackManager.FeedbackPattern,
+        performanceTime: NSHapticFeedbackManager.PerformanceTime
+    ) {
+        invokedPerform = true
+        invokedPerformCount += 1
+    }
+}


### PR DESCRIPTION
# Description
* Added `CodeEditSplitViewController` which handles all snap logic.
* `NavigatorSidebarToolbarTop` wrapped in `GeometryReader`. Now, HStack can react to width changes and choose appropriate space between items.
* Add unit tests for `CodeEditSplitViewController`.

# Related Issue
* #856 

# Checklist
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots
![photo_2023-01-01_15-06-23](https://user-images.githubusercontent.com/18378212/210168458-365a930c-38de-4e90-aff2-0d1b86cfb88c.jpg)