### PR TITLE
Added NSWindow environment key

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -305,6 +305,8 @@
 		6C05A8AF284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */; };
 		6C14CEB028777D3C001468FE /* FindNavigatorListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C14CEAF28777D3C001468FE /* FindNavigatorListViewController.swift */; };
 		6C14CEB32877A68F001468FE /* FindNavigatorMatchListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C14CEB22877A68F001468FE /* FindNavigatorMatchListCell.swift */; };
+		6C48D8F22972DAFC00D6D205 /* IsFullscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F12972DAFC00D6D205 /* IsFullscreen.swift */; };
+		6C48D8F42972DB1A00D6D205 /* Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F32972DB1A00D6D205 /* Window.swift */; };
 		6CDA84AB284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AA284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift */; };
 		6CDA84AD284C1BA000C1CC3A /* TabBarContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */; };
 		B62617282964924E00E866AB /* CodeEditKit in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 2801BB89290D5A8E00EBF552 /* CodeEditKit */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -669,6 +671,8 @@
 		6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkspaceDocument+Listeners.swift"; sourceTree = "<group>"; };
 		6C14CEAF28777D3C001468FE /* FindNavigatorListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorListViewController.swift; sourceTree = "<group>"; };
 		6C14CEB22877A68F001468FE /* FindNavigatorMatchListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorMatchListCell.swift; sourceTree = "<group>"; };
+		6C48D8F12972DAFC00D6D205 /* IsFullscreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsFullscreen.swift; sourceTree = "<group>"; };
+		6C48D8F32972DB1A00D6D205 /* Window.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Window.swift; sourceTree = "<group>"; };
 		6CDA84AA284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItemButtonStyle.swift; sourceTree = "<group>"; };
 		6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarContextMenu.swift; sourceTree = "<group>"; };
 		B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodeEdit.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1777,6 +1781,7 @@
 		58D01C85293167DC00C5B6B4 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				6C48D8EF2972DAC300D6D205 /* Environment */,
 				58D01C87293167DC00C5B6B4 /* Extensions */,
 				58D01C8F293167DC00C5B6B4 /* KeyChain */,
 				5831E3C92933E83400D5A6D2 /* Protocols */,
@@ -2110,6 +2115,15 @@
 				6C14CEB22877A68F001468FE /* FindNavigatorMatchListCell.swift */,
 			);
 			path = FindNavigatorResultList;
+			sourceTree = "<group>";
+		};
+		6C48D8EF2972DAC300D6D205 /* Environment */ = {
+			isa = PBXGroup;
+			children = (
+				6C48D8F12972DAFC00D6D205 /* IsFullscreen.swift */,
+				6C48D8F32972DB1A00D6D205 /* Window.swift */,
+			);
+			path = Environment;
 			sourceTree = "<group>";
 		};
 		B658FB2327DA9E0F00EA4DBD = {
@@ -2591,6 +2605,7 @@
 				5882252D292C280D00E83CDE /* StatusBarSplitTerminalButton.swift in Sources */,
 				58798238292E30B90085B254 /* FeedbackWindowController.swift in Sources */,
 				587B9E6C29301D8F00AC7927 /* GitLabNamespace.swift in Sources */,
+				6C48D8F22972DAFC00D6D205 /* IsFullscreen.swift in Sources */,
 				587B9E8729301D8F00AC7927 /* GitHubRepositories.swift in Sources */,
 				587B9DA329300ABD00AC7927 /* SettingsTextEditor.swift in Sources */,
 				2072FA1A280D872600C7F8D4 /* LineEndings.swift in Sources */,
@@ -2684,6 +2699,7 @@
 				58F2EB09292FB2B0004A9BDE /* TerminalPreferences.swift in Sources */,
 				587D9B742933BF5700BF7490 /* FileItem+Array.swift in Sources */,
 				587D9B772933BF5700BF7490 /* Live.swift in Sources */,
+				6C48D8F42972DB1A00D6D205 /* Window.swift in Sources */,
 				2072FA18280D871200C7F8D4 /* TextEncoding.swift in Sources */,
 				58F2EAF3292FB2B0004A9BDE /* ThemePreviewIcon.swift in Sources */,
 				58F2EB07292FB2B0004A9BDE /* GeneralPreferences.swift in Sources */,

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		6C14CEB32877A68F001468FE /* FindNavigatorMatchListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C14CEB22877A68F001468FE /* FindNavigatorMatchListCell.swift */; };
 		6C48D8F22972DAFC00D6D205 /* IsFullscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F12972DAFC00D6D205 /* IsFullscreen.swift */; };
 		6C48D8F42972DB1A00D6D205 /* Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F32972DB1A00D6D205 /* Window.swift */; };
