### PR TITLE
Raised the default editor and terminal font sizes from 11pt to 12pt.

### DIFF
--- a/CodeEdit/Features/AppPreferences/Model/Terminal/TerminalPreferences.swift
+++ b/CodeEdit/Features/AppPreferences/Model/Terminal/TerminalPreferences.swift
@@ -52,7 +52,7 @@ extension AppPreferences {
         var customFont: Bool = false
 
         /// The font size for the custom font
-        var size: Int = 11
+        var size: Int = 12
 
         /// The name of the custom font
         var name: String = "SFMono-Medium"

--- a/CodeEdit/Features/AppPreferences/Model/Text Editing/TextEditingPreferences.swift
+++ b/CodeEdit/Features/AppPreferences/Model/Text Editing/TextEditingPreferences.swift
@@ -41,7 +41,7 @@ extension AppPreferences {
         var customFont: Bool = false
 
         /// The font size for the custom font
-        var size: Int = 11
+        var size: Int = 12
 
         /// The name of the custom font
         var name: String = "SFMono-Medium"


### PR DESCRIPTION
# Description

Raised default editor and terminal font size from 11pt to 12pt.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->

- #912 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
