### PR TITLE
Add support for saving .swift files

### DIFF
--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -234,6 +234,25 @@
 		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
+				<string>Swift</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Swift source code</string>
+			<key>CFBundleTypeOSTypes</key>
+			<array>
+				<string>TEXT</string>
+				<string>utxt</string>
+				<string>TUTX</string>
+				<string>****</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>NSDocumentClass</key>
+			<string>CodeFileDocument</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
 				<string>cs</string>
 				<string>csx</string>
 			</array>


### PR DESCRIPTION
# Description

Added Swift file type to `info.plist` for supporting saving .swift files.

# Related Issue

Add enhancement for issue #896

# Screenshots
<img width="583" alt="image" src="https://user-images.githubusercontent.com/5067237/211108542-1c737949-fb6a-417d-bf41-5a4a80beb00d.png">