### PR TITLE
When setting use monochrome icons fixed icon color to be gray instead of folder blue

### DIFF
--- a/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -129,11 +129,9 @@ final class OutlineTableViewCell: NSTableCellView {
     /// - Parameter item: The `FileItem` to get the color for
     /// - Returns: A `NSColor` for the given `FileItem`.
     private func color(for item: WorkspaceClient.FileItem) -> NSColor {
-        if item.children == nil && prefs.fileIconStyle == .color {
-            return NSColor(item.iconColor)
-        } else {
-            return NSColor(named: "FolderBlue")!
-        }
+        return prefs.fileIconStyle == .color
+            ? item.children == nil ? NSColor(item.iconColor) : NSColor(named: "FolderBlue")!
+            : .secondaryLabelColor
     }
 }
 


### PR DESCRIPTION
# Description

Fixed bug where files and folders were blue if using monochrome icon setting.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #938 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

Before

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/806104/212149871-427ddce1-33cf-4a99-9388-9b97293e4e2e.png">

After

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/806104/212149903-9f37bc53-4370-4f84-bf8e-10de5d5f8305.png">

