### PR TITLE
[fix]: Update Mechanism

### DIFF
--- a/CodeEdit/Features/AppPreferences/SoftwareUpdater.swift
+++ b/CodeEdit/Features/AppPreferences/SoftwareUpdater.swift
@@ -42,7 +42,6 @@ class SoftwareUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
             }
             return
         }
-        print("RESULT: \(result)")
         URL.appcast = URL(
             string: "https://github.com/CodeEditApp/CodeEdit/releases/download/\(result.tagName)/appcast.xml"
         )!

--- a/CodeEdit/Features/AppPreferences/SoftwareUpdater.swift
+++ b/CodeEdit/Features/AppPreferences/SoftwareUpdater.swift
@@ -30,6 +30,8 @@ class SoftwareUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
         }
     }
 
+    private var feedURLTask: Task<(), Never>?
+
     private func setFeedURL() async {
         let url = URL(string: "https://api.github.com/repos/CodeEditApp/CodeEdit/releases/latest")!
         let request = URLRequest(url: url)
@@ -57,7 +59,7 @@ class SoftwareUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
             userDriverDelegate: nil
         ).updater
 
-        Task {
+        feedURLTask = Task {
             await setFeedURL()
         }
 
@@ -79,6 +81,10 @@ class SoftwareUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
         )
 
         includePrereleaseVersions = UserDefaults.standard.bool(forKey: "includePrereleaseVersions")
+    }
+
+    deinit {
+        feedURLTask?.cancel()
     }
 
     func allowedChannels(for updater: SPUUpdater) -> Set<String> {

--- a/CodeEdit/Features/AppPreferences/SoftwareUpdater.swift
+++ b/CodeEdit/Features/AppPreferences/SoftwareUpdater.swift
@@ -30,7 +30,7 @@ class SoftwareUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
         }
     }
 
-    func setFeedURL() async {
+    private func setFeedURL() async {
         let url = URL(string: "https://api.github.com/repos/CodeEditApp/CodeEdit/releases/latest")!
         let request = URLRequest(url: url)
         guard let data = try? await URLSession.shared.data(for: request),


### PR DESCRIPTION
A quick fix for the update mechanism. Instead of providing a static url, the latest release is now fetched from GitHub API and set accordingly