### PR TITLE
fix: update latest release link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ CodeEdit is a code editor built by the community, for the community, written ent
 ![GitHub forks](https://img.shields.io/github/forks/CodeEditApp/CodeEdit?style=flat-square)
 [![Discord Badge](https://img.shields.io/discord/951544472238444645?color=5865F2&label=Discord&logo=discord&logoColor=white&style=flat-square)](https://discord.gg/vChUXVf9Em)
 
-| :warning: | CodeEdit is currently in development and not yet ready for production use. You can test the latest [alpha build](https://github.com/CodeEditApp/CodeEdit/releases/tag/latest) if you would like, but be warned, you will find many bugs and incomplete features. Please file new issues [here](https://github.com/CodeEditApp/CodeEdit/issues) after searching to see if the issue already exists either in this repository or in our [related repositories](https://github.com/CodeEditApp/CodeEdit#related-repositories). [Contributors welcome](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md)! |
+| :warning: | CodeEdit is currently in development and not yet ready for production use. You can test the latest [alpha build](https://github.com/CodeEditApp/CodeEdit/releases/latest) if you would like, but be warned, you will find many bugs and incomplete features. Please file new issues [here](https://github.com/CodeEditApp/CodeEdit/issues) after searching to see if the issue already exists either in this repository or in our [related repositories](https://github.com/CodeEditApp/CodeEdit#related-repositories). [Contributors welcome](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md)! |
 | - |:-|
 
 ## Table of Contents


### PR DESCRIPTION
The latest release link was previously broken.

# Description

Changes the alpha release link so that it works.
`https://github.com/CodeEditApp/CodeEdit/releases/tag/latest` -> `https://github.com/CodeEditApp/CodeEdit/releases/latest`

# Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [ ] My code builds and runs on my machine
- [ ] I documented my code
- [ ] Review requested

