### PR TITLE
Fixed inspector sidebar toggle so it is now displayed as expected

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -174,7 +174,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
 
             return toolbarItem
         case .toggleLastSidebarItem:
-            let toolbarItem = NSToolbarItem(itemIdentifier: NSToolbarItem.Identifier.toggleFirstSidebarItem)
+            let toolbarItem = NSToolbarItem(itemIdentifier: NSToolbarItem.Identifier.toggleLastSidebarItem)
             toolbarItem.label = "Inspector Sidebar"
             toolbarItem.paletteLabel = "Inspector Sidebar"
             toolbarItem.toolTip = "Hide or show the Inspectors"


### PR DESCRIPTION
# Description

Inspector toggle was not showing displaying at all, this fix brings it back.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #880

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="213" alt="image" src="https://user-images.githubusercontent.com/806104/212120084-75902c21-5337-48f9-9f1f-a10072572302.png">
