### PR TITLE
Fixed incorrect background colors to be more consistent

### DIFF
--- a/CodeEdit/Features/TabBar/Views/TabBarDivider.swift
+++ b/CodeEdit/Features/TabBar/Views/TabBarDivider.swift
@@ -66,7 +66,7 @@ struct TabBarBottomDivider: View {
             .foregroundColor(
                 prefs.preferences.general.tabBarStyle == .xcode
                 ? Color(nsColor: .separatorColor)
-                    .opacity(colorScheme == .dark ? 0.80 : 0.40)
+                    .opacity(colorScheme == .dark ? 0.80 : 1)
                 : Color(nsColor: .black)
                     .opacity(colorScheme == .dark ? 0.65 : 0.13)
 

--- a/CodeEdit/Features/TabBar/Views/TabBarView.swift
+++ b/CodeEdit/Features/TabBar/Views/TabBarView.swift
@@ -392,15 +392,7 @@ struct TabBarView: View {
             }
         }
         .background {
-            if prefs.preferences.general.tabBarStyle == .xcode {
-                EffectView(
-                    NSVisualEffectView.Material.titlebar,
-                    blendingMode: NSVisualEffectView.BlendingMode.withinWindow
-                )
-                // Set bottom padding to avoid material overlapping in bar.
-                .padding(.bottom, TabBarView.height)
-                .edgesIgnoringSafeArea(.top)
-            } else {
+            if prefs.preferences.general.tabBarStyle == .native {
                 TabBarNativeMaterial()
                     .edgesIgnoringSafeArea(.top)
             }

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -49,6 +49,8 @@ struct WorkspaceView: View {
     @State
     private var leaveFullscreenObserver: Any?
 
+    @Environment(\.colorScheme) var colorScheme
+
     var noEditor: some View {
         Text("No Editor")
             .font(.system(size: 17))
@@ -80,27 +82,21 @@ struct WorkspaceView: View {
                 ZStack {
                     tabContent
                 }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background {
-                        if prefs.preferences.general.tabBarStyle == .xcode {
-                            // Use the same background material as xcode tab bar style.
-                            // Only when the tab bar style is set to `xcode`.
-                            TabBarXcodeBackground()
-                        }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .safeAreaInset(edge: .top, spacing: 0) {
+                    VStack(spacing: 0) {
+                        TabBarView(windowController: windowController, workspace: workspace)
+                        TabBarBottomDivider()
                     }
-                    .safeAreaInset(edge: .top, spacing: 0) {
-                        VStack(spacing: 0) {
-                            TabBarView(windowController: windowController, workspace: workspace)
-                            TabBarBottomDivider()
-                        }
-                    }
-                    .safeAreaInset(edge: .bottom) {
-                        StatusBarView(model: model)
-                    }
+                }
+                .safeAreaInset(edge: .bottom) {
+                    StatusBarView(model: model)
+                }
             } else {
                 EmptyView()
             }
         }
+        .background(colorScheme == .dark ? Color(.black).opacity(0.25) : Color(.white))
         .alert(alertTitle, isPresented: $showingAlert, actions: {
             Button(
                 action: { showingAlert = false },


### PR DESCRIPTION
# Description

Fixed incorrect background colors.

# Related Issue

* #926

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="894" alt="image" src="https://user-images.githubusercontent.com/806104/212141193-5fa2dc48-6f5c-46ab-bdff-28672a0ed2b7.png">

Tab bar and breadcrumb bar are darker.