### PR TITLE
Fix typo: exisiting => existing

### DIFF
--- a/CodeEdit/Features/Welcome/Views/Resources/en.lproj/Localizable.strings
+++ b/CodeEdit/Features/Welcome/Views/Resources/en.lproj/Localizable.strings
@@ -5,7 +5,7 @@
 
 // Welcome Screen - New File
 "Create a new file" = "Create a new file";
-"Clone an exisiting project" = "Clone an exisiting project";
+"Clone an existing project" = "Clone an existing project";
 
 // Welcome Screen - Open File
 "Open a file or folder" = "Open a file or folder";

--- a/CodeEdit/Features/Welcome/Views/WelcomeView.swift
+++ b/CodeEdit/Features/Welcome/Views/WelcomeView.swift
@@ -154,7 +154,7 @@ struct WelcomeView: View {
                         }
                         WelcomeActionView(
                             iconName: "plus.square.on.square",
-                            title: NSLocalizedString("Clone an exisiting project", comment: ""),
+                            title: NSLocalizedString("Clone an existing project", comment: ""),
                             subtitle: NSLocalizedString(
                                 "Start working on something from a Git repository",
                                 comment: ""

--- a/CodeEdit/Localization/en.lproj/Localizable.strings
+++ b/CodeEdit/Localization/en.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 
 // Welcome Screen - New File
 "Create a new file" = "Create a new file";
-"Clone an exisiting project" = "Clone an exisiting project";
+"Clone an existing project" = "Clone an existing project";
 
 // Welcome Screen - Open File
 "Open a file or folder" = "Open a file or folder";


### PR DESCRIPTION
# Description

Fixes an typo: exisiting => existing that appears in the launch screen.

# Checklist

<!--- Add things that are not yet implemented above -->
- [ X ] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X  ] My changes generate no new warnings
- [ X ] My code builds and runs on my machine
- [ ] I documented my code
- [ X ] Review requested

# Screenshots