+		6C48D8F72972E5F300D6D205 /* WindowObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F62972E5F300D6D205 /* WindowObserver.swift */; };
 		6CDA84AB284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AA284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift */; };
 		6CDA84AD284C1BA000C1CC3A /* TabBarContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */; };
 		B62617282964924E00E866AB /* CodeEditKit in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 2801BB89290D5A8E00EBF552 /* CodeEditKit */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -673,6 +674,7 @@
 		6C14CEB22877A68F001468FE /* FindNavigatorMatchListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorMatchListCell.swift; sourceTree = "<group>"; };
 		6C48D8F12972DAFC00D6D205 /* IsFullscreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsFullscreen.swift; sourceTree = "<group>"; };
 		6C48D8F32972DB1A00D6D205 /* Window.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Window.swift; sourceTree = "<group>"; };
+		6C48D8F62972E5F300D6D205 /* WindowObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowObserver.swift; sourceTree = "<group>"; };
 		6CDA84AA284C0E4A00C1CC3A /* TabBarItemButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItemButtonStyle.swift; sourceTree = "<group>"; };
 		6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarContextMenu.swift; sourceTree = "<group>"; };
 		B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodeEdit.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2165,6 +2167,7 @@
 				04660F6027E3A68A00477777 /* Info.plist */,
 				043C321927E32295006AE443 /* MainMenu.xib */,
 				B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */,
+				6C48D8F62972E5F300D6D205 /* WindowObserver.swift */,
 				28069DA527F5BD320016BC47 /* DefaultThemes */,
 			);
 			path = CodeEdit;
@@ -2546,6 +2549,7 @@
 				D7012EE827E757850001E1EF /* FindNavigatorView.swift in Sources */,
 				58A5DF8029325B5A00D1BD5D /* GitClient.swift in Sources */,
 				D7E201AE27E8B3C000CB86D0 /* String+Ranges.swift in Sources */,
+				6C48D8F72972E5F300D6D205 /* WindowObserver.swift in Sources */,
 				587B9E6B29301D8F00AC7927 /* GitLabAvatarURL.swift in Sources */,
 				58798262292EC4080085B254 /* PluginRelease.swift in Sources */,
 				58F2EB10292FB2B0004A9BDE /* PreferencesColorPicker.swift in Sources */,

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -68,7 +68,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         let feedbackPerformer = NSHapticFeedbackManager.defaultPerformer
         let splitVC = CodeEditSplitViewController(feedbackPerformer: feedbackPerformer)
 
-        let navigatorView = NavigatorSidebarView(workspace: workspace, windowController: self)
+        let navigatorView = NavigatorSidebarView(workspace: workspace)
         let navigator = NSSplitViewItem(
             sidebarWithViewController: NSHostingController(rootView: navigatorView)
         )
@@ -77,14 +77,15 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         navigator.collapseBehavior = .useConstraints
         splitVC.addSplitViewItem(navigator)
 
-        let workspaceView = WorkspaceView(windowController: self, workspace: workspace)
+        let workspaceView = WorkspaceView(workspace: workspace)
+            .environment(\.window, window!)
         let mainContent = NSSplitViewItem(
             viewController: NSHostingController(rootView: workspaceView)
         )
         mainContent.titlebarSeparatorStyle = .line
         splitVC.addSplitViewItem(mainContent)
 
-        let inspectorView = InspectorSidebarView(workspace: workspace, windowController: self)
+        let inspectorView = InspectorSidebarView(workspace: workspace)
         let inspector = NSSplitViewItem(
             viewController: NSHostingController(rootView: inspectorView)
         )

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -77,8 +77,10 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         navigator.collapseBehavior = .useConstraints
         splitVC.addSplitViewItem(navigator)
 
-        let workspaceView = WorkspaceView(workspace: workspace)
-            .environment(\.window, window!)
+        let workspaceView = WindowObserver(window: window!) {
+            WorkspaceView(workspace: workspace)
+        }
+
         let mainContent = NSSplitViewItem(
             viewController: NSHostingController(rootView: workspaceView)
         )

