### PR TITLE
quick typo fix. "Bitbucket Cloud" should be "Github".

### DIFF
--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/AccountPreferencesView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/AccountPreferencesView.swift
@@ -94,7 +94,7 @@ struct AccountPreferencesView: View {
                     }
                     .pickerStyle(.radioGroup)
 
-                    Text("New repositories will be cloned from Bitbucket Cloud using HTTPS.")
+                    Text("New repositories will be cloned from Github using HTTPS.")
                         .lineLimit(2)
                         .font(.system(size: 11))
                         .foregroundColor(Color.secondary)


### PR DESCRIPTION
# Description
Change "Bitbucket Cloud" to "Github" in  Preferences > Source Control Accounts.

# Related Issue
 #930

# Screenshot

<img width="444" alt="image" src="https://user-images.githubusercontent.com/5067237/212402101-0c4adcb7-b393-484c-8794-cfe033e583df.png">