--- a/CodeEdit/Features/Documents/Views/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Features/Documents/Views/WorkspaceCodeFileView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct WorkspaceCodeFileView: View {
-    var windowController: NSWindowController
-
     @ObservedObject
     var workspace: WorkspaceDocument
 

--- a/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
+++ b/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
@@ -12,14 +12,11 @@ struct InspectorSidebarView: View {
     @ObservedObject
     private var workspace: WorkspaceDocument
 
-    private let windowController: NSWindowController
-
     @State
     private var selection: Int = 0
 
-    init(workspace: WorkspaceDocument, windowController: NSWindowController) {
+    init(workspace: WorkspaceDocument) {
         self.workspace = workspace
-        self.windowController = windowController
     }
 
     var body: some View {

--- a/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarView.swift
+++ b/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarView.swift
@@ -11,23 +11,20 @@ struct NavigatorSidebarView: View {
     @ObservedObject
     private var workspace: WorkspaceDocument
 
-    private let windowController: NSWindowController
-
     @State
     private var selection: Int = 0
 
     private let toolbarPadding: Double = -8.0
 
-    init(workspace: WorkspaceDocument, windowController: NSWindowController) {
+    init(workspace: WorkspaceDocument) {
         self.workspace = workspace
-        self.windowController = windowController
     }
 
     var body: some View {
         VStack {
             switch selection {
             case 0:
-                ProjectNavigatorView(workspace: workspace, windowController: windowController)
+                ProjectNavigatorView(workspace: workspace)
             case 1:
                 SourceControlNavigatorView(workspace: workspace)
             case 2:

--- a/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/ProjectNavigatorView.swift
+++ b/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/ProjectNavigatorView.swift
@@ -16,7 +16,6 @@ import SwiftUI
 ///
 struct ProjectNavigatorView: View {
     @ObservedObject var workspace: WorkspaceDocument
-    var windowController: NSWindowController
 
     var body: some View {
         OutlineView(workspace: workspace)

--- a/CodeEdit/Features/TabBar/Views/TabBarItemView.swift
+++ b/CodeEdit/Features/TabBar/Views/TabBarItemView.swift
@@ -76,9 +76,6 @@ struct TabBarItemView: View {
     /// You can get tab-related information from here, like `label`, `icon`, etc.
     private var item: TabBarItemRepresentable
 
-    /// AppKit window controller.
-    private var windowController: NSWindowController
-
     private var isTemporary: Bool
 
     /// Is the current tab the active tab.
@@ -121,14 +118,12 @@ struct TabBarItemView: View {
     init(
         expectedWidth: Binding<CGFloat>,
         item: TabBarItemRepresentable,
-        windowController: NSWindowController,
         draggingTabId: Binding<TabBarItemID?>,
         onDragTabId: Binding<TabBarItemID?>,
         workspace: WorkspaceDocument
     ) {
         self._expectedWidth = expectedWidth
         self.item = item
-        self.windowController = windowController
         self._draggingTabId = draggingTabId
         self._onDragTabId = onDragTabId
         self.workspace = workspace

--- a/CodeEdit/Features/TabBar/Views/TabBarView.swift
+++ b/CodeEdit/Features/TabBar/Views/TabBarView.swift
@@ -31,9 +31,6 @@ struct TabBarView: View {
     @StateObject
     private var prefs: AppPreferencesModel = .shared
 
-    /// The controller of current NSWindow.
-    private let windowController: NSWindowController
-
     /// The tab id of current dragging tab.
     ///
     /// It will be `nil` when there is no tab dragged currently.
@@ -117,9 +114,8 @@ struct TabBarView: View {
     @State
     private var onDragLastLocation: CGPoint?
 
-    // TabBar(windowController: windowController, workspace: workspace)
-    init(windowController: NSWindowController, workspace: WorkspaceDocument) {
-        self.windowController = windowController
+    // TabBar(workspace: workspace)
+    init(workspace: WorkspaceDocument) {
         self.workspace = workspace
     }
 
@@ -302,7 +298,6 @@ struct TabBarView: View {
                                     TabBarItemView(
                                         expectedWidth: $expectedTabWidth,
                                         item: item,
-                                        windowController: windowController,
                                         draggingTabId: $draggingTabId,
                                         onDragTabId: $onDragTabId,
                                         workspace: workspace

--- a/CodeEdit/Utils/Environment/IsFullscreen.swift
+++ b/CodeEdit/Utils/Environment/IsFullscreen.swift
@@ -1,0 +1,19 @@
+//
+//  IsFullscreen.swift
+//  CodeEdit
+//
+//  Created by Wouter Hennen on 14/01/2023.
+//
+
+import SwiftUI
+
+private struct WorkspaceFullscreenStateEnvironmentKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
+extension EnvironmentValues {
+    var isFullscreen: Bool {
+        get { self[WorkspaceFullscreenStateEnvironmentKey.self] }
+        set { self[WorkspaceFullscreenStateEnvironmentKey.self] = newValue }
+    }
+}

--- a/CodeEdit/Utils/Environment/Window.swift
+++ b/CodeEdit/Utils/Environment/Window.swift
@@ -1,0 +1,19 @@
+//
+//  Window.swift
+//  CodeEdit
+//
+//  Created by Wouter Hennen on 14/01/2023.
+//
+
+import SwiftUI
+
+struct NSWindowEnvironmentKey: EnvironmentKey {
+    static var defaultValue = NSWindow()
+}
+
+extension EnvironmentValues {
+    var window: NSWindowEnvironmentKey.Value {
+        get { self[NSWindowEnvironmentKey.self] }
+        set { self[NSWindowEnvironmentKey.self] = newValue }
+    }
+}

--- a/CodeEdit/WindowObserver.swift
+++ b/CodeEdit/WindowObserver.swift
@@ -1,0 +1,48 @@
+//
+//  WindowObserver.swift
+//  CodeEdit
+//
+//  Created by Wouter Hennen on 14/01/2023.
+//
+
+import SwiftUI
+
+struct WindowObserver<Content: View>: View {
+
+    var window: NSWindow
+
+    @ViewBuilder
+    var content: Content
+
+    /// The fullscreen state of the NSWindow.
+    /// This will be passed into all child views as an environment variable.
+    @State
+    private var isFullscreen = false
+
+    @StateObject
+    private var prefs: AppPreferencesModel = .shared
+
+    var body: some View {
+        content
+            .environment(\.window, window)
+            .environment(\.isFullscreen, isFullscreen)
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didEnterFullScreenNotification)) { _ in
+                self.isFullscreen = true
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.willExitFullScreenNotification)) { _ in
+                self.isFullscreen = false
+            }
+            // When tab bar style is changed, update NSWindow configuration as follows.
+            .onChange(of: prefs.preferences.general.tabBarStyle) { newStyle in
+                DispatchQueue.main.async {
+                    if newStyle == .native {
+                        window.titlebarAppearsTransparent = true
+                        window.titlebarSeparatorStyle = .none
+                    } else {
+                        window.titlebarAppearsTransparent = false
+                        window.titlebarSeparatorStyle = .automatic
+                    }
+                }
+            }
+    }
+}

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -9,12 +9,10 @@ import SwiftUI
 import AppKit
 
 struct WorkspaceView: View {
-    init(windowController: NSWindowController, workspace: WorkspaceDocument) {
-        self.windowController = windowController
+    init(workspace: WorkspaceDocument) {
         self.workspace = workspace
     }
 
-    let windowController: NSWindowController
     let tabBarHeight = 28.0
     private var path: String = ""
 
@@ -23,6 +21,9 @@ struct WorkspaceView: View {
 
     @StateObject
     private var prefs: AppPreferencesModel = .shared
+
+    @Environment(\.window)
+    private var window
 
     private var keybindings: KeybindingManager =  .shared
 
@@ -63,7 +64,7 @@ struct WorkspaceView: View {
         if let tabID = workspace.selectionState.selectedId {
             switch tabID {
             case .codeEditor:
-                WorkspaceCodeFileView(windowController: windowController, workspace: workspace)
+                WorkspaceCodeFileView(workspace: workspace)
             case .extensionInstallation:
                 if let plugin = workspace.selectionState.selected as? Plugin {
                     ExtensionInstallationView(plugin: plugin)
@@ -85,7 +86,7 @@ struct WorkspaceView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .safeAreaInset(edge: .top, spacing: 0) {
                     VStack(spacing: 0) {
-                        TabBarView(windowController: windowController, workspace: workspace)
+                        TabBarView(workspace: workspace)
                         TabBarBottomDivider()
                     }
                 }
@@ -105,7 +106,7 @@ struct WorkspaceView: View {
         }, message: { Text(alertMsg) })
         .onChange(of: workspace.selectionState.selectedId) { newValue in
             if newValue == nil {
-                windowController.window?.subtitle = ""
+                window.subtitle = ""
             }
         }
         .onAppear {
@@ -140,24 +141,13 @@ struct WorkspaceView: View {
         .onChange(of: prefs.preferences.general.tabBarStyle) { newStyle in
             DispatchQueue.main.async {
                 if newStyle == .native {
-                    windowController.window?.titlebarAppearsTransparent = true
-                    windowController.window?.titlebarSeparatorStyle = .none
+                    window.titlebarAppearsTransparent = true
+                    window.titlebarSeparatorStyle = .none
                 } else {
-                    windowController.window?.titlebarAppearsTransparent = false
-                    windowController.window?.titlebarSeparatorStyle = .automatic
+                    window.titlebarAppearsTransparent = false
+                    window.titlebarSeparatorStyle = .automatic
                 }
             }
         }
-    }
-}
-
-private struct WorkspaceFullscreenStateEnvironmentKey: EnvironmentKey {
-    static let defaultValue: Bool = false
-}
-
-extension EnvironmentValues {
-    var isFullscreen: Bool {
-        get { self[WorkspaceFullscreenStateEnvironmentKey.self] }
-        set { self[WorkspaceFullscreenStateEnvironmentKey.self] = newValue }
     }
 }

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -39,17 +39,6 @@ struct WorkspaceView: View {
     @State
     var showInspector = true
 
-    /// The fullscreen state of the NSWindow.
-    /// This will be passed into all child views as an environment variable.
-    @State
-    var isFullscreen = false
-
-    @State
-    private var enterFullscreenObserver: Any?
-
-    @State
-    private var leaveFullscreenObserver: Any?
-
     @Environment(\.colorScheme) var colorScheme
 
     var noEditor: some View {
@@ -107,46 +96,6 @@ struct WorkspaceView: View {
         .onChange(of: workspace.selectionState.selectedId) { newValue in
             if newValue == nil {
                 window.subtitle = ""
-            }
-        }
-        .onAppear {
-            // There may be other methods to monitor the full-screen state.
-            // But I cannot find a better one for now because I need to pass this into the SwiftUI.
-            // And it should always be updated.
-            enterFullscreenObserver = NotificationCenter.default.addObserver(
-                forName: NSWindow.didEnterFullScreenNotification,
-                object: nil,
-                queue: .current,
-                using: { _ in self.isFullscreen = true }
-            )
-            leaveFullscreenObserver = NotificationCenter.default.addObserver(
-                forName: NSWindow.willExitFullScreenNotification,
-                object: nil,
-                queue: .current,
-                using: { _ in self.isFullscreen = false }
-            )
-        }
-        .onDisappear {
-            // Unregister the observer when the view is going to disappear.
-            if enterFullscreenObserver != nil {
-                NotificationCenter.default.removeObserver(enterFullscreenObserver!)
-            }
-            if leaveFullscreenObserver != nil {
-                NotificationCenter.default.removeObserver(leaveFullscreenObserver!)
-            }
-        }
-        // Send the environment to all subviews.
-        .environment(\.isFullscreen, self.isFullscreen)
-        // When tab bar style is changed, update NSWindow configuration as follows.
-        .onChange(of: prefs.preferences.general.tabBarStyle) { newStyle in
-            DispatchQueue.main.async {
-                if newStyle == .native {
-                    window.titlebarAppearsTransparent = true
-                    window.titlebarSeparatorStyle = .none
-                } else {
-                    window.titlebarAppearsTransparent = false
-                    window.titlebarSeparatorStyle = .automatic
-                }
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Wouter01 <wouterhennen@gmail.com>

# Description

This removes various references to the windowController out of views, most were unused.
A `window` environment key was added for views requiring a reference to the window.

A `WindowObserver` view has been added and controls some window behaviors which were previously in `WorkspaceView`.

This should reduce the amount of dependencies some views require.

# Related Issue

#961 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
