### PR TITLE
[chore] Code Style: Multiline argument/parameter indentation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,6 +25,7 @@ opt_in_rules:
   - modifier_order
   - convenience_type
   - pattern_matching_keywords
+  - multiline_parameters_brackets
 
 custom_rules:
   spaces_over_tabs:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,6 +26,7 @@ opt_in_rules:
   - convenience_type
   - pattern_matching_keywords
   - multiline_parameters_brackets
+  - multiline_arguments_brackets
 
 custom_rules:
   spaces_over_tabs:

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -25,7 +25,7 @@ final class CodeEditApplication: NSApplication {
 }
 
 @NSApplicationMain
-final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
+final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject { // swiftlint:disable:this type_body_length
     var updater: SoftwareUpdater = SoftwareUpdater()
 
     func applicationWillFinishLaunching(_ notification: Notification) {
@@ -44,9 +44,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
                    !projects.isEmpty {
                     projects.forEach { path in
                         let url = URL(fileURLWithPath: path)
-                        CodeEditDocumentController.shared.reopenDocument(for: url,
-                                                                        withContentsOf: url,
-                                                                        display: true) { document, _, _ in
+                        CodeEditDocumentController.shared.reopenDocument(
+                            for: url,
+                            withContentsOf: url,
+                            display: true
+                        ) { document, _, _ in
                             document?.windowControllers.first?.synchronizeWindowTitleWithDocumentName()
                         }
                     }
@@ -60,9 +62,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
                     let path = CommandLine.arguments[index+1]
                     let url = URL(fileURLWithPath: path)
 
-                    CodeEditDocumentController.shared.reopenDocument(for: url,
-                                                                    withContentsOf: url,
-                                                                    display: true) { document, _, _ in
+                    CodeEditDocumentController.shared.reopenDocument(
+                        for: url,
+                        withContentsOf: url,
+                        display: true
+                    ) { document, _, _ in
                         document?.windowControllers.first?.synchronizeWindowTitleWithDocumentName()
                     }
 
@@ -215,9 +219,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
                 CodeEditDocumentController.shared.reopenDocument(
                     for: fileURL,
                     withContentsOf: fileURL,
-                    display: true) { document, _, _ in
-                        document?.windowControllers.first?.synchronizeWindowTitleWithDocumentName()
-                    }
+                    display: true
+                ) { document, _, _ in
+                    document?.windowControllers.first?.synchronizeWindowTitleWithDocumentName()
+                }
             }
 
             defaults.removeObject(forKey: "openInCEFiles")
@@ -256,8 +261,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             Preferences.Pane(
                 identifier: Preferences.PaneIdentifier("Navigation"),
                 title: "Navigation",
-                toolbarIcon: NSImage(systemSymbolName: "arrow.triangle.turn.up.right.diamond",
-                                     accessibilityDescription: nil)!
+                toolbarIcon: NSImage(
+                    systemSymbolName: "arrow.triangle.turn.up.right.diamond",
+                    accessibilityDescription: nil
+                )!
             ) {
                 PreferencesPlaceholderView()
             },

--- a/CodeEdit/Features/About/Views/AboutView.swift
+++ b/CodeEdit/Features/About/Views/AboutView.swift
@@ -88,9 +88,10 @@ public struct AboutView: View {
     }
 
     public func showWindow(width: CGFloat, height: CGFloat) {
-        AboutViewWindowController(view: self,
-                                    size: NSSize(width: width,
-                                                 height: height))
+        AboutViewWindowController(
+            view: self,
+            size: NSSize(width: width, height: height)
+        )
         .showWindow(nil)
     }
 }

--- a/CodeEdit/Features/AppPreferences/Model/Accounts/AccountsPreferences.swift
+++ b/CodeEdit/Features/AppPreferences/Model/Accounts/AccountsPreferences.swift
@@ -20,8 +20,10 @@ extension AppPreferences {
         /// Explicit decoder init for setting default values when key is not present in `JSON`
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.sourceControlAccounts = try container.decodeIfPresent(GitAccounts.self,
-                                                                       forKey: .sourceControlAccounts) ?? .init()
+            self.sourceControlAccounts = try container.decodeIfPresent(
+                GitAccounts.self,
+                forKey: .sourceControlAccounts
+            ) ?? .init()
         }
     }
 

--- a/CodeEdit/Features/AppPreferences/Model/AppPreferences.swift
+++ b/CodeEdit/Features/AppPreferences/Model/AppPreferences.swift
@@ -54,8 +54,10 @@ struct AppPreferences: Codable {
         self.theme = try container.decodeIfPresent(ThemePreferences.self, forKey: .theme) ?? .init()
         self.terminal = try container.decodeIfPresent(TerminalPreferences.self, forKey: .terminal) ?? .init()
         self.textEditing = try container.decodeIfPresent(TextEditingPreferences.self, forKey: .textEditing) ?? .init()
-        self.sourceControl = try container.decodeIfPresent(SourceControlPreferences.self,
-                                                           forKey: .sourceControl) ?? .init()
+        self.sourceControl = try container.decodeIfPresent(
+            SourceControlPreferences.self,
+            forKey: .sourceControl
+        ) ?? .init()
         self.keybindings = try container.decodeIfPresent(KeybindingsPreferences.self, forKey: .keybindings) ?? .init()
     }
 }

--- a/CodeEdit/Features/AppPreferences/Model/Keybindings/KeybindingsPreferences.swift
+++ b/CodeEdit/Features/AppPreferences/Model/Keybindings/KeybindingsPreferences.swift
@@ -22,16 +22,20 @@ extension AppPreferences {
         /// Explicit decoder init for setting default values when key is not present in `JSON`
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.keybindings = try container.decodeIfPresent([String: KeyboardShortcutWrapper].self,
-                                                                       forKey: .keybindings) ?? .init()
+            self.keybindings = try container.decodeIfPresent(
+                [String: KeyboardShortcutWrapper].self,
+                forKey: .keybindings
+            ) ?? .init()
             appendNew()
 
             let mgr = CommandManager.shared
             let wrap = CommandClosureWrapper.init(closure: {
                 print("testing closure")
             })
-            mgr.addCommand(name: "Send test to console",
-                           title: "Send test to console", id: "codeedit.test", command: wrap)
+            mgr.addCommand(
+                name: "Send test to console",
+                title: "Send test to console", id: "codeedit.test", command: wrap
+            )
             mgr.executeCommand(name: "test")
         }
 

--- a/CodeEdit/Features/AppPreferences/Model/Source Control/SourceControlPreferences.swift
+++ b/CodeEdit/Features/AppPreferences/Model/Source Control/SourceControlPreferences.swift
@@ -54,21 +54,35 @@ extension AppPreferences {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.enableSourceControl = try container.decodeIfPresent(Bool.self, forKey: .enableSourceControl) ?? true
             self.refreshStatusLocaly = try container.decodeIfPresent(Bool.self, forKey: .refreshStatusLocaly) ?? true
-            self.fetchRefreshServerStatus = try container.decodeIfPresent(Bool.self,
-                                                                          forKey: .fetchRefreshServerStatus) ?? true
-            self.addRemoveAutomatically = try container.decodeIfPresent(Bool.self,
-                                                                        forKey: .addRemoveAutomatically) ?? true
+            self.fetchRefreshServerStatus = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .fetchRefreshServerStatus
+            ) ?? true
+            self.addRemoveAutomatically = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .addRemoveAutomatically
+            ) ?? true
             self.selectFilesToCommit = try container.decodeIfPresent(Bool.self, forKey: .selectFilesToCommit) ?? true
-            self.showSourceControlChanges = try container.decodeIfPresent(Bool.self,
-                                                                          forKey: .showSourceControlChanges) ?? true
-            self.includeUpstreamChanges = try container.decodeIfPresent(Bool.self,
-                                                                        forKey: .includeUpstreamChanges) ?? true
-            self.openFeedbackInBrowser = try container.decodeIfPresent(Bool.self,
-                                                                        forKey: .openFeedbackInBrowser) ?? true
-            self.revisionComparisonLayout = try container.decodeIfPresent(RevisionComparisonLayout.self,
-                                                                forKey: .revisionComparisonLayout) ?? .localLeft
-            self.controlNavigatorOrder = try container.decodeIfPresent(ControlNavigatorOrder.self,
-                                                                  forKey: .controlNavigatorOrder) ?? .sortByName
+            self.showSourceControlChanges = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .showSourceControlChanges
+            ) ?? true
+            self.includeUpstreamChanges = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .includeUpstreamChanges
+            ) ?? true
+            self.openFeedbackInBrowser = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .openFeedbackInBrowser
+            ) ?? true
+            self.revisionComparisonLayout = try container.decodeIfPresent(
+                RevisionComparisonLayout.self,
+                forKey: .revisionComparisonLayout
+            ) ?? .localLeft
+            self.controlNavigatorOrder = try container.decodeIfPresent(
+                ControlNavigatorOrder.self,
+                forKey: .controlNavigatorOrder
+            ) ?? .sortByName
             self.defaultBranchName = try container.decodeIfPresent(String.self, forKey: .defaultBranchName) ?? "main"
         }
     }
@@ -107,12 +121,18 @@ extension AppPreferences {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.authorName = try container.decodeIfPresent(String.self, forKey: .authorName) ?? ""
             self.authorEmail = try container.decodeIfPresent(String.self, forKey: .authorEmail) ?? ""
-            self.ignoredFiles = try container.decodeIfPresent([IgnoredFiles].self,
-                                                              forKey: .ignoredFiles) ?? []
-            self.preferRebaseWhenPulling = try container.decodeIfPresent(Bool.self,
-                                                                         forKey: .preferRebaseWhenPulling) ?? false
-            self.showMergeCommitsPerFileLog = try container.decodeIfPresent(Bool.self,
-                                                                        forKey: .showMergeCommitsPerFileLog) ?? false
+            self.ignoredFiles = try container.decodeIfPresent(
+                [IgnoredFiles].self,
+                forKey: .ignoredFiles
+            ) ?? []
+            self.preferRebaseWhenPulling = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .preferRebaseWhenPulling
+            ) ?? false
+            self.showMergeCommitsPerFileLog = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .showMergeCommitsPerFileLog
+            ) ?? false
         }
     }
 }

--- a/CodeEdit/Features/AppPreferences/Model/Text Editing/TextEditingPreferences.swift
+++ b/CodeEdit/Features/AppPreferences/Model/Text Editing/TextEditingPreferences.swift
@@ -41,13 +41,21 @@ extension AppPreferences {
             self.defaultTabWidth = try container.decodeIfPresent(Int.self, forKey: .defaultTabWidth) ?? 4
             self.font = try container.decodeIfPresent(EditorFont.self, forKey: .font) ?? .init()
             self.enableTypeOverCompletion = try container.decodeIfPresent(
-                Bool.self, forKey: .enableTypeOverCompletion) ?? true
-            self.autocompleteBraces = try container.decodeIfPresent(Bool.self,
-                                                                    forKey: .autocompleteBraces) ?? true
-            self.wrapLinesToEditorWidth = try container.decodeIfPresent(Bool.self,
-                                                                    forKey: .wrapLinesToEditorWidth) ?? true
-            self.lineHeightMultiple = try container.decodeIfPresent(Double.self,
-                                                                    forKey: .lineHeightMultiple) ?? 1.45
+                Bool.self,
+                forKey: .enableTypeOverCompletion
+            ) ?? true
+            self.autocompleteBraces = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .autocompleteBraces
+            ) ?? true
+            self.wrapLinesToEditorWidth = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .wrapLinesToEditorWidth
+            ) ?? true
+            self.lineHeightMultiple = try container.decodeIfPresent(
+                Double.self,
+                forKey: .lineHeightMultiple
+            ) ?? 1.45
 
             self.populateCommands()
         }
@@ -62,7 +70,8 @@ extension AppPreferences {
                 id: "prefs.text_editing.type_over_completion",
                 command: CommandClosureWrapper {
                     AppPreferencesModel.shared.preferences.textEditing.enableTypeOverCompletion.toggle()
-            })
+                }
+            )
 
             mgr.addCommand(
                 name: "Toggle Autocomplete Braces",
@@ -70,7 +79,8 @@ extension AppPreferences {
                 id: "prefs.text_editing.autocomplete_braces",
                 command: CommandClosureWrapper {
                     AppPreferencesModel.shared.preferences.textEditing.autocompleteBraces.toggle()
-            })
+                }
+            )
 
             mgr.addCommand(
                 name: "Toggle Word Wrap",
@@ -78,7 +88,8 @@ extension AppPreferences {
                 id: "prefs.text_editing.wrap_lines_to_editor_width",
                 command: CommandClosureWrapper {
                     AppPreferencesModel.shared.preferences.textEditing.wrapLinesToEditorWidth.toggle()
-            })
+                }
+            )
         }
     }
 

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/AccountPreferencesView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/AccountPreferencesView.swift
@@ -48,8 +48,10 @@ struct AccountPreferencesView: View {
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-            List($prefs.preferences.accounts.sourceControlAccounts.gitAccount,
-                 selection: $accountSelection) { gitAccount in
+            List(
+                $prefs.preferences.accounts.sourceControlAccounts.gitAccount,
+                selection: $accountSelection
+            ) { gitAccount in
                 GitAccountItemView(sourceControlAccount: gitAccount)
             }
                  .background(

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubEnterpriseLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubEnterpriseLoginView.swift
@@ -39,8 +39,10 @@ struct GitHubEnterpriseLoginView: View {
                 }
                 HStack {
                     Text("Token:")
-                    SecureField("Enter your Personal Access Token",
-                                text: $accountToken)
+                    SecureField(
+                        "Enter your Personal Access Token",
+                        text: $accountToken
+                    )
                     .frame(width: 300)
                 }
             }
@@ -76,8 +78,10 @@ struct GitHubEnterpriseLoginView: View {
     private func loginGitHubEnterprise(gitAccountName: String) {
         let gitAccounts = prefs.preferences.accounts.sourceControlAccounts.gitAccount
 
-        let config = GitHubTokenConfiguration(accountToken,
-                                              url: eneterpriseLink )
+        let config = GitHubTokenConfiguration(
+            accountToken,
+            url: eneterpriseLink
+        )
         GitHubAccount(config).me { response in
             switch response {
             case .success(let user):
@@ -86,14 +90,17 @@ struct GitHubEnterpriseLoginView: View {
                 } else {
                     print(user)
                     prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
-                        SourceControlAccounts(id: gitAccountName.lowercased(),
-                                              gitProvider: "GitHub",
-                                              gitProviderLink: eneterpriseLink,
-                                              gitProviderDescription: "GitHub",
-                                              gitAccountName: gitAccountName,
-                                              gitCloningProtocol: true,
-                                              gitSSHKey: "",
-                                              isTokenValid: true))
+                        SourceControlAccounts(
+                            id: gitAccountName.lowercased(),
+                            gitProvider: "GitHub",
+                            gitProviderLink: eneterpriseLink,
+                            gitProviderDescription: "GitHub",
+                            gitAccountName: gitAccountName,
+                            gitCloningProtocol: true,
+                            gitSSHKey: "",
+                            isTokenValid: true
+                        )
+                    )
                     keychain.set(accountToken, forKey: "github_\(accountName)_enterprise")
                     dismissDialog = false
                 }

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubLoginView.swift
@@ -33,8 +33,10 @@ struct GitHubLoginView: View {
                 }
                 HStack {
                     Text("Token:")
-                    SecureField("Enter your Personal Access Token",
-                                text: $accountToken)
+                    SecureField(
+                        "Enter your Personal Access Token",
+                        text: $accountToken
+                    )
                     .frame(width: 300)
                 }
             }
@@ -111,14 +113,17 @@ struct GitHubLoginView: View {
                 } else {
                     print(user)
                     prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
-                        SourceControlAccounts(id: gitAccountName.lowercased(),
-                                              gitProvider: "GitHub",
-                                              gitProviderLink: "https://github.com",
-                                              gitProviderDescription: "GitHub",
-                                              gitAccountName: gitAccountName,
-                                              gitCloningProtocol: true,
-                                              gitSSHKey: "",
-                                              isTokenValid: true))
+                        SourceControlAccounts(
+                            id: gitAccountName.lowercased(),
+                            gitProvider: "GitHub",
+                            gitProviderLink: "https://github.com",
+                            gitProviderDescription: "GitHub",
+                            gitAccountName: gitAccountName,
+                            gitCloningProtocol: true,
+                            gitSSHKey: "",
+                            isTokenValid: true
+                        )
+                    )
                     keychain.set(accountToken, forKey: "github_\(accountName)")
                     dismissDialog.toggle()
                 }

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabHostedLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabHostedLoginView.swift
@@ -38,8 +38,10 @@ struct GitLabHostedLoginView: View {
                 }
                 HStack {
                     Text("Token:")
-                    SecureField("Enter your Personal Access Token",
-                                text: $accountToken)
+                    SecureField(
+                        "Enter your Personal Access Token",
+                        text: $accountToken
+                    )
                     .frame(width: 300)
                 }
             }
@@ -75,8 +77,7 @@ struct GitLabHostedLoginView: View {
     private func loginGitLabSelfHosted(gitAccountName: String) {
         let gitAccounts = prefs.preferences.accounts.sourceControlAccounts.gitAccount
 
-        let config = GitLabTokenConfiguration(accountToken,
-                                              url: eneterpriseLink )
+        let config = GitLabTokenConfiguration(accountToken, url: eneterpriseLink)
         GitLabAccount(config).me { response in
             switch response {
             case .success(let user):
@@ -85,14 +86,17 @@ struct GitLabHostedLoginView: View {
                 } else {
                     print(user)
                     prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
-                        SourceControlAccounts(id: gitAccountName.lowercased(),
-                                              gitProvider: "GitLab",
-                                              gitProviderLink: eneterpriseLink,
-                                              gitProviderDescription: "GitLab",
-                                              gitAccountName: gitAccountName,
-                                              gitCloningProtocol: true,
-                                              gitSSHKey: "",
-                                              isTokenValid: true))
+                        SourceControlAccounts(
+                            id: gitAccountName.lowercased(),
+                            gitProvider: "GitLab",
+                            gitProviderLink: eneterpriseLink,
+                            gitProviderDescription: "GitLab",
+                            gitAccountName: gitAccountName,
+                            gitCloningProtocol: true,
+                            gitSSHKey: "",
+                            isTokenValid: true
+                        )
+                    )
                     keychain.set(accountToken, forKey: "gitlab_\(gitAccountName)_hosted")
                     dismissDialog = false
                 }

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabLoginView.swift
@@ -33,8 +33,10 @@ struct GitLabLoginView: View {
                 }
                 HStack {
                     Text("Token:")
-                    SecureField("Enter your Personal Access Token",
-                                text: $accountToken)
+                    SecureField(
+                        "Enter your Personal Access Token",
+                        text: $accountToken
+                    )
                     .frame(width: 300)
                 }
             }
@@ -79,14 +81,17 @@ struct GitLabLoginView: View {
                 } else {
                     print(user)
                     prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
-                        SourceControlAccounts(id: gitAccountName.lowercased(),
-                                              gitProvider: "GitLab",
-                                              gitProviderLink: "https://gitlab.com",
-                                              gitProviderDescription: "GitLab",
-                                              gitAccountName: gitAccountName,
-                                              gitCloningProtocol: true,
-                                              gitSSHKey: "",
-                                              isTokenValid: true))
+                        SourceControlAccounts(
+                            id: gitAccountName.lowercased(),
+                            gitProvider: "GitLab",
+                            gitProviderLink: "https://gitlab.com",
+                            gitProviderDescription: "GitLab",
+                            gitAccountName: gitAccountName,
+                            gitCloningProtocol: true,
+                            gitSSHKey: "",
+                            isTokenValid: true
+                        )
+                    )
                     keychain.set(accountToken, forKey: "gitlab_\(accountName)")
                     dismissDialog = false
                 }

--- a/CodeEdit/Features/AppPreferences/Sections/GeneralPreferences/GeneralPreferencesView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/GeneralPreferences/GeneralPreferencesView.swift
@@ -293,8 +293,10 @@ private extension GeneralPreferencesView {
 
     var autoSaveSection: some View {
         PreferencesSection("Auto Save Behavior", hideLabels: false) {
-            Toggle("Automatically save changes to disk",
-                   isOn: $prefs.preferences.general.isAutoSaveOn)
+            Toggle(
+                "Automatically save changes to disk",
+                isOn: $prefs.preferences.general.isAutoSaveOn
+            )
             .toggleStyle(.checkbox)
         }
     }

--- a/CodeEdit/Features/AppPreferences/Sections/SourceControlPreferences/SourceControlGeneralView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/SourceControlPreferences/SourceControlGeneralView.swift
@@ -27,42 +27,58 @@ struct SourceControlGeneralView: View {
                     .toggleStyle(.checkbox)
 
                 VStack(alignment: .leading) {
-                    Toggle("Refresh local status automatically",
-                           isOn: $prefs.preferences.sourceControl.general.refreshStatusLocaly)
-                        .toggleStyle(.checkbox)
-                    Toggle("Fetch and refresh server status automatically",
-                           isOn: $prefs.preferences.sourceControl.general.fetchRefreshServerStatus)
-                        .toggleStyle(.checkbox)
-                    Toggle("Add and remove files automatically",
-                           isOn: $prefs.preferences.sourceControl.general.addRemoveAutomatically)
-                        .toggleStyle(.checkbox)
-                    Toggle("Select files to commit automatically",
-                           isOn: $prefs.preferences.sourceControl.general.selectFilesToCommit)
-                        .toggleStyle(.checkbox)
+                    Toggle(
+                        "Refresh local status automatically",
+                        isOn: $prefs.preferences.sourceControl.general.refreshStatusLocaly
+                    )
+                    .toggleStyle(.checkbox)
+                    Toggle(
+                        "Fetch and refresh server status automatically",
+                        isOn: $prefs.preferences.sourceControl.general.fetchRefreshServerStatus
+                    )
+                    .toggleStyle(.checkbox)
+                    Toggle(
+                        "Add and remove files automatically",
+                        isOn: $prefs.preferences.sourceControl.general.addRemoveAutomatically
+                    )
+                    .toggleStyle(.checkbox)
+                    Toggle(
+                        "Select files to commit automatically",
+                        isOn: $prefs.preferences.sourceControl.general.selectFilesToCommit
+                    )
+                    .toggleStyle(.checkbox)
                 }
                 .padding(.leading, 20)
             }
 
             PreferencesSection("Text Editing", hideLabels: false) {
-                Toggle("Show Source Control changes",
-                       isOn: $prefs.preferences.sourceControl.general.showSourceControlChanges)
-                    .toggleStyle(.checkbox)
+                Toggle(
+                    "Show Source Control changes",
+                    isOn: $prefs.preferences.sourceControl.general.showSourceControlChanges
+                )
+                .toggleStyle(.checkbox)
 
-                Toggle("Include upstream changes",
-                       isOn: $prefs.preferences.sourceControl.general.includeUpstreamChanges)
-                    .toggleStyle(.checkbox)
-                    .padding(.leading, 20)
+                Toggle(
+                    "Include upstream changes",
+                    isOn: $prefs.preferences.sourceControl.general.includeUpstreamChanges
+                )
+                .toggleStyle(.checkbox)
+                .padding(.leading, 20)
             }
 
             PreferencesSection("Reporting", hideLabels: false) {
-                Toggle("Open created issue in the browser",
-                       isOn: $prefs.preferences.sourceControl.general.openFeedbackInBrowser)
-                    .toggleStyle(.checkbox)
+                Toggle(
+                    "Open created issue in the browser",
+                    isOn: $prefs.preferences.sourceControl.general.openFeedbackInBrowser
+                )
+                .toggleStyle(.checkbox)
             }
 
             PreferencesSection("Comparison View", hideLabels: true) {
-                Picker("Comparison View",
-                       selection: $prefs.preferences.sourceControl.general.revisionComparisonLayout) {
+                Picker(
+                    "Comparison View",
+                    selection: $prefs.preferences.sourceControl.general.revisionComparisonLayout
+                ) {
                     Text("Local Revision on Left Side")
                         .tag(AppPreferences.RevisionComparisonLayout.localLeft)
                     Text("Local Revision on Right Side")
@@ -72,8 +88,10 @@ struct SourceControlGeneralView: View {
             }
 
             PreferencesSection("Source Control Navigator", hideLabels: true) {
-                Picker("Source Control Navigator",
-                       selection: $prefs.preferences.sourceControl.general.controlNavigatorOrder) {
+                Picker(
+                    "Source Control Navigator",
+                    selection: $prefs.preferences.sourceControl.general.controlNavigatorOrder
+                ) {
                     Text("Sort by Name")
                         .tag(AppPreferences.ControlNavigatorOrder.sortByName)
                     Text("Sort by Date")

--- a/CodeEdit/Features/AppPreferences/Sections/SourceControlPreferences/SourceControlGitView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/SourceControlPreferences/SourceControlGitView.swift
@@ -30,8 +30,10 @@ struct SourceControlGitView: View {
 
             PreferencesSection("Ignored Files", hideLabels: false, align: .top) {
                 VStack(spacing: 1) {
-                    List($prefs.preferences.sourceControl.git.ignoredFiles,
-                         selection: $ignoredFileSelection) { ignoredFile in
+                    List(
+                        $prefs.preferences.sourceControl.git.ignoredFiles,
+                        selection: $ignoredFileSelection
+                    ) { ignoredFile in
                         IgnoredFileView(ignoredFile: ignoredFile)
                     }
                     .overlay(Group {
@@ -52,14 +54,18 @@ struct SourceControlGitView: View {
             }
 
             PreferencesSection("Options", hideLabels: false) {
-                Toggle("Prefer to rebase when pulling",
-                       isOn: $prefs.preferences.sourceControl.git.preferRebaseWhenPulling)
-                    .toggleStyle(.checkbox)
-                    .frame(width: inputWidth, alignment: .leading)
-                Toggle("Show merge commits in per-file log",
-                       isOn: $prefs.preferences.sourceControl.git.showMergeCommitsPerFileLog)
-                    .toggleStyle(.checkbox)
-                    .frame(width: inputWidth, alignment: .leading)
+                Toggle(
+                    "Prefer to rebase when pulling",
+                    isOn: $prefs.preferences.sourceControl.git.preferRebaseWhenPulling
+                )
+                .toggleStyle(.checkbox)
+                .frame(width: inputWidth, alignment: .leading)
+                Toggle(
+                    "Show merge commits in per-file log",
+                    isOn: $prefs.preferences.sourceControl.git.showMergeCommitsPerFileLog
+                )
+                .toggleStyle(.checkbox)
+                .frame(width: inputWidth, alignment: .leading)
             }
         }
         .frame(height: 350)

--- a/CodeEdit/Features/AppPreferences/Sections/TextEditingPreferences/TextEditingPreferencesView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/TextEditingPreferences/TextEditingPreferencesView.swift
@@ -42,9 +42,11 @@ struct TextEditingPreferencesView: View {
                     TextField("", value: $prefs.preferences.textEditing.defaultTabWidth, formatter: tabWidthFormatter)
                         .multilineTextAlignment(.trailing)
                         .frame(width: 40)
-                    Stepper("Default Tab Width:",
-                            value: $prefs.preferences.textEditing.defaultTabWidth,
-                            in: 1...8)
+                    Stepper(
+                        "Default Tab Width:",
+                        value: $prefs.preferences.textEditing.defaultTabWidth,
+                        in: 1...8
+                    )
                     Text("spaces")
                 }
             }
@@ -107,10 +109,12 @@ struct TextEditingPreferencesView: View {
             TextField("", value: $prefs.preferences.textEditing.lineHeightMultiple, formatter: lineHeightFormatter)
                 .multilineTextAlignment(.trailing)
                 .frame(width: 40)
-            Stepper("Line Height:",
-                    value: $prefs.preferences.textEditing.lineHeightMultiple,
-                    in: 0.75...2.0,
-                    step: 0.05)
+            Stepper(
+                "Line Height:",
+                value: $prefs.preferences.textEditing.lineHeightMultiple,
+                in: 0.75...2.0,
+                step: 0.05
+            )
         }
     }
 }

--- a/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/EditorThemeView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/EditorThemeView.swift
@@ -24,21 +24,33 @@ struct EditorThemeView: View {
                         .padding(.bottom, 20)
                     HStack(spacing: 0) {
                         VStack(alignment: .leading, spacing: 10) {
-                            PreferencesColorPicker($themeModel.themes[index].editor.text.swiftColor,
-                                                   label: "Text")
-                            PreferencesColorPicker($themeModel.themes[index].editor.insertionPoint.swiftColor,
-                                                   label: "Cursor")
-                            PreferencesColorPicker($themeModel.themes[index].editor.invisibles.swiftColor,
-                                                   label: "Invisibles")
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.text.swiftColor,
+                                label: "Text"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.insertionPoint.swiftColor,
+                                label: "Cursor"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.invisibles.swiftColor,
+                                label: "Invisibles"
+                            )
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                         VStack(alignment: .leading, spacing: 10) {
-                            PreferencesColorPicker($themeModel.themes[index].editor.background.swiftColor,
-                                                   label: "Background")
-                            PreferencesColorPicker($themeModel.themes[index].editor.lineHighlight.swiftColor,
-                                                   label: "Current Line")
-                            PreferencesColorPicker($themeModel.themes[index].editor.selection.swiftColor,
-                                                   label: "Selection")
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.background.swiftColor,
+                                label: "Background"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.lineHighlight.swiftColor,
+                                label: "Current Line"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.selection.swiftColor,
+                                label: "Selection"
+                            )
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
@@ -49,29 +61,49 @@ struct EditorThemeView: View {
                         .padding(.bottom, 10)
                     HStack(spacing: 0) {
                         VStack(alignment: .leading, spacing: 10) {
-                            PreferencesColorPicker($themeModel.themes[index].editor.keywords.swiftColor,
-                                                   label: "Keywords")
-                            PreferencesColorPicker($themeModel.themes[index].editor.commands.swiftColor,
-                                                   label: "Commands")
-                            PreferencesColorPicker($themeModel.themes[index].editor.types.swiftColor,
-                                                   label: "Types")
-                            PreferencesColorPicker($themeModel.themes[index].editor.attributes.swiftColor,
-                                                   label: "Attributes")
-                            PreferencesColorPicker($themeModel.themes[index].editor.variables.swiftColor,
-                                                   label: "Variables")
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.keywords.swiftColor,
+                                label: "Keywords"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.commands.swiftColor,
+                                label: "Commands"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.types.swiftColor,
+                                label: "Types"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.attributes.swiftColor,
+                                label: "Attributes"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.variables.swiftColor,
+                                label: "Variables"
+                            )
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                         VStack(alignment: .leading, spacing: 10) {
-                            PreferencesColorPicker($themeModel.themes[index].editor.values.swiftColor,
-                                                   label: "Values")
-                            PreferencesColorPicker($themeModel.themes[index].editor.numbers.swiftColor,
-                                                   label: "Numbers")
-                            PreferencesColorPicker($themeModel.themes[index].editor.strings.swiftColor,
-                                                   label: "Strings")
-                            PreferencesColorPicker($themeModel.themes[index].editor.characters.swiftColor,
-                                                   label: "Characters")
-                            PreferencesColorPicker($themeModel.themes[index].editor.comments.swiftColor,
-                                                   label: "Comments")
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.values.swiftColor,
+                                label: "Values"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.numbers.swiftColor,
+                                label: "Numbers"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.strings.swiftColor,
+                                label: "Strings"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.characters.swiftColor,
+                                label: "Characters"
+                            )
+                            PreferencesColorPicker(
+                                $themeModel.themes[index].editor.comments.swiftColor,
+                                label: "Comments"
+                            )
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }

--- a/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/Model/Theme.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/Model/Theme.swift
@@ -137,22 +137,24 @@ extension Theme {
 
         var editorTheme: EditorTheme {
             get {
-                .init(text: text.nsColor,
-                      insertionPoint: insertionPoint.nsColor,
-                      invisibles: invisibles.nsColor,
-                      background: background.nsColor,
-                      lineHighlight: lineHighlight.nsColor,
-                      selection: selection.nsColor,
-                      keywords: keywords.nsColor,
-                      commands: commands.nsColor,
-                      types: types.nsColor,
-                      attributes: attributes.nsColor,
-                      variables: variables.nsColor,
-                      values: values.nsColor,
-                      numbers: numbers.nsColor,
-                      strings: strings.nsColor,
-                      characters: characters.nsColor,
-                      comments: comments.nsColor)
+                .init(
+                    text: text.nsColor,
+                    insertionPoint: insertionPoint.nsColor,
+                    invisibles: invisibles.nsColor,
+                    background: background.nsColor,
+                    lineHighlight: lineHighlight.nsColor,
+                    selection: selection.nsColor,
+                    keywords: keywords.nsColor,
+                    commands: commands.nsColor,
+                    types: types.nsColor,
+                    attributes: attributes.nsColor,
+                    variables: variables.nsColor,
+                    values: values.nsColor,
+                    numbers: numbers.nsColor,
+                    strings: strings.nsColor,
+                    characters: characters.nsColor,
+                    comments: comments.nsColor
+                )
             }
             set {
                 self.text.nsColor = newValue.text

--- a/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/Model/ThemeModel.swift
@@ -222,8 +222,10 @@ final class ThemeModel: ObservableObject {
             }
             let json = try Data(contentsOf: defaultUrl)
             let jsonObject = try JSONSerialization.jsonObject(with: json)
-            let prettyJSON = try JSONSerialization.data(withJSONObject: jsonObject,
-                                                        options: .prettyPrinted)
+            let prettyJSON = try JSONSerialization.data(
+                withJSONObject: jsonObject,
+                options: .prettyPrinted
+            )
 
             try prettyJSON.write(to: themesURL.appendingPathComponent("\(themeName).json"), options: .atomic)
         }

--- a/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/TerminalThemeView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/TerminalThemeView.swift
@@ -48,19 +48,29 @@ struct TerminalThemeView: View {
                 if let selectedTheme = themeModel.selectedTheme,
                    let index = themeModel.themes.firstIndex(of: selectedTheme) {
                     VStack(alignment: .leading, spacing: 10) {
-                        PreferencesColorPicker($themeModel.themes[index].terminal.text.swiftColor,
-                                               label: "Text")
-                        PreferencesColorPicker($themeModel.themes[index].terminal.boldText.swiftColor,
-                                               label: "Bold Text")
-                        PreferencesColorPicker($themeModel.themes[index].terminal.cursor.swiftColor,
-                                               label: "Cursor")
+                        PreferencesColorPicker(
+                            $themeModel.themes[index].terminal.text.swiftColor,
+                            label: "Text"
+                        )
+                        PreferencesColorPicker(
+                            $themeModel.themes[index].terminal.boldText.swiftColor,
+                            label: "Bold Text"
+                        )
+                        PreferencesColorPicker(
+                            $themeModel.themes[index].terminal.cursor.swiftColor,
+                            label: "Cursor"
+                        )
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     VStack(alignment: .leading, spacing: 10) {
-                        PreferencesColorPicker($themeModel.themes[index].terminal.background.swiftColor,
-                                               label: "Background")
-                        PreferencesColorPicker($themeModel.themes[index].terminal.selection.swiftColor,
-                                               label: "Selection")
+                        PreferencesColorPicker(
+                            $themeModel.themes[index].terminal.background.swiftColor,
+                            label: "Background"
+                        )
+                        PreferencesColorPicker(
+                            $themeModel.themes[index].terminal.selection.swiftColor,
+                            label: "Selection"
+                        )
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/ThemePreferencesView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/ThemePreferencesView.swift
@@ -119,9 +119,7 @@ struct ThemePreferencesView: View {
                 repeating: .init(.fixed(130), spacing: 20, alignment: .center),
                 count: 2
             )
-            LazyVGrid(columns: grid,
-                      alignment: .center,
-                      spacing: 20) {
+            LazyVGrid(columns: grid, alignment: .center, spacing: 20) {
                 ForEach(themeModel.selectedAppearance == 0 ? themeModel.darkThemes : themeModel.lightThemes) { theme in
                     ThemePreviewIcon(
                         theme,

--- a/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsComponent.swift
+++ b/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsComponent.swift
@@ -91,9 +91,11 @@ struct BreadcrumbsComponent: View {
                 if let position = position,
                    let windowHeight = NSApp.keyWindow?.contentView?.frame.height {
                     let pos = NSPoint(x: position.x, y: windowHeight - 72) // 72 = offset from top to breadcrumbs bar
-                    menu.popUp(positioning: menu.item(withTitle: fileItem.fileName),
-                               at: pos,
-                               in: NSApp.keyWindow?.contentView)
+                    menu.popUp(
+                        positioning: menu.item(withTitle: fileItem.fileName),
+                        at: pos,
+                        in: NSApp.keyWindow?.contentView
+                    )
                 }
             }
         }

--- a/CodeEdit/Features/CodeEditExtension/ExtensionManager.swift
+++ b/CodeEdit/Features/CodeEditExtension/ExtensionManager.swift
@@ -38,9 +38,11 @@ final class ExtensionManager {
 
         do {
             try FileManager.default
-                .createDirectory(at: self.extensionsFolder,
-                                 withIntermediateDirectories: true,
-                                 attributes: nil)
+                .createDirectory(
+                    at: self.extensionsFolder,
+                    withIntermediateDirectories: true,
+                    attributes: nil
+                )
         } catch {
             fatalError("Error while initializing the ExtensionManager, line: 36")
         }

--- a/CodeEdit/Features/CodeEditUI/Views/OverlayPanel.swift
+++ b/CodeEdit/Features/CodeEditUI/Views/OverlayPanel.swift
@@ -12,7 +12,8 @@ final class OverlayPanel: NSPanel, NSWindowDelegate {
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 48),
             styleMask: [.fullSizeContentView, .titled, .resizable],
-            backing: .buffered, defer: false)
+            backing: .buffered, defer: false
+        )
         self.delegate = self
         self.center()
         self.titlebarAppearsTransparent = true

--- a/CodeEdit/Features/Commands/Views/CommandPaletteView.swift
+++ b/CodeEdit/Features/Commands/Views/CommandPaletteView.swift
@@ -140,13 +140,15 @@ struct CommandPaletteView: View {
                         .frame(width: 16, height: 16)
                         .padding(.leading, 20)
                         .offset(x: 0, y: 1)
-                    ActionAwareInput(text: $state.commandQuery, onDown: onKeyDown,
-                                     onTextChange: onQueryChange)
-                        .font(.system(size: 24, weight: .light, design: .default))
-                        .padding(16)
-                        .frame(height: 52, alignment: .center)
-                        .foregroundColor(Color(.systemGray).opacity(0.85))
-                        .background(EffectView(.sidebar, blendingMode: .behindWindow))
+                    ActionAwareInput(
+                        text: $state.commandQuery, onDown: onKeyDown,
+                        onTextChange: onQueryChange
+                    )
+                    .font(.system(size: 24, weight: .light, design: .default))
+                    .padding(16)
+                    .frame(height: 52, alignment: .center)
+                    .foregroundColor(Color(.systemGray).opacity(0.85))
+                    .background(EffectView(.sidebar, blendingMode: .behindWindow))
                 }
 
             Divider()
@@ -155,31 +157,38 @@ struct CommandPaletteView: View {
                     // swiftlint:disable multiple_closures_with_trailing_closure
                     Button(action: { onCommandClick(command: command) }) {
                         VStack {
-                            SearchResultLabel(labelName: command.title,
-                                              textToMatch: state.commandQuery,
-                                              fontColor: textColor(command: command))
+                            SearchResultLabel(
+                                labelName: command.title,
+                                textToMatch: state.commandQuery,
+                                fontColor: textColor(command: command)
+                            )
                             .padding(.zero)
-                        }.frame(maxWidth: .infinity, maxHeight: 15, alignment: .leading)
-                    }.frame(maxWidth: .infinity, maxHeight: 15, alignment: .leading)
-                        .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
-                        .padding(.init(top: 5, leading: 5, bottom: 5, trailing: 0))
-                        .buttonStyle(.borderless)
-                        .background(self.selectedItem == command ?
-                                           RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: 15, alignment: .leading)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: 15, alignment: .leading)
+                    .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                    .padding(.init(top: 5, leading: 5, bottom: 5, trailing: 0))
+                    .buttonStyle(.borderless)
+                    .background(
+                        self.selectedItem == command ? RoundedRectangle(cornerRadius: 5, style: .continuous)
                             .fill(Color(red: 0, green: 0.38, blue: 0.816, opacity: 0.85)) :
-                                            RoundedRectangle(cornerRadius: 5, style: .continuous)
-                            .fill(Color.clear))
-                        .onHover(perform: { _ in self.selectedItem = command })
-                    }.listStyle(SidebarListStyle())
-
+                            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Color.clear)
+                    )
+                    .onHover(perform: { _ in self.selectedItem = command })
+                }
+                .listStyle(SidebarListStyle())
             }
         }
         .background(EffectView(.sidebar, blendingMode: .behindWindow))
         .foregroundColor(.gray)
         .edgesIgnoringSafeArea(.vertical)
-        .frame(minWidth: 600,
-           minHeight: self.state.isShowingCommandsList ? 400 : 28,
-           maxHeight: self.state.isShowingCommandsList ? .infinity : 28)
+        .frame(
+            minWidth: 600,
+            minHeight: self.state.isShowingCommandsList ? 400 : 28,
+            maxHeight: self.state.isShowingCommandsList ? .infinity : 28
+        )
     }
 }
 
@@ -240,8 +249,10 @@ struct SearchResultLabel: NSViewRepresentable {
     func highlight() -> NSAttributedString {
 
         let attribText = NSMutableAttributedString(string: self.labelName)
-        let range: NSRange = attribText.mutableString.range(of: self.textToMatch,
-                                                                options: NSString.CompareOptions.caseInsensitive)
+        let range: NSRange = attribText.mutableString.range(
+            of: self.textToMatch,
+            options: NSString.CompareOptions.caseInsensitive
+        )
         attribText.addAttribute(.foregroundColor, value: NSColor(fontColor.opacity(0.85)), range: range)
 
         return attribText

--- a/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
@@ -21,9 +21,11 @@ final class CodeEditDocumentController: NSDocumentController {
         }, onCancel: {})
     }
 
-    override func openDocument(withContentsOf url: URL,
-                               display displayDocument: Bool,
-                               completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void) {
+    override func openDocument(
+        withContentsOf url: URL,
+        display displayDocument: Bool,
+        completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void
+    ) {
         super.openDocument(withContentsOf: url, display: displayDocument) { document, documentWasAlreadyOpen, error in
 
             if let document = document {

--- a/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
@@ -70,8 +70,10 @@ extension NSDocumentController {
 
                     guard let document = document else {
                         let alert = NSAlert()
-                        alert.messageText = NSLocalizedString("Failed to get document",
-                                                              comment: "Failed to get document")
+                        alert.messageText = NSLocalizedString(
+                            "Failed to get document",
+                            comment: "Failed to get document"
+                        )
                         alert.runModal()
                         return
                     }

--- a/CodeEdit/Features/Documents/WorkspaceDocument+Search.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument+Search.swift
@@ -36,7 +36,7 @@ extension WorkspaceDocument {
         ///
         /// - Parameter text: The search text to search for. Pass `nil` to this parameter to clear
         ///                   the search results.
-        func search(_ text: String?) {
+        func search(_ text: String?) { // swiftlint:disable:this function_body_length
             guard let text = text else {
                 searchResult = []
                 searchResultCount = 0
@@ -48,14 +48,16 @@ extension WorkspaceDocument {
             self.searchResult = []
             self.searchId = UUID()
             guard let url = self.workspace.fileURL else { return }
-            let enumerator = FileManager.default.enumerator(at: url,
-                                                            includingPropertiesForKeys: [
-                                                                .isRegularFileKey
-                                                            ],
-                                                            options: [
-                                                                .skipsHiddenFiles,
-                                                                .skipsPackageDescendants
-                                                            ])
+            let enumerator = FileManager.default.enumerator(
+                at: url,
+                includingPropertiesForKeys: [
+                    .isRegularFileKey
+                ],
+                options: [
+                    .skipsHiddenFiles,
+                    .skipsPackageDescendants
+                ]
+            )
             guard let filePaths = enumerator?.allObjects as? [URL] else { return }
 
             // TODO: Optimization
@@ -89,10 +91,12 @@ extension WorkspaceDocument {
                     if lineContainsSearchTerm(line: noSpaceLine, term: textToCompare) {
                         // We've got a match
                         let matches = noSpaceLine.ranges(of: textToCompare).map { range in
-                            return SearchResultMatchModel(lineNumber: lineNumber,
-                                                          file: fileItem,
-                                                          lineContent: String(noSpaceLine),
-                                                          keywordRange: range)
+                            return SearchResultMatchModel(
+                                lineNumber: lineNumber,
+                                file: fileItem,
+                                lineContent: String(noSpaceLine),
+                                keywordRange: range
+                            )
                         }
                         if fileSearchResult != nil {
                             // We've already found something in this file, add the rest
@@ -100,8 +104,10 @@ extension WorkspaceDocument {
                             fileSearchResult?.lineMatches.append(contentsOf: matches)
                         } else {
                             // We haven't found anything in this file yet, record a new one
-                            fileSearchResult = SearchResultModel(file: fileItem,
-                                                                 lineMatches: matches)
+                            fileSearchResult = SearchResultModel(
+                                file: fileItem,
+                                lineMatches: matches
+                            )
                         }
                         searchResultCount += 1
                     }
@@ -188,11 +194,14 @@ extension String {
             guard index + substring.count < self.count else { continue }
             let lengthOfFoundCharacter = self.index(self.startIndex, offsetBy: (substring.count + index))
             if self[startOfFoundCharacter..<lengthOfFoundCharacter] == substring {
-                let startIndex = self.index(self.startIndex,
-                    offsetBy: index - (toLeft <= index ? toLeft : 0))
-                let endIndex = self.index(self.startIndex,
-                    offsetBy: substring.count + index +
-                        (substring.count+index+toRight <= self.count ? toRight : 0))
+                let startIndex = self.index(
+                    self.startIndex,
+                    offsetBy: index - (toLeft <= index ? toLeft : 0)
+                )
+                let endIndex = self.index(
+                    self.startIndex,
+                    offsetBy: substring.count + index + (substring.count+index+toRight <= self.count ? toRight : 0)
+                )
                 appearances.append(startIndex..<endIndex)
             }
         }

--- a/CodeEdit/Features/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument.swift
@@ -284,10 +284,12 @@ import CodeEditKit
         self.commandsPaletteState = .init()
         self.statusBarModel = .init(workspaceURL: url)
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(convertTemporaryTab),
-                                               name: NSNotification.Name("CodeEditor.didBeginEditing"),
-                                               object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(convertTemporaryTab),
+            name: NSNotification.Name("CodeEditor.didBeginEditing"),
+            object: nil
+        )
     }
 
     /// Retrieves selection state from UserDefaults using SHA256 hash of project  path as key

--- a/CodeEdit/Features/ExtensionsStore/API/ExtensionsStoreAPI.swift
+++ b/CodeEdit/Features/ExtensionsStore/API/ExtensionsStoreAPI.swift
@@ -85,8 +85,10 @@ enum ExtensionsStoreAPI {
 }
 
 final class ExtensionsStoreAgent {
-    func run<T: Decodable>(_ request: URLRequest,
-                           _ decoder: JSONDecoder = JSONDecoder()) -> AnyPublisher<APIResponse<T>, Error> {
+    func run<T: Decodable>(
+        _ request: URLRequest,
+        _ decoder: JSONDecoder = JSONDecoder()
+    ) -> AnyPublisher<APIResponse<T>, Error> {
         URLSession.shared
             .dataTaskPublisher(for: request)
             .tryMap { result -> APIResponse<T> in

--- a/CodeEdit/Features/ExtensionsStore/API/ExtensionsStoreAPI.swift
+++ b/CodeEdit/Features/ExtensionsStore/API/ExtensionsStoreAPI.swift
@@ -57,8 +57,10 @@ enum ExtensionsStoreAPI {
     ///   - page: page to be requested
     /// - Returns: publisher with the page
     static func pluginReleases(id: UUID, page: Int) -> AnyPublisher<APIPage<PluginRelease>, Error> {
-        var components = URLComponents(url: base.appendingPathComponent("plugins/\(id.uuidString)/releases"),
-                                       resolvingAgainstBaseURL: false)
+        var components = URLComponents(
+            url: base.appendingPathComponent("plugins/\(id.uuidString)/releases"),
+            resolvingAgainstBaseURL: false
+        )
         components?.queryItems = [
             .init(name: "page", value: "\(page)")
         ]

--- a/CodeEdit/Features/ExtensionsStore/ExtensionsManager.swift
+++ b/CodeEdit/Features/ExtensionsStore/ExtensionsManager.swift
@@ -37,9 +37,11 @@ final class ExtensionsManager {
         self.extensionsFolder = codeeditFolder.appendingPathComponent("Extensions", isDirectory: true)
 
         try FileManager.default
-            .createDirectory(at: self.codeeditFolder,
-                             withIntermediateDirectories: true,
-                             attributes: nil)
+            .createDirectory(
+                at: self.codeeditFolder,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
 
         self.dbQueue = try DatabaseQueue(path: self.codeeditFolder
                                             .appendingPathComponent("extensions.db")
@@ -81,8 +83,7 @@ final class ExtensionsManager {
 
     private func loadBundle(id: UUID, withExtension ext: String) throws -> Bundle? {
         guard let bundleURL = try FileManager.default.contentsOfDirectory(
-            at: extensionsFolder.appendingPathComponent(id.uuidString,
-                                                        isDirectory: true),
+            at: extensionsFolder.appendingPathComponent(id.uuidString, isDirectory: true),
             includingPropertiesForKeys: nil,
             options: .skipsPackageDescendants
         ).first(where: { $0.pathExtension == ext }) else { return nil }
@@ -118,9 +119,11 @@ final class ExtensionsManager {
                 return nil
             }
 
-            return try LSPClient(lspURL,
-                                 workspace: workspaceURL,
-                                 arguments: loadedBundles[id]?.infoDictionary?["CELSPArguments"] as? [String])
+            return try LSPClient(
+                lspURL,
+                workspace: workspaceURL,
+                arguments: loadedBundles[id]?.infoDictionary?["CELSPArguments"] as? [String]
+            )
         }
 
         guard let bundle = try loadBundle(id: id, withExtension: "celsp") else {
@@ -135,9 +138,11 @@ final class ExtensionsManager {
             return nil
         }
 
-        return try LSPClient(lspURL,
-                             workspace: workspaceURL,
-                             arguments: loadedBundles[id]?.infoDictionary?["CELSPArguments"] as? [String])
+        return try LSPClient(
+            lspURL,
+            workspace: workspaceURL,
+            arguments: loadedBundles[id]?.infoDictionary?["CELSPArguments"] as? [String]
+        )
     }
 
     /// Preloads all extensions' bundles to `loadedBundles`
@@ -198,9 +203,11 @@ final class ExtensionsManager {
         let extensionsFolder = codeeditFolder.appendingPathComponent("Extensions", isDirectory: true)
 
         try FileManager.default
-            .createDirectory(at: extensionsFolder,
-                             withIntermediateDirectories: true,
-                             attributes: nil)
+            .createDirectory(
+                at: extensionsFolder,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
 
         let cacheTar = try FileManager.default
             .url(
@@ -226,8 +233,10 @@ final class ExtensionsManager {
                 .addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed) else {
                     throw ExtensionsStoreAPIError.pathError
                 }
-        try FileManager.default.createFilesAndDirectories(path: path,
-                                                          tarPath: cacheTar.path)
+        try FileManager.default.createFilesAndDirectories(
+            path: path,
+            tarPath: cacheTar.path
+        )
 
         let manifest = extensionsFolder.appendingPathComponent("\(plugin.id.uuidString).json")
 

--- a/CodeEdit/Features/Feedback/FeedbackView.swift
+++ b/CodeEdit/Features/Feedback/FeedbackView.swift
@@ -39,20 +39,24 @@ struct FeedbackView: View {
                     Text("Failed to submit feedback")
                 }
                 Button {
-                    feedbackModel.createIssue(title: feedbackModel.feedbackTitle,
-                                              description: feedbackModel.issueDescription,
-                                              steps: feedbackModel.stepsReproduceDescription,
-                                              expectation: feedbackModel.expectationDescription,
-                                              actuallyHappened: feedbackModel.whatHappenedDescription)
+                    feedbackModel.createIssue(
+                        title: feedbackModel.feedbackTitle,
+                        description: feedbackModel.issueDescription,
+                        steps: feedbackModel.stepsReproduceDescription,
+                        expectation: feedbackModel.expectationDescription,
+                        actuallyHappened: feedbackModel.whatHappenedDescription
+                    )
                     isSubmitButtonPressed = true
                 } label: {
                     Text("Submit")
                 }
                 .alert(isPresented: self.$showsAlert) {
-                    Alert(title: Text("No GitHub Account"),
-                          message: Text("A GitHub account is required to submit feedback."),
-                          primaryButton: .default(Text("Cancel")),
-                          secondaryButton: .default(Text("Add Account")))
+                    Alert(
+                        title: Text("No GitHub Account"),
+                        message: Text("A GitHub account is required to submit feedback."),
+                        primaryButton: .default(Text("Cancel")),
+                        secondaryButton: .default(Text("Add Account"))
+                    )
                 }
             }
             .padding(10)

--- a/CodeEdit/Features/Feedback/Model/FeedbackModel.swift
+++ b/CodeEdit/Features/Feedback/Model/FeedbackModel.swift
@@ -113,10 +113,12 @@ public class FeedbackModel: ObservableObject {
     /// The format for the issue body is how it will be displayed on
     /// repos issues. If any changes are made use markdown format
     /// because the text gets converted when created.
-    private func createIssueBody(description: String,
-                                 steps: String?,
-                                 expectation: String?,
-                                 actuallyHappened: String?) -> String {
+    private func createIssueBody(
+        description: String,
+        steps: String?,
+        expectation: String?,
+        actuallyHappened: String?
+    ) -> String {
         """
         **Description**
 
@@ -136,11 +138,13 @@ public class FeedbackModel: ObservableObject {
         """
     }
 
-    public func createIssue(title: String,
-                            description: String,
-                            steps: String?,
-                            expectation: String?,
-                            actuallyHappened: String?) {
+    public func createIssue(
+        title: String,
+        description: String,
+        steps: String?,
+        expectation: String?,
+        actuallyHappened: String?
+    ) {
         let gitAccounts = prefs.preferences.accounts.sourceControlAccounts.gitAccount
         let firstGitAccount = gitAccounts.first
 

--- a/CodeEdit/Features/Feedback/Model/FeedbackModel.swift
+++ b/CodeEdit/Features/Feedback/Model/FeedbackModel.swift
@@ -149,15 +149,19 @@ public class FeedbackModel: ObservableObject {
         let firstGitAccount = gitAccounts.first
 
         let config = GitHubTokenConfiguration(keychain.get(firstGitAccount!.gitAccountName))
-        GitHubAccount(config).postIssue(owner: "CodeEditApp",
-                                  repository: "CodeEdit",
-                                  title: "\(getFeebackTypeTitle()) \(title)",
-                                  body: createIssueBody(description: description,
-                                                        steps: steps,
-                                                        expectation: expectation,
-                                                        actuallyHappened: actuallyHappened),
-                                  assignee: "",
-                                  labels: [getFeebackTypeLabel(), getIssueLabel()]) { response in
+        GitHubAccount(config).postIssue(
+            owner: "CodeEditApp",
+            repository: "CodeEdit",
+            title: "\(getFeebackTypeTitle()) \(title)",
+            body: createIssueBody(
+                description: description,
+                steps: steps,
+                expectation: expectation,
+                actuallyHappened: actuallyHappened
+            ),
+            assignee: "",
+            labels: [getFeebackTypeLabel(), getIssueLabel()]
+        ) { response in
             switch response {
             case .success(let issue):
                 if self.prefs.preferences.sourceControl.general.openFeedbackInBrowser {

--- a/CodeEdit/Features/Git/Accounts/Bitbucket/BitBucketAccount+Token.swift
+++ b/CodeEdit/Features/Git/Accounts/Bitbucket/BitBucketAccount+Token.swift
@@ -34,7 +34,8 @@ extension BitBucketAccount {
                             let error = NSError(
                                 domain: "com.codeedit.models.accounts.bitbucket",
                                 code: response.statusCode,
-                                userInfo: [NSLocalizedDescriptionKey: errorDescription])
+                                userInfo: [NSLocalizedDescriptionKey: errorDescription]
+                            )
                             completion(Result.failure(error))
                         } else {
                             let tokenConfig = BitBucketTokenConfiguration(json: responseJSON)

--- a/CodeEdit/Features/Git/Accounts/Bitbucket/BitBucketOAuthConfiguration.swift
+++ b/CodeEdit/Features/Git/Accounts/Bitbucket/BitBucketOAuthConfiguration.swift
@@ -73,8 +73,10 @@ struct BitBucketOAuthConfiguration: GitRouterConfiguration {
     private func configFromData(_ data: Data?) -> BitBucketTokenConfiguration? {
         guard let data = data else { return nil }
         do {
-            guard let json = try JSONSerialization.jsonObject(with: data,
-                                                              options: .allowFragments) as? [String: AnyObject] else {
+            guard let json = try JSONSerialization.jsonObject(
+                with: data,
+                options: .allowFragments
+            ) as? [String: AnyObject] else {
                 return nil
             }
             let config = BitBucketTokenConfiguration(json: json)

--- a/CodeEdit/Features/Git/Accounts/Bitbucket/BitBucketOAuthConfiguration.swift
+++ b/CodeEdit/Features/Git/Accounts/Bitbucket/BitBucketOAuthConfiguration.swift
@@ -16,8 +16,12 @@ struct BitBucketOAuthConfiguration: GitRouterConfiguration {
     let webEndpoint: String
     let errorDomain = "com.codeedit.models.accounts.bitbucket"
 
-    init(_ url: String = GitURL.bitbucketBaseURL, webURL: String = GitURL.bitbucketWebURL,
-         token: String, secret: String, scopes: [String]
+    init(
+        _ url: String = GitURL.bitbucketBaseURL,
+        webURL: String = GitURL.bitbucketWebURL,
+        token: String,
+        secret: String,
+        scopes: [String]
     ) {
         apiEndpoint = url
         webEndpoint = webURL
@@ -43,9 +47,10 @@ struct BitBucketOAuthConfiguration: GitRouterConfiguration {
         return config
     }
 
-    func authorize(_ session: GitURLSession,
-                   code: String,
-                   completion: @escaping (_ config: BitBucketTokenConfiguration) -> Void
+    func authorize(
+        _ session: GitURLSession,
+        code: String,
+        completion: @escaping (_ config: BitBucketTokenConfiguration) -> Void
     ) {
         let request = BitBucketOAuthRouter.accessToken(self, code).URLRequest
 
@@ -79,9 +84,10 @@ struct BitBucketOAuthConfiguration: GitRouterConfiguration {
         }
     }
 
-    func handleOpenURL(_ session: GitURLSession = URLSession.shared,
-                       url: URL,
-                       completion: @escaping (_ config: BitBucketTokenConfiguration) -> Void
+    func handleOpenURL(
+        _ session: GitURLSession = URLSession.shared,
+        url: URL,
+        completion: @escaping (_ config: BitBucketTokenConfiguration) -> Void
     ) {
         let params = url.bitbucketURLParameters()
 

--- a/CodeEdit/Features/Git/Accounts/Bitbucket/BitBucketTokenConfiguration.swift
+++ b/CodeEdit/Features/Git/Accounts/Bitbucket/BitBucketTokenConfiguration.swift
@@ -23,10 +23,11 @@ struct BitBucketTokenConfiguration: GitRouterConfiguration {
         expirationDate = currentDate.addingTimeInterval(TimeInterval(expiresIn ?? 0))
     }
 
-    init(_ token: String? = nil,
-         refreshToken: String? = nil,
-         expirationDate: Date? = nil,
-         url: String = GitURL.bitbucketBaseURL
+    init(
+        _ token: String? = nil,
+        refreshToken: String? = nil,
+        expirationDate: Date? = nil,
+        url: String = GitURL.bitbucketBaseURL
     ) {
         apiEndpoint = url
         accessToken = token

--- a/CodeEdit/Features/Git/Accounts/Bitbucket/Model/BitBucketRepositories.swift
+++ b/CodeEdit/Features/Git/Accounts/Bitbucket/Model/BitBucketRepositories.swift
@@ -43,10 +43,11 @@ enum BitbucketPaginatedResponse<T> {
 
 extension BitBucketAccount {
 
-    func repositories(_ session: GitURLSession = URLSession.shared,
-                      userName: String? = nil,
-                      nextParameters: [String: String] = [:],
-                      completion: @escaping (_ response: BitbucketPaginatedResponse<[BitBucketRepositories]>) -> Void
+    func repositories(
+        _ session: GitURLSession = URLSession.shared,
+        userName: String? = nil,
+        nextParameters: [String: String] = [:],
+        completion: @escaping (_ response: BitbucketPaginatedResponse<[BitBucketRepositories]>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = BitBucketRepositoryRouter.readRepositories(configuration, userName, nextParameters)
 
@@ -64,10 +65,11 @@ extension BitBucketAccount {
         }
     }
 
-    func repository(_ session: GitURLSession = URLSession.shared,
-                    owner: String,
-                    name: String,
-                    completion: @escaping (_ response: Result<BitBucketRepositories, Error>) -> Void
+    func repository(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String,
+        name: String,
+        completion: @escaping (_ response: Result<BitBucketRepositories, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = BitBucketRepositoryRouter.readRepository(configuration, owner, name)
 

--- a/CodeEdit/Features/Git/Accounts/Bitbucket/Model/BitBucketRepositories.swift
+++ b/CodeEdit/Features/Git/Accounts/Bitbucket/Model/BitBucketRepositories.swift
@@ -51,9 +51,11 @@ extension BitBucketAccount {
     ) -> GitURLSessionDataTaskProtocol? {
         let router = BitBucketRepositoryRouter.readRepositories(configuration, userName, nextParameters)
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: BitBucketRepositories.self) { repo, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: BitBucketRepositories.self
+        ) { repo, error in
 
             if let error = error {
                 completion(BitbucketPaginatedResponse.failure(error))
@@ -73,9 +75,11 @@ extension BitBucketAccount {
     ) -> GitURLSessionDataTaskProtocol? {
         let router = BitBucketRepositoryRouter.readRepository(configuration, owner, name)
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: BitBucketRepositories.self) { data, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: BitBucketRepositories.self
+        ) { data, error in
 
             if let error = error {
                 completion(Result.failure(error))

--- a/CodeEdit/Features/Git/Accounts/Bitbucket/Model/BitBucketUser.swift
+++ b/CodeEdit/Features/Git/Accounts/Bitbucket/Model/BitBucketUser.swift
@@ -44,9 +44,11 @@ extension BitBucketAccount {
 
             let router = BitBucketUserRouter.readAuthenticatedUser(configuration)
 
-            return router.load(session,
-                               dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                               expectedResultType: BitBucketUser.self) { user, error in
+            return router.load(
+                session,
+                dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+                expectedResultType: BitBucketUser.self
+            ) { user, error in
                 if let error = error {
                     completion(.failure(error))
                 } else {
@@ -64,9 +66,11 @@ extension BitBucketAccount {
 
             let router = BitBucketUserRouter.readEmails(configuration)
 
-            return router.load(session,
-                               dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                               expectedResultType: BitBucketEmail.self) { email, error in
+            return router.load(
+                session,
+                dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+                expectedResultType: BitBucketEmail.self
+            ) { email, error in
                 if let error = error {
                     completion(.failure(error))
                 } else {

--- a/CodeEdit/Features/Git/Accounts/Bitbucket/Model/BitBucketUser.swift
+++ b/CodeEdit/Features/Git/Accounts/Bitbucket/Model/BitBucketUser.swift
@@ -39,7 +39,8 @@ extension BitBucketAccount {
 
     func me(
         _ session: GitURLSession = URLSession.shared,
-        completion: @escaping (_ response: Result<BitBucketUser, Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ response: Result<BitBucketUser, Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
             let router = BitBucketUserRouter.readAuthenticatedUser(configuration)
 
@@ -58,7 +59,8 @@ extension BitBucketAccount {
 
     func emails(
         _ session: GitURLSession = URLSession.shared,
-        completion: @escaping (_ response: Result<BitBucketEmail, Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ response: Result<BitBucketEmail, Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
             let router = BitBucketUserRouter.readEmails(configuration)
 

--- a/CodeEdit/Features/Git/Accounts/GitHub/GitHubConfiguration.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/GitHubConfiguration.swift
@@ -54,8 +54,13 @@ struct GitHubOAuthConfiguration: GitRouterConfiguration {
         return previewCustomHeaders
     }
 
-    init(_ url: String = GitURL.githubBaseURL, webURL: String = GitURL.githubWebURL,
-         token: String, secret: String, scopes: [String], previewHeaders: [GitHubPreviewHeader] = []
+    init(
+        _ url: String = GitURL.githubBaseURL,
+        webURL: String = GitURL.githubWebURL,
+        token: String,
+        secret: String,
+        scopes: [String],
+        previewHeaders: [GitHubPreviewHeader] = []
     ) {
         apiEndpoint = url
         webEndpoint = webURL
@@ -72,7 +77,8 @@ struct GitHubOAuthConfiguration: GitRouterConfiguration {
     func authorize(
         _ session: GitURLSession = URLSession.shared,
         code: String,
-        completion: @escaping (_ config: GitHubTokenConfiguration) -> Void) {
+        completion: @escaping (_ config: GitHubTokenConfiguration) -> Void
+    ) {
 
         let request = GitHubOAuthRouter.accessToken(self, code).URLRequest
         if let request = request {
@@ -98,7 +104,8 @@ struct GitHubOAuthConfiguration: GitRouterConfiguration {
     func handleOpenURL(
         _ session: GitURLSession = URLSession.shared,
         url: URL,
-        completion: @escaping (_ config: GitHubTokenConfiguration) -> Void) {
+        completion: @escaping (_ config: GitHubTokenConfiguration) -> Void
+    ) {
 
         if let code = url.URLParameters["code"] {
             authorize(session, code: code) { config in

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubAccount+deleteReference.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubAccount+deleteReference.swift
@@ -22,11 +22,12 @@ extension GitHubAccount {
             - completion: Callback for the outcome of the deletion.
      */
     @discardableResult
-    func deleteReference(_ session: GitURLSession = URLSession.shared,
-                         owner: String,
-                         repository: String,
-                         ref: String,
-                         completion: @escaping (_ response: Error?) -> Void
+    func deleteReference(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String,
+        repository: String,
+        ref: String,
+        completion: @escaping (_ response: Error?) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitHubRouter.deleteReference(configuration, owner, repository, ref)
         return router.load(session, completion: completion)

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubGist.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubGist.swift
@@ -72,7 +72,8 @@ extension GitHubAccount {
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: [GitHubGist].self) { gists, error in
+            expectedResultType: [GitHubGist].self
+        ) { gists, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -106,7 +107,8 @@ extension GitHubAccount {
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: [GitHubGist].self) { gists, error in
+            expectedResultType: [GitHubGist].self
+        ) { gists, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -136,7 +138,8 @@ extension GitHubAccount {
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: GitHubGist.self) { gist, error in
+            expectedResultType: GitHubGist.self
+        ) { gist, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -175,7 +178,8 @@ extension GitHubAccount {
         return router.post(
             session,
             decoder: decoder,
-            expectedResultType: GitHubGist.self) { gist, error in
+            expectedResultType: GitHubGist.self
+        ) { gist, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -214,7 +218,8 @@ extension GitHubAccount {
         return router.post(
             session,
             decoder: decoder,
-            expectedResultType: GitHubGist.self) { gist, error in
+            expectedResultType: GitHubGist.self
+        ) { gist, error in
 
             if let error = error {
                 completion(.failure(error))

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubGist.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubGist.swift
@@ -64,8 +64,8 @@ extension GitHubAccount {
         _ session: GitURLSession = URLSession.shared,
         page: String = "1",
         perPage: String = "100",
-        completion: @escaping (
-            _ response: Result<[GitHubGist], Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ response: Result<[GitHubGist], Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         let router = GitHubGistRouter.readAuthenticatedGists(configuration, page, perPage)
 
@@ -98,8 +98,8 @@ extension GitHubAccount {
         owner: String,
         page: String = "1",
         perPage: String = "100",
-        completion: @escaping (
-            _ response: Result<[GitHubGist], Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ response: Result<[GitHubGist], Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         let router = GitHubGistRouter.readGists(configuration, owner, page, perPage)
 
@@ -128,8 +128,8 @@ extension GitHubAccount {
     func gist(
         _ session: GitURLSession = URLSession.shared,
         id: String,
-        completion: @escaping (
-            _ response: Result<GitHubGist, Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ response: Result<GitHubGist, Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         let router = GitHubGistRouter.readGist(configuration, id)
 
@@ -158,13 +158,14 @@ extension GitHubAccount {
      - parameter completion: Callback for the gist that is created.
      */
     @discardableResult
-    func postGistFile(_ session: GitURLSession = URLSession.shared,
-                      description: String,
-                      filename: String,
-                      fileContent: String,
-                      publicAccess: Bool,
-                      completion: @escaping (
-                        _ response: Result<GitHubGist, Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+    func postGistFile(
+        _ session: GitURLSession = URLSession.shared,
+        description: String,
+        filename: String,
+        fileContent: String,
+        publicAccess: Bool,
+        completion: @escaping (_ response: Result<GitHubGist, Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         let router = GitHubGistRouter.postGistFile(configuration, description, filename, fileContent, publicAccess)
         let decoder = JSONDecoder()
@@ -196,13 +197,14 @@ extension GitHubAccount {
      - parameter completion: Callback for the gist that is created.
      */
     @discardableResult
-    func patchGistFile(_ session: GitURLSession = URLSession.shared,
-                       id: String,
-                       description: String,
-                       filename: String,
-                       fileContent: String,
-                       completion: @escaping (
-                        _ response: Result<GitHubGist, Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+    func patchGistFile(
+        _ session: GitURLSession = URLSession.shared,
+        id: String,
+        description: String,
+        filename: String,
+        fileContent: String,
+        completion: @escaping (_ response: Result<GitHubGist, Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         let router = GitHubGistRouter.patchGistFile(configuration, id, description, filename, fileContent)
         let decoder = JSONDecoder()

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubIssue.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubIssue.swift
@@ -64,11 +64,12 @@ extension GitHubAccount {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func myIssues(_ session: GitURLSession = URLSession.shared,
-                  state: GitHubOpenness = .open,
-                  page: String = "1",
-                  perPage: String = "100",
-                  completion: @escaping (_ response: Result<[GitHubIssue], Error>) -> Void
+    func myIssues(
+        _ session: GitURLSession = URLSession.shared,
+        state: GitHubOpenness = .open,
+        page: String = "1",
+        perPage: String = "100",
+        completion: @escaping (_ response: Result<[GitHubIssue], Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitHubIssueRouter.readAuthenticatedIssues(configuration, page, perPage, state)
 
@@ -96,11 +97,12 @@ extension GitHubAccount {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func issue(_ session: GitURLSession = URLSession.shared,
-               owner: String, repository: String,
-               number: Int,
-               completion: @escaping (
-                _ response: Result<GitHubIssue, Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+    func issue(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String, repository: String,
+        number: Int,
+        completion: @escaping (_ response: Result<GitHubIssue, Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
         let router = GitHubIssueRouter.readIssue(configuration, owner, repository, number)
 
         return router.load(
@@ -129,14 +131,15 @@ extension GitHubAccount {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func issues(_ session: GitURLSession = URLSession.shared,
-                owner: String,
-                repository: String,
-                state: GitHubOpenness = .open,
-                page: String = "1",
-                perPage: String = "100",
-                completion: @escaping (
-                    _ response: Result<[GitHubIssue], Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+    func issues(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String,
+        repository: String,
+        state: GitHubOpenness = .open,
+        page: String = "1",
+        perPage: String = "100",
+        completion: @escaping (_ response: Result<[GitHubIssue], Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
         let router = GitHubIssueRouter.readIssues(configuration, owner, repository, page, perPage, state)
 
         return router.load(
@@ -169,15 +172,16 @@ extension GitHubAccount {
      - parameter completion: Callback for the issue that is created.
      */
     @discardableResult
-    func postIssue(_ session: GitURLSession = URLSession.shared,
-                   owner: String,
-                   repository: String,
-                   title: String,
-                   body: String? = nil,
-                   assignee: String? = nil,
-                   labels: [String] = [],
-                   completion: @escaping (
-                    _ response: Result<GitHubIssue, Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+    func postIssue(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String,
+        repository: String,
+        title: String,
+        body: String? = nil,
+        assignee: String? = nil,
+        labels: [String] = [],
+        completion: @escaping (_ response: Result<GitHubIssue, Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         let router = GitHubIssueRouter.postIssue(configuration, owner, repository, title, body, assignee, labels)
         let decoder = JSONDecoder()
@@ -213,16 +217,17 @@ extension GitHubAccount {
      - parameter completion: Callback for the issue that is created.
      */
     @discardableResult
-    func patchIssue(_ session: GitURLSession = URLSession.shared,
-                    owner: String,
-                    repository: String,
-                    number: Int,
-                    title: String? = nil,
-                    body: String? = nil,
-                    assignee: String? = nil,
-                    state: GitHubOpenness? = nil,
-                    completion: @escaping (
-                        _ response: Result<GitHubIssue, Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+    func patchIssue(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String,
+        repository: String,
+        number: Int,
+        title: String? = nil,
+        body: String? = nil,
+        assignee: String? = nil,
+        state: GitHubOpenness? = nil,
+        completion: @escaping (_ response: Result<GitHubIssue, Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         let router = GitHubIssueRouter.patchIssue(
             configuration, owner, repository, number, title, body, assignee, state
@@ -251,13 +256,14 @@ extension GitHubAccount {
     ///   - body: The contents of the comment.
     ///   - completion: Callback for the comment that is created.
     @discardableResult
-    func commentIssue(_ session: GitURLSession = URLSession.shared,
-                      owner: String,
-                      repository: String,
-                      number: Int,
-                      body: String,
-                      completion: @escaping (
-                        _ response: Result<GitHubComment, Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+    func commentIssue(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String,
+        repository: String,
+        number: Int,
+        body: String,
+        completion: @escaping (_ response: Result<GitHubComment, Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         let router = GitHubIssueRouter.commentIssue(configuration, owner, repository, number, body)
         let decoder = JSONDecoder()
@@ -289,14 +295,15 @@ extension GitHubAccount {
     /// - perPage: Number of comments per page. `100` by default.
     /// - completion: Callback for the outcome of the fetch.
     @discardableResult
-    func issueComments(_ session: GitURLSession = URLSession.shared,
-                       owner: String,
-                       repository: String,
-                       number: Int,
-                       page: String = "1",
-                       perPage: String = "100",
-                       completion: @escaping (
-                        _ response: Result<[GitHubComment], Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+    func issueComments(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String,
+        repository: String,
+        number: Int,
+        page: String = "1",
+        perPage: String = "100",
+        completion: @escaping (_ response: Result<[GitHubComment], Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         let router = GitHubIssueRouter.readIssueComments(configuration, owner, repository, number, page, perPage)
 
@@ -330,8 +337,8 @@ extension GitHubAccount {
         repository: String,
         number: Int,
         body: String,
-        completion: @escaping (
-            _ response: Result<GitHubComment, Error>) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ response: Result<GitHubComment, Error>) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         let router = GitHubIssueRouter.patchIssueComment(configuration, owner, repository, number, body)
         let decoder = JSONDecoder()

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubIssue.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubIssue.swift
@@ -76,7 +76,8 @@ extension GitHubAccount {
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: [GitHubIssue].self) { issues, error in
+            expectedResultType: [GitHubIssue].self
+        ) { issues, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -108,7 +109,8 @@ extension GitHubAccount {
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: GitHubIssue.self) { issue, error in
+            expectedResultType: GitHubIssue.self
+        ) { issue, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -145,7 +147,8 @@ extension GitHubAccount {
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: [GitHubIssue].self) { issues, error in
+            expectedResultType: [GitHubIssue].self
+        ) { issues, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -191,7 +194,8 @@ extension GitHubAccount {
         return router.post(
             session,
             decoder: decoder,
-            expectedResultType: GitHubIssue.self) { issue, error in
+            expectedResultType: GitHubIssue.self
+        ) { issue, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -235,7 +239,8 @@ extension GitHubAccount {
 
         return router.post(
             session,
-            expectedResultType: GitHubIssue.self) { issue, error in
+            expectedResultType: GitHubIssue.self
+        ) { issue, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -273,7 +278,8 @@ extension GitHubAccount {
         return router.post(
             session,
             decoder: decoder,
-            expectedResultType: GitHubComment.self) { issue, error in
+            expectedResultType: GitHubComment.self
+        ) { issue, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -310,7 +316,8 @@ extension GitHubAccount {
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: [GitHubComment].self) { comments, error in
+            expectedResultType: [GitHubComment].self
+        ) { comments, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -346,7 +353,8 @@ extension GitHubAccount {
 
         return router.post(
             session, decoder: decoder,
-            expectedResultType: GitHubComment.self) { issue, error in
+            expectedResultType: GitHubComment.self
+        ) { issue, error in
 
             if let error = error {
                 completion(.failure(error))

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubPullRequest.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubPullRequest.swift
@@ -105,7 +105,8 @@ extension GitHubAccount {
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: GitHubPullRequest.self) { pullRequest, error in
+            expectedResultType: GitHubPullRequest.self
+        ) { pullRequest, error in
 
             if let error = error {
                 completion(.failure(error))
@@ -148,12 +149,14 @@ extension GitHubAccount {
             head,
             state,
             sort,
-            direction)
+            direction
+        )
 
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: [GitHubPullRequest].self) { pullRequests, error in
+            expectedResultType: [GitHubPullRequest].self
+        ) { pullRequests, error in
 
             if let error = error {
                 completion(.failure(error))

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubPullRequest.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubPullRequest.swift
@@ -93,12 +93,12 @@ extension GitHubAccount {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func pullRequest(_ session: GitURLSession = URLSession.shared,
-                     owner: String,
-                     repository: String,
-                     number: Int,
-                     completion: @escaping (
-                        _ response: Result<GitHubPullRequest, Error>) -> Void
+    func pullRequest(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String,
+        repository: String,
+        number: Int,
+        completion: @escaping (_ response: Result<GitHubPullRequest, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitHubPullRequestRouter.readPullRequest(configuration, owner, repository, "\(number)")
 
@@ -129,15 +129,16 @@ extension GitHubAccount {
      - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func pullRequests(_ session: GitURLSession = URLSession.shared,
-                      owner: String,
-                      repository: String,
-                      base: String? = nil,
-                      head: String? = nil,
-                      state: GitHubOpenness = .open,
-                      sort: GitSortType = .created,
-                      direction: GitSortDirection = .desc,
-                      completion: @escaping (_ response: Result<[GitHubPullRequest], Error>) -> Void
+    func pullRequests(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String,
+        repository: String,
+        base: String? = nil,
+        head: String? = nil,
+        state: GitHubOpenness = .open,
+        sort: GitSortType = .created,
+        direction: GitSortDirection = .desc,
+        completion: @escaping (_ response: Result<[GitHubPullRequest], Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitHubPullRequestRouter.readPullRequests(
             configuration,

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubRepositories.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubRepositories.swift
@@ -57,12 +57,12 @@ extension GitHubAccount {
             - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func repositories(_ session: GitURLSession = URLSession.shared,
-                      owner: String? = nil,
-                      page: String = "1",
-                      perPage: String = "100",
-                      completion: @escaping (
-                        _ response: Result<[GitHubRepositories], Error>) -> Void
+    func repositories(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String? = nil,
+        page: String = "1",
+        perPage: String = "100",
+        completion: @escaping (_ response: Result<[GitHubRepositories], Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = (owner != nil)
             ? GitHubRepositoryRouter.readRepositories(configuration, owner!, page, perPage)
@@ -87,10 +87,11 @@ extension GitHubAccount {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func repository(_ session: GitURLSession = URLSession.shared,
-                    owner: String,
-                    name: String,
-                    completion: @escaping (_ response: Result<GitHubRepositories, Error>) -> Void
+    func repository(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String,
+        name: String,
+        completion: @escaping (_ response: Result<GitHubRepositories, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitHubRepositoryRouter.readRepository(configuration, owner, name)
 

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubReview.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubReview.swift
@@ -44,11 +44,12 @@ extension GitHubReview {
 extension GitHubAccount {
 
     @discardableResult
-    func listReviews(_ session: GitURLSession = URLSession.shared,
-                     owner: String,
-                     repository: String,
-                     pullRequestNumber: Int,
-                     completion: @escaping (_ response: Result<[GitHubReview], Error>) -> Void
+    func listReviews(
+        _ session: GitURLSession = URLSession.shared,
+        owner: String,
+        repository: String,
+        pullRequestNumber: Int,
+        completion: @escaping (_ response: Result<[GitHubReview], Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitHubReviewsRouter.listReviews(configuration, owner, repository, pullRequestNumber)
 

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubReview.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubReview.swift
@@ -56,7 +56,8 @@ extension GitHubAccount {
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: [GitHubReview].self) { pullRequests, error in
+            expectedResultType: [GitHubReview].self
+        ) { pullRequests, error in
 
             if let error = error {
                 completion(.failure(error))

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubUser.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubUser.swift
@@ -84,7 +84,8 @@ extension GitHubAccount {
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: GitHubUser.self) { user, error in
+            expectedResultType: GitHubUser.self
+        ) { user, error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -110,7 +111,8 @@ extension GitHubAccount {
         return router.load(
             session,
             dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-            expectedResultType: GitHubUser.self) { user, error in
+            expectedResultType: GitHubUser.self
+        ) { user, error in
             if let error = error {
                 completion(.failure(error))
             } else {

--- a/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubUser.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/Model/GitHubUser.swift
@@ -74,9 +74,10 @@ extension GitHubAccount {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func user(_ session: GitURLSession = URLSession.shared,
-              name: String,
-              completion: @escaping (_ response: Result<GitHubUser, Error>) -> Void
+    func user(
+        _ session: GitURLSession = URLSession.shared,
+        name: String,
+        completion: @escaping (_ response: Result<GitHubUser, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitHubUserRouter.readUser(name, configuration)
 
@@ -100,8 +101,9 @@ extension GitHubAccount {
          - parameter completion: Callback for the outcome of the fetch.
      */
     @discardableResult
-    func me(_ session: GitURLSession = URLSession.shared,
-            completion: @escaping (_ response: Result<GitHubUser, Error>) -> Void
+    func me(
+        _ session: GitURLSession = URLSession.shared,
+        completion: @escaping (_ response: Result<GitHubUser, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitHubUserRouter.readAuthenticatedUser(configuration)
 

--- a/CodeEdit/Features/Git/Accounts/GitHub/PublicKey.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/PublicKey.swift
@@ -22,7 +22,8 @@ extension GitHubAccount {
 
         return router.postJSON(
             session,
-            expectedResultType: [String: AnyObject].self) { json, error in
+            expectedResultType: [String: AnyObject].self
+        ) { json, error in
 
             if let error = error {
                 completion(.failure(error))

--- a/CodeEdit/Features/Git/Accounts/GitHub/PublicKey.swift
+++ b/CodeEdit/Features/Git/Accounts/GitHub/PublicKey.swift
@@ -12,10 +12,11 @@ import FoundationNetworking
 
 // TODO: DOCS (Nanashi Li)
 extension GitHubAccount {
-    func postPublicKey(_ session: GitURLSession = URLSession.shared,
-                       publicKey: String,
-                       title: String,
-                       completion: @escaping (_ response: Result<String, Error>) -> Void
+    func postPublicKey(
+        _ session: GitURLSession = URLSession.shared,
+        publicKey: String,
+        title: String,
+        completion: @escaping (_ response: Result<String, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitHubPublicKeyRouter.postPublicKey(publicKey, title, configuration)
 

--- a/CodeEdit/Features/Git/Accounts/GitLab/GitLabOAuthConfiguration.swift
+++ b/CodeEdit/Features/Git/Accounts/GitLab/GitLabOAuthConfiguration.swift
@@ -17,8 +17,12 @@ struct GitLabOAuthConfiguration: GitRouterConfiguration {
     let webEndpoint: String
     let errorDomain = "com.codeedit.models.accounts.gitlab"
 
-    init(_ url: String = GitURL.gitlabBaseURL, webURL: String = GitURL.gitlabWebURL,
-         token: String, secret: String, redirectURI: String
+    init(
+        _ url: String = GitURL.gitlabBaseURL,
+        webURL: String = GitURL.gitlabWebURL,
+        token: String,
+        secret: String,
+        redirectURI: String
     ) {
         apiEndpoint = url
         webEndpoint = webURL
@@ -31,9 +35,10 @@ struct GitLabOAuthConfiguration: GitRouterConfiguration {
         GitLabOAuthRouter.authorize(self, redirectURI).URLRequest?.url
     }
 
-    func authorize(_ session: GitURLSession = URLSession.shared,
-                   code: String,
-                   completion: @escaping (_ config: GitLabTokenConfiguration) -> Void
+    func authorize(
+        _ session: GitURLSession = URLSession.shared,
+        code: String,
+        completion: @escaping (_ config: GitLabTokenConfiguration) -> Void
     ) {
         let request = GitLabOAuthRouter.accessToken(self, code, redirectURI).URLRequest
         if let request = request {
@@ -62,9 +67,10 @@ struct GitLabOAuthConfiguration: GitRouterConfiguration {
         }
     }
 
-    func handleOpenURL(_ session: GitURLSession = URLSession.shared,
-                       url: URL,
-                       completion: @escaping (_ config: GitLabTokenConfiguration) -> Void
+    func handleOpenURL(
+        _ session: GitURLSession = URLSession.shared,
+        url: URL,
+        completion: @escaping (_ config: GitLabTokenConfiguration) -> Void
     ) {
         if let code = url.absoluteString.components(separatedBy: "=").last {
             authorize(session, code: code) { (config) in

--- a/CodeEdit/Features/Git/Accounts/GitLab/GitLabOAuthConfiguration.swift
+++ b/CodeEdit/Features/Git/Accounts/GitLab/GitLabOAuthConfiguration.swift
@@ -51,8 +51,10 @@ struct GitLabOAuthConfiguration: GitRouterConfiguration {
                             return
                         }
                         do {
-                            let json = try JSONSerialization.jsonObject(with: data,
-                                                                        options: .allowFragments) as? [String: Any]
+                            let json = try JSONSerialization.jsonObject(
+                                with: data,
+                                options: .allowFragments
+                            ) as? [String: Any]
                             if let json = json, let accessToken = json["access_token"] as? String {
                                 let config = GitLabTokenConfiguration(accessToken, url: self.apiEndpoint ?? "")
                                 completion(config)

--- a/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabAccountModel.swift
+++ b/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabAccountModel.swift
@@ -22,16 +22,17 @@ extension GitLabAccount {
      set to `true` to only show simple info.
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func projects(_ session: GitURLSession = URLSession.shared,
-                  page: String = "1",
-                  perPage: String = "20",
-                  archived: Bool = false,
-                  visibility: GitLabVisibility = GitLabVisibility.all,
-                  orderBy: GitLabOrderBy = GitLabOrderBy.creationDate,
-                  sort: GitLabSort = GitLabSort.descending,
-                  search: String = "",
-                  simple: Bool = false,
-                  completion: @escaping (_ response: Result<[GitLabProject], Error>) -> Void
+    func projects(
+        _ session: GitURLSession = URLSession.shared,
+        page: String = "1",
+        perPage: String = "20",
+        archived: Bool = false,
+        visibility: GitLabVisibility = GitLabVisibility.all,
+        orderBy: GitLabOrderBy = GitLabOrderBy.creationDate,
+        sort: GitLabSort = GitLabSort.descending,
+        search: String = "",
+        simple: Bool = false,
+        completion: @escaping (_ response: Result<[GitLabProject], Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabProjectRouter.readAuthenticatedProjects(configuration: configuration,
                                                              page: page,
@@ -62,9 +63,10 @@ extension GitLabAccount {
      Make sure that the namespace/project-name is URL-encoded, eg. "%2F" for "/".
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func project(_ session: GitURLSession = URLSession.shared,
-                 id: String,
-                 completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
+    func project(
+        _ session: GitURLSession = URLSession.shared,
+        id: String,
+        completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabProjectRouter.readSingleProject(configuration: configuration, id: id)
 
@@ -96,16 +98,17 @@ extension GitLabAccount {
      set to `true` to only show simple info.
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func visibleProjects(_ session: GitURLSession = URLSession.shared,
-                         page: String = "1",
-                         perPage: String = "20",
-                         archived: Bool = false,
-                         visibility: GitLabVisibility = GitLabVisibility.all,
-                         orderBy: GitLabOrderBy = GitLabOrderBy.creationDate,
-                         sort: GitLabSort = GitLabSort.descending,
-                         search: String = "",
-                         simple: Bool = false,
-                         completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
+    func visibleProjects(
+        _ session: GitURLSession = URLSession.shared,
+        page: String = "1",
+        perPage: String = "20",
+        archived: Bool = false,
+        visibility: GitLabVisibility = GitLabVisibility.all,
+        orderBy: GitLabOrderBy = GitLabOrderBy.creationDate,
+        sort: GitLabSort = GitLabSort.descending,
+        search: String = "",
+        simple: Bool = false,
+        completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabProjectRouter.readVisibleProjects(configuration: configuration,
                                                        page: page,
@@ -145,16 +148,17 @@ extension GitLabAccount {
      set to `true` to only show simple info.
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func ownedProjects(_ session: GitURLSession = URLSession.shared,
-                       page: String = "1",
-                       perPage: String = "20",
-                       archived: Bool = false,
-                       visibility: GitLabVisibility = GitLabVisibility.all,
-                       orderBy: GitLabOrderBy = GitLabOrderBy.creationDate,
-                       sort: GitLabSort = GitLabSort.descending,
-                       search: String = "",
-                       simple: Bool = false,
-                       completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
+    func ownedProjects(
+        _ session: GitURLSession = URLSession.shared,
+        page: String = "1",
+        perPage: String = "20",
+        archived: Bool = false,
+        visibility: GitLabVisibility = GitLabVisibility.all,
+        orderBy: GitLabOrderBy = GitLabOrderBy.creationDate,
+        sort: GitLabSort = GitLabSort.descending,
+        search: String = "",
+        simple: Bool = false,
+        completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabProjectRouter.readOwnedProjects(configuration: configuration,
                                                      page: page,
@@ -194,16 +198,17 @@ extension GitLabAccount {
      Default is false, set to `true` to only show simple info.
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func starredProjects(_ session: GitURLSession = URLSession.shared,
-                         page: String = "1",
-                         perPage: String = "20",
-                         archived: Bool = false,
-                         visibility: GitLabVisibility = GitLabVisibility.all,
-                         orderBy: GitLabOrderBy = GitLabOrderBy.creationDate,
-                         sort: GitLabSort = GitLabSort.descending,
-                         search: String = "",
-                         simple: Bool = false,
-                         completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
+    func starredProjects(
+        _ session: GitURLSession = URLSession.shared,
+        page: String = "1",
+        perPage: String = "20",
+        archived: Bool = false,
+        visibility: GitLabVisibility = GitLabVisibility.all,
+        orderBy: GitLabOrderBy = GitLabOrderBy.creationDate,
+        sort: GitLabSort = GitLabSort.descending,
+        search: String = "",
+        simple: Bool = false,
+        completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabProjectRouter.readStarredProjects(configuration: configuration,
                                                        page: page,
@@ -243,16 +248,17 @@ extension GitLabAccount {
      Default is false, set to `true` to only show simple info.
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func allProjects(_ session: GitURLSession = URLSession.shared,
-                     page: String = "1",
-                     perPage: String = "20",
-                     archived: Bool = false,
-                     visibility: GitLabVisibility = GitLabVisibility.all,
-                     orderBy: GitLabOrderBy = GitLabOrderBy.creationDate,
-                     sort: GitLabSort = GitLabSort.descending,
-                     search: String = "",
-                     simple: Bool = false,
-                     completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
+    func allProjects(
+        _ session: GitURLSession = URLSession.shared,
+        page: String = "1",
+        perPage: String = "20",
+        archived: Bool = false,
+        visibility: GitLabVisibility = GitLabVisibility.all,
+        orderBy: GitLabOrderBy = GitLabOrderBy.creationDate,
+        sort: GitLabSort = GitLabSort.descending,
+        search: String = "",
+        simple: Bool = false,
+        completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabProjectRouter.readAllProjects(configuration: configuration,
                                                    page: page,
@@ -285,11 +291,12 @@ extension GitLabAccount {
      - parameter id: The ID or NAMESPACE/PROJECT_NAME of the project.
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func projectEvents(_ session: GitURLSession = URLSession.shared,
-                       id: String,
-                       page: String = "1",
-                       perPage: String = "20",
-                       completion: @escaping (_ response: Result<GitLabEvent, Error>) -> Void
+    func projectEvents(
+        _ session: GitURLSession = URLSession.shared,
+        id: String,
+        page: String = "1",
+        perPage: String = "20",
+        completion: @escaping (_ response: Result<GitLabEvent, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabProjectRouter.readProjectEvents(configuration: configuration,
                                                      id: id,

--- a/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabAccountModel.swift
+++ b/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabAccountModel.swift
@@ -34,18 +34,22 @@ extension GitLabAccount {
         simple: Bool = false,
         completion: @escaping (_ response: Result<[GitLabProject], Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
-        let router = GitLabProjectRouter.readAuthenticatedProjects(configuration: configuration,
-                                                             page: page,
-                                                             perPage: perPage,
-                                                             archived: archived,
-                                                             visibility: visibility,
-                                                             orderBy: orderBy,
-                                                             sort: sort,
-                                                             search: search,
-                                                             simple: simple)
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabProject.self) { json, error in
+        let router = GitLabProjectRouter.readAuthenticatedProjects(
+            configuration: configuration,
+            page: page,
+            perPage: perPage,
+            archived: archived,
+            visibility: visibility,
+            orderBy: orderBy,
+            sort: sort,
+            search: search,
+            simple: simple
+        )
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabProject.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))
@@ -70,9 +74,11 @@ extension GitLabAccount {
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabProjectRouter.readSingleProject(configuration: configuration, id: id)
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabProject.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabProject.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))
@@ -110,19 +116,23 @@ extension GitLabAccount {
         simple: Bool = false,
         completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
-        let router = GitLabProjectRouter.readVisibleProjects(configuration: configuration,
-                                                       page: page,
-                                                       perPage: perPage,
-                                                       archived: archived,
-                                                       visibility: visibility,
-                                                       orderBy: orderBy,
-                                                       sort: sort,
-                                                       search: search,
-                                                       simple: simple)
+        let router = GitLabProjectRouter.readVisibleProjects(
+            configuration: configuration,
+            page: page,
+            perPage: perPage,
+            archived: archived,
+            visibility: visibility,
+            orderBy: orderBy,
+            sort: sort,
+            search: search,
+            simple: simple
+        )
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabProject.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabProject.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))
@@ -160,19 +170,23 @@ extension GitLabAccount {
         simple: Bool = false,
         completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
-        let router = GitLabProjectRouter.readOwnedProjects(configuration: configuration,
-                                                     page: page,
-                                                     perPage: perPage,
-                                                     archived: archived,
-                                                     visibility: visibility,
-                                                     orderBy: orderBy,
-                                                     sort: sort,
-                                                     search: search,
-                                                     simple: simple)
+        let router = GitLabProjectRouter.readOwnedProjects(
+            configuration: configuration,
+            page: page,
+            perPage: perPage,
+            archived: archived,
+            visibility: visibility,
+            orderBy: orderBy,
+            sort: sort,
+            search: search,
+            simple: simple
+        )
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabProject.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabProject.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))
@@ -210,19 +224,23 @@ extension GitLabAccount {
         simple: Bool = false,
         completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
-        let router = GitLabProjectRouter.readStarredProjects(configuration: configuration,
-                                                       page: page,
-                                                       perPage: perPage,
-                                                       archived: archived,
-                                                       visibility: visibility,
-                                                       orderBy: orderBy,
-                                                       sort: sort,
-                                                       search: search,
-                                                       simple: simple)
+        let router = GitLabProjectRouter.readStarredProjects(
+            configuration: configuration,
+            page: page,
+            perPage: perPage,
+            archived: archived,
+            visibility: visibility,
+            orderBy: orderBy,
+            sort: sort,
+            search: search,
+            simple: simple
+        )
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabProject.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabProject.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))
@@ -260,19 +278,23 @@ extension GitLabAccount {
         simple: Bool = false,
         completion: @escaping (_ response: Result<GitLabProject, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
-        let router = GitLabProjectRouter.readAllProjects(configuration: configuration,
-                                                   page: page,
-                                                   perPage: perPage,
-                                                   archived: archived,
-                                                   visibility: visibility,
-                                                   orderBy: orderBy,
-                                                   sort: sort,
-                                                   search: search,
-                                                   simple: simple)
+        let router = GitLabProjectRouter.readAllProjects(
+            configuration: configuration,
+            page: page,
+            perPage: perPage,
+            archived: archived,
+            visibility: visibility,
+            orderBy: orderBy,
+            sort: sort,
+            search: search,
+            simple: simple
+        )
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabProject.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabProject.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))
@@ -298,14 +320,18 @@ extension GitLabAccount {
         perPage: String = "20",
         completion: @escaping (_ response: Result<GitLabEvent, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
-        let router = GitLabProjectRouter.readProjectEvents(configuration: configuration,
-                                                     id: id,
-                                                     page: page,
-                                                     perPage: perPage)
+        let router = GitLabProjectRouter.readProjectEvents(
+            configuration: configuration,
+            id: id,
+            page: page,
+            perPage: perPage
+        )
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabEvent.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabEvent.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))

--- a/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabCommit.swift
+++ b/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabCommit.swift
@@ -125,12 +125,13 @@ extension GitLabAccount {
      - parameter until: Only commits before or in this date will be returned in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ.
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func commits(_ session: GitURLSession = URLSession.shared,
-                 id: String,
-                 refName: String = "",
-                 since: String = "",
-                 until: String = "",
-                 completion: @escaping (_ response: Result<GitLabCommit, Error>) -> Void
+    func commits(
+        _ session: GitURLSession = URLSession.shared,
+        id: String,
+        refName: String = "",
+        since: String = "",
+        until: String = "",
+        completion: @escaping (_ response: Result<GitLabCommit, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabCommitRouter.readCommits(self.configuration,
                                               id: id,
@@ -158,10 +159,11 @@ extension GitLabAccount {
      - parameter sha: The commit hash or name of a repository branch or tag.
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func commit(_ session: GitURLSession = URLSession.shared,
-                id: String,
-                sha: String,
-                completion: @escaping (_ response: Result<GitLabCommit, Error>) -> Void
+    func commit(
+        _ session: GitURLSession = URLSession.shared,
+        id: String,
+        sha: String,
+        completion: @escaping (_ response: Result<GitLabCommit, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabCommitRouter.readCommit(self.configuration, id: id, sha: sha)
 
@@ -185,10 +187,11 @@ extension GitLabAccount {
      - parameter sha: The commit hash or name of a repository branch or tag.
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func commitDiffs(_ session: GitURLSession = URLSession.shared,
-                     id: String,
-                     sha: String,
-                     completion: @escaping (_ response: Result<GitLabCommitDiff, Error>) -> Void
+    func commitDiffs(
+        _ session: GitURLSession = URLSession.shared,
+        id: String,
+        sha: String,
+        completion: @escaping (_ response: Result<GitLabCommitDiff, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabCommitRouter.readCommitDiffs(self.configuration, id: id, sha: sha)
 
@@ -212,10 +215,11 @@ extension GitLabAccount {
      - parameter sha: The commit hash or name of a repository branch or tag.
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func commitComments(_ session: GitURLSession = URLSession.shared,
-                        id: String,
-                        sha: String,
-                        completion: @escaping (_ response: Result<GitLabCommitComment, Error>) -> Void
+    func commitComments(
+        _ session: GitURLSession = URLSession.shared,
+        id: String,
+        sha: String,
+        completion: @escaping (_ response: Result<GitLabCommitComment, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabCommitRouter.readCommitComments(self.configuration, id: id, sha: sha)
 
@@ -243,14 +247,15 @@ extension GitLabAccount {
      - parameter all: Return all statuses, not only the latest ones. (Boolean value)
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func commitStatuses(_ session: GitURLSession = URLSession.shared,
-                        id: String,
-                        sha: String,
-                        ref: String = "",
-                        stage: String = "",
-                        name: String = "",
-                        all: Bool = false,
-                        completion: @escaping (_ response: Result<GitLabCommitStatus, Error>) -> Void
+    func commitStatuses(
+        _ session: GitURLSession = URLSession.shared,
+        id: String,
+        sha: String,
+        ref: String = "",
+        stage: String = "",
+        name: String = "",
+        all: Bool = false,
+        completion: @escaping (_ response: Result<GitLabCommitStatus, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabCommitRouter.readCommitStatuses(self.configuration, id: id,
                                                      sha: sha,

--- a/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabCommit.swift
+++ b/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabCommit.swift
@@ -133,15 +133,19 @@ extension GitLabAccount {
         until: String = "",
         completion: @escaping (_ response: Result<GitLabCommit, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
-        let router = GitLabCommitRouter.readCommits(self.configuration,
-                                              id: id,
-                                              refName: refName,
-                                              since: since,
-                                              until: until)
+        let router = GitLabCommitRouter.readCommits(
+            self.configuration,
+            id: id,
+            refName: refName,
+            since: since,
+            until: until
+        )
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabCommit.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabCommit.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))
@@ -167,9 +171,11 @@ extension GitLabAccount {
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabCommitRouter.readCommit(self.configuration, id: id, sha: sha)
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabCommit.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabCommit.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))
@@ -195,9 +201,11 @@ extension GitLabAccount {
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabCommitRouter.readCommitDiffs(self.configuration, id: id, sha: sha)
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabCommitDiff.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabCommitDiff.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))
@@ -223,9 +231,11 @@ extension GitLabAccount {
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabCommitRouter.readCommitComments(self.configuration, id: id, sha: sha)
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabCommitComment.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabCommitComment.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))
@@ -257,16 +267,20 @@ extension GitLabAccount {
         all: Bool = false,
         completion: @escaping (_ response: Result<GitLabCommitStatus, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
-        let router = GitLabCommitRouter.readCommitStatuses(self.configuration, id: id,
-                                                     sha: sha,
-                                                     ref: ref,
-                                                     stage: stage,
-                                                     name: name,
-                                                     all: all)
+        let router = GitLabCommitRouter.readCommitStatuses(
+            self.configuration, id: id,
+            sha: sha,
+            ref: ref,
+            stage: stage,
+            name: name,
+            all: all
+        )
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabCommitStatus.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabCommitStatus.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))

--- a/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabProjectHook.swift
+++ b/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabProjectHook.swift
@@ -54,9 +54,11 @@ extension GitLabAccount {
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabProjectRouter.readProjectHooks(configuration: configuration, id: id)
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabProjectHook.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabProjectHook.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))
@@ -82,13 +84,17 @@ extension GitLabAccount {
         hookId: String,
         completion: @escaping (_ response: Result<GitLabProjectHook, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
-        let router = GitLabProjectRouter.readProjectHook(configuration: configuration,
-                                                   id: id,
-                                                   hookId: hookId)
+        let router = GitLabProjectRouter.readProjectHook(
+            configuration: configuration,
+            id: id,
+            hookId: hookId
+        )
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabProjectHook.self) { json, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabProjectHook.self
+        ) { json, error in
 
             if let error = error {
                 completion(Result.failure(error))

--- a/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabProjectHook.swift
+++ b/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabProjectHook.swift
@@ -47,9 +47,10 @@ extension GitLabAccount {
      Make sure that the namespace/project-name is URL-encoded, eg. "%2F" for "/".
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func projectHooks(_ session: GitURLSession = URLSession.shared,
-                      id: String,
-                      completion: @escaping (_ response: Result<GitLabProjectHook, Error>) -> Void
+    func projectHooks(
+        _ session: GitURLSession = URLSession.shared,
+        id: String,
+        completion: @escaping (_ response: Result<GitLabProjectHook, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabProjectRouter.readProjectHooks(configuration: configuration, id: id)
 
@@ -75,10 +76,11 @@ extension GitLabAccount {
      (you can get the ID of a hook by searching for it with the **allProjectHooks** request).
      - parameter completion: Callback for the outcome of the fetch.
      */
-    func projectHook(_ session: GitURLSession = URLSession.shared,
-                     id: String,
-                     hookId: String,
-                     completion: @escaping (_ response: Result<GitLabProjectHook, Error>) -> Void
+    func projectHook(
+        _ session: GitURLSession = URLSession.shared,
+        id: String,
+        hookId: String,
+        completion: @escaping (_ response: Result<GitLabProjectHook, Error>) -> Void
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabProjectRouter.readProjectHook(configuration: configuration,
                                                    id: id,

--- a/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabUser.swift
+++ b/CodeEdit/Features/Git/Accounts/GitLab/Model/GitLabUser.swift
@@ -68,9 +68,11 @@ extension GitLabAccount {
     ) -> GitURLSessionDataTaskProtocol? {
         let router = GitLabUserRouter.readAuthenticatedUser(self.configuration)
 
-        return router.load(session,
-                           dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
-                           expectedResultType: GitLabUser.self) { data, error in
+        return router.load(
+            session,
+            dateDecodingStrategy: .formatted(GitTime.rfc3339DateFormatter),
+            expectedResultType: GitLabUser.self
+        ) { data, error in
 
             if let error = error {
                 completion(Result.failure(error))

--- a/CodeEdit/Features/Git/Accounts/GitLab/Routers/GitLabProjectRouter.swift
+++ b/CodeEdit/Features/Git/Accounts/GitLab/Routers/GitLabProjectRouter.swift
@@ -117,7 +117,8 @@ enum GitLabProjectRouter: GitRouter {
             orderBy,
             sort,
             search,
-            simple):
+            simple
+        ):
             return [
                 "page": page,
                 "per_page": perPage,
@@ -126,7 +127,8 @@ enum GitLabProjectRouter: GitRouter {
                 "order_by": orderBy,
                 "sort": sort,
                 "search": search,
-                "simple": String(simple)]
+                "simple": String(simple)
+            ]
         case let .readVisibleProjects(
             _,
             page,
@@ -136,7 +138,8 @@ enum GitLabProjectRouter: GitRouter {
             orderBy,
             sort,
             search,
-            simple):
+            simple
+        ):
             return [
                 "page": page,
                 "per_page": perPage,
@@ -145,7 +148,8 @@ enum GitLabProjectRouter: GitRouter {
                 "order_by": orderBy,
                 "sort": sort,
                 "search": search,
-                "simple": String(simple)]
+                "simple": String(simple)
+            ]
         case let .readOwnedProjects(
             _,
             page,
@@ -155,7 +159,8 @@ enum GitLabProjectRouter: GitRouter {
             orderBy,
             sort,
             search,
-            simple):
+            simple
+        ):
             return [
                 "page": page,
                 "per_page": perPage,
@@ -164,7 +169,8 @@ enum GitLabProjectRouter: GitRouter {
                 "order_by": orderBy,
                 "sort": sort,
                 "search": search,
-                "simple": String(simple)]
+                "simple": String(simple)
+            ]
         case let .readStarredProjects(
             _,
             page,
@@ -174,7 +180,8 @@ enum GitLabProjectRouter: GitRouter {
             orderBy,
             sort,
             search,
-            simple):
+            simple
+        ):
             return [
                 "page": page,
                 "per_page": perPage,
@@ -183,7 +190,8 @@ enum GitLabProjectRouter: GitRouter {
                 "order_by": orderBy,
                 "sort": sort,
                 "search": search,
-                "simple": String(simple)]
+                "simple": String(simple)
+            ]
         case let .readAllProjects(
             _,
             page,
@@ -193,7 +201,8 @@ enum GitLabProjectRouter: GitRouter {
             orderBy,
             sort,
             search,
-            simple):
+            simple
+        ):
             return [
                 "page": page,
                 "per_page": perPage,
@@ -202,7 +211,8 @@ enum GitLabProjectRouter: GitRouter {
                 "order_by": orderBy,
                 "sort": sort,
                 "search": search,
-                "simple": String(simple)]
+                "simple": String(simple)
+            ]
         case .readSingleProject:
             return [:]
         case let .readProjectEvents(_, _, page, perPage):

--- a/CodeEdit/Features/Git/Accounts/Networking/GitJSONPostRouter.swift
+++ b/CodeEdit/Features/Git/Accounts/Networking/GitJSONPostRouter.swift
@@ -67,21 +67,21 @@ extension GitJSONPostRouter {
                     var userInfo = [String: Any]()
                     if let data = data, let json = try? JSONSerialization.jsonObject(
                         with: data,
-                        options: .mutableContainers) as? [String: Any] {
+                        options: .mutableContainers
+                    ) as? [String: Any] {
 
                         userInfo[gitErrorKey] = json as Any?
 
-                    } else if let data = data, let string = String(
-                        data: data,
-                        encoding: String.Encoding.utf8) {
-
+                    } else if let data = data,
+                              let string = String(data: data, encoding: .utf8) {
                         userInfo[gitErrorKey] = string as Any?
                     }
 
                     let error = NSError(
                         domain: self.configuration?.errorDomain ?? "",
                         code: response.statusCode,
-                        userInfo: userInfo)
+                        userInfo: userInfo
+                    )
 
                     completion(nil, error)
                     return
@@ -123,7 +123,8 @@ extension GitJSONPostRouter {
                 var userInfo = [String: Any]()
                 if let json = try? JSONSerialization.jsonObject(
                     with: responseTuple.0,
-                    options: .mutableContainers) as? [String: Any] {
+                    options: .mutableContainers
+                ) as? [String: Any] {
 
                     userInfo[gitErrorKey] = json as Any?
 
@@ -162,7 +163,8 @@ extension GitJSONPostRouter {
                 var userInfo = [String: Any]()
                 if let data = data, let json = try? JSONSerialization.jsonObject(
                     with: data,
-                    options: .mutableContainers) as? [String: Any] {
+                    options: .mutableContainers
+                ) as? [String: Any] {
 
                     userInfo[gitErrorKey] = json as Any?
 
@@ -172,7 +174,8 @@ extension GitJSONPostRouter {
                 let error = NSError(
                     domain: self.configuration?.errorDomain ?? "",
                     code: response.statusCode,
-                    userInfo: userInfo)
+                    userInfo: userInfo
+                )
 
                 completion(nil, error)
 
@@ -214,7 +217,8 @@ extension GitJSONPostRouter {
             var userInfo = [String: Any]()
             if let json = try? JSONSerialization.jsonObject(
                 with: responseTuple.0,
-                options: .mutableContainers) as? [String: Any] {
+                options: .mutableContainers
+            ) as? [String: Any] {
 
                 userInfo[gitErrorKey] = json as Any?
             } else if let string = String(data: responseTuple.0, encoding: String.Encoding.utf8) {

--- a/CodeEdit/Features/Git/Accounts/Networking/GitJSONPostRouter.swift
+++ b/CodeEdit/Features/Git/Accounts/Networking/GitJSONPostRouter.swift
@@ -18,13 +18,15 @@ protocol GitJSONPostRouter: GitRouter {
     func postJSON<T>(
         _ session: GitURLSession,
         expectedResultType: T.Type,
-        completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> GitURLSessionDataTaskProtocol?
+        completion: @escaping (_ json: T?, _ error: Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol?
 
     func post<T: Codable>(
         _ session: GitURLSession,
         decoder: JSONDecoder,
         expectedResultType: T.Type,
-        completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> GitURLSessionDataTaskProtocol?
+        completion: @escaping (_ json: T?, _ error: Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol?
 
     #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -34,7 +36,8 @@ protocol GitJSONPostRouter: GitRouter {
     func post<T: Codable>(
         _ session: GitURLSession,
         decoder: JSONDecoder,
-        expectedResultType: T.Type) async throws -> T
+        expectedResultType: T.Type
+    ) async throws -> T
     #endif
 }
 
@@ -42,7 +45,8 @@ extension GitJSONPostRouter {
     func postJSON<T>(
         _ session: GitURLSession = URLSession.shared,
         expectedResultType _: T.Type,
-        completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ json: T?, _ error: Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         guard let request = request() else {
             return nil
@@ -105,7 +109,8 @@ extension GitJSONPostRouter {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postJSON<T>(
         _ session: GitURLSession = URLSession.shared,
-        expectedResultType _: T.Type) async throws -> T? {
+        expectedResultType _: T.Type
+    ) async throws -> T? {
 
         guard let request = request() else {
             throw NSError(domain: configuration?.errorDomain ?? "", code: -876, userInfo: nil)
@@ -137,7 +142,8 @@ extension GitJSONPostRouter {
         _ session: GitURLSession = URLSession.shared,
         decoder: JSONDecoder = JSONDecoder(),
         expectedResultType _: T.Type,
-        completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ json: T?, _ error: Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         guard let request = request() else {
             return nil
@@ -195,7 +201,8 @@ extension GitJSONPostRouter {
     func post<T: Codable>(
         _ session: GitURLSession,
         decoder: JSONDecoder = JSONDecoder(),
-        expectedResultType _: T.Type) async throws -> T {
+        expectedResultType _: T.Type
+    ) async throws -> T {
 
         guard let request = request() else {
             throw NSError(domain: configuration?.errorDomain ?? "", code: -876, userInfo: nil)

--- a/CodeEdit/Features/Git/Accounts/Networking/GitRouter.swift
+++ b/CodeEdit/Features/Git/Accounts/Networking/GitRouter.swift
@@ -68,19 +68,22 @@ protocol GitRouter {
     func loadJSON<T: Codable>(
         _ session: GitURLSession,
         expectedResultType: T.Type,
-        completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> GitURLSessionDataTaskProtocol?
+        completion: @escaping (_ json: T?, _ error: Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol?
 
     func load<T: Codable>(
         _ session: GitURLSession,
         dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?,
         expectedResultType: T.Type,
-        completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> GitURLSessionDataTaskProtocol?
+        completion: @escaping (_ json: T?, _ error: Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol?
 
     func load<T: Codable>(
         _ session: GitURLSession,
         decoder: JSONDecoder,
         expectedResultType: T.Type,
-        completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> GitURLSessionDataTaskProtocol?
+        completion: @escaping (_ json: T?, _ error: Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol?
 
     func request() -> URLRequest?
 }
@@ -194,7 +197,8 @@ extension GitRouter {
     func loadJSON<T: Codable>(
         _ session: GitURLSession = URLSession.shared,
         expectedResultType: T.Type,
-        completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ json: T?, _ error: Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
         load(session, expectedResultType: expectedResultType, completion: completion)
     }
 
@@ -202,7 +206,8 @@ extension GitRouter {
         _ session: GitURLSession = URLSession.shared,
         dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?,
         expectedResultType: T.Type,
-        completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ json: T?, _ error: Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         let decoder = JSONDecoder()
 
@@ -216,7 +221,8 @@ extension GitRouter {
     func load<T: Codable>(
         _ session: GitURLSession = URLSession.shared,
         decoder: JSONDecoder = JSONDecoder(), expectedResultType _: T.Type,
-        completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ json: T?, _ error: Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         guard let request = request() else {
             return nil
@@ -265,7 +271,8 @@ extension GitRouter {
     func load<T: Codable>(
         _ session: GitURLSession = URLSession.shared,
         decoder: JSONDecoder = JSONDecoder(),
-        expectedResultType _: T.Type) async throws -> T {
+        expectedResultType _: T.Type
+    ) async throws -> T {
 
         guard let request = request() else {
             throw NSError(domain: configuration?.errorDomain ?? "", code: -876, userInfo: nil)
@@ -295,7 +302,8 @@ extension GitRouter {
     func load<T: Codable>(
         _ session: GitURLSession = URLSession.shared,
         dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?,
-        expectedResultType: T.Type) async throws -> T {
+        expectedResultType: T.Type
+    ) async throws -> T {
 
         let decoder = JSONDecoder()
 
@@ -308,7 +316,8 @@ extension GitRouter {
 
     func load(
         _ session: GitURLSession = URLSession.shared,
-        completion: @escaping (_ error: Error?) -> Void) -> GitURLSessionDataTaskProtocol? {
+        completion: @escaping (_ error: Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol? {
 
         guard let request = request() else {
             return nil

--- a/CodeEdit/Features/Git/Accounts/Networking/GitRouter.swift
+++ b/CodeEdit/Features/Git/Accounts/Networking/GitRouter.swift
@@ -132,13 +132,15 @@ extension GitRouter {
             switch value {
             case let value as String:
                 if let escapedValue = value.addingPercentEncoding(
-                    withAllowedCharacters: CharacterSet.URLQueryAllowedCharacterSet()) {
+                    withAllowedCharacters: CharacterSet.URLQueryAllowedCharacterSet()
+                ) {
                     components.append(URLQueryItem(name: key, value: escapedValue))
                 }
             case let valueArray as [String]:
                 for (index, item) in valueArray.enumerated() {
                     if let escapedValue = item.addingPercentEncoding(
-                        withAllowedCharacters: CharacterSet.URLQueryAllowedCharacterSet()) {
+                        withAllowedCharacters: CharacterSet.URLQueryAllowedCharacterSet()
+                    ) {
                         components.append(URLQueryItem(name: "\(key)[\(index)]", value: escapedValue))
                     }
                 }
@@ -146,7 +148,8 @@ extension GitRouter {
                 for nestedKey in valueDict.keys.sorted(by: <) {
                     guard let value = valueDict[nestedKey] as? String else { continue }
                     if let escapedValue = value.addingPercentEncoding(
-                        withAllowedCharacters: CharacterSet.URLQueryAllowedCharacterSet()) {
+                        withAllowedCharacters: CharacterSet.URLQueryAllowedCharacterSet()
+                    ) {
                         components.append(URLQueryItem(name: "\(key)[\(nestedKey)]", value: escapedValue))
                     }
                 }
@@ -234,7 +237,8 @@ extension GitRouter {
                     var userInfo = [String: Any]()
                     if let data = data, let json = try? JSONSerialization.jsonObject(
                         with: data,
-                        options: .mutableContainers) as? [String: Any] {
+                        options: .mutableContainers
+                    ) as? [String: Any] {
 
                         userInfo[gitErrorKey] = json as Any?
                     }
@@ -242,7 +246,8 @@ extension GitRouter {
                     let error = NSError(
                         domain: self.configuration?.errorDomain ?? "",
                         code: response.statusCode,
-                        userInfo: userInfo)
+                        userInfo: userInfo
+                    )
 
                     completion(nil, error)
 
@@ -285,7 +290,8 @@ extension GitRouter {
                 var userInfo = [String: Any]()
                 if let json = try? JSONSerialization.jsonObject(
                     with: responseTuple.0,
-                    options: .mutableContainers) as? [String: Any] {
+                    options: .mutableContainers
+                ) as? [String: Any] {
 
                     userInfo[gitErrorKey] = json as Any?
 
@@ -329,7 +335,8 @@ extension GitRouter {
                     var userInfo = [String: Any]()
                     if let data = data, let json = try? JSONSerialization.jsonObject(
                         with: data,
-                        options: .mutableContainers) as? [String: Any] {
+                        options: .mutableContainers
+                    ) as? [String: Any] {
 
                         userInfo[gitErrorKey] = json as Any?
 
@@ -338,7 +345,8 @@ extension GitRouter {
                     let error = NSError(
                         domain: self.configuration?.errorDomain ?? "",
                         code: response.statusCode,
-                        userInfo: userInfo)
+                        userInfo: userInfo
+                    )
 
                     completion(error)
 

--- a/CodeEdit/Features/Git/Accounts/Networking/GitURLSession.swift
+++ b/CodeEdit/Features/Git/Accounts/Networking/GitURLSession.swift
@@ -17,22 +17,28 @@ protocol GitURLSession {
 
     func dataTask(
         with request: URLRequest,
-        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void) -> GitURLSessionDataTaskProtocol
+        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void
+    ) -> GitURLSessionDataTaskProtocol
 
     func uploadTask(
         with request: URLRequest,
         fromData bodyData: Data?,
-        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> GitURLSessionDataTaskProtocol
+        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol
 
 #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func data(for request: URLRequest,
-              delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse)
+    func data(
+        for request: URLRequest,
+        delegate: URLSessionTaskDelegate?
+    ) async throws -> (Data, URLResponse)
 
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func upload(for request: URLRequest,
-                from bodyData: Data,
-                delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse)
+    func upload(
+        for request: URLRequest,
+        from bodyData: Data,
+        delegate: URLSessionTaskDelegate?
+    ) async throws -> (Data, URLResponse)
 #endif
 }
 
@@ -46,14 +52,16 @@ extension URLSession: GitURLSession {
 
     func dataTask(
         with request: URLRequest,
-        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void) -> GitURLSessionDataTaskProtocol {
-            (dataTask(with: request, completionHandler: completionHandler) as URLSessionDataTask)
-        }
+        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void
+    ) -> GitURLSessionDataTaskProtocol {
+        (dataTask(with: request, completionHandler: completionHandler) as URLSessionDataTask)
+    }
 
     func uploadTask(
         with request: URLRequest,
         fromData bodyData: Data?,
-        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> GitURLSessionDataTaskProtocol {
-            uploadTask(with: request, from: bodyData, completionHandler: completionHandler)
-        }
+        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) -> GitURLSessionDataTaskProtocol {
+        uploadTask(with: request, from: bodyData, completionHandler: completionHandler)
+    }
 }

--- a/CodeEdit/Features/Git/Client/GitClient.swift
+++ b/CodeEdit/Features/Git/Client/GitClient.swift
@@ -133,8 +133,10 @@ struct GitClient {
                     .init(rawValue: parameters[safe: 0] ?? "") ?? GitType.unknown
                 }
 
-                return GitChangedFile(changeType: gitType,
-                                    fileLink: url)
+                return GitChangedFile(
+                    changeType: gitType,
+                    fileLink: url
+                )
             }
     }
 

--- a/CodeEdit/Features/Git/Clone/GitCheckoutBranchView+CheckoutBranch.swift
+++ b/CodeEdit/Features/Git/Clone/GitCheckoutBranchView+CheckoutBranch.swift
@@ -15,8 +15,10 @@ extension GitCheckoutBranchView {
             return [""]
         }
         do {
-            let branches = try GitClient(directoryURL: url,
-                                                 shellClient: shellClient).getBranches(true)
+            let branches = try GitClient(
+                directoryURL: url,
+                shellClient: shellClient
+            ).getBranches(true)
             return branches
         } catch {
             return [""]

--- a/CodeEdit/Features/Git/Clone/GitCheckoutBranchView.swift
+++ b/CodeEdit/Features/Git/Clone/GitCheckoutBranchView.swift
@@ -14,9 +14,10 @@ struct GitCheckoutBranchView: View {
     @Binding var repoPath: String
     // TODO: This has to be derived from git
     @State var selectedBranch = "main"
-    init(isPresented: Binding<Bool>,
-         repoPath: Binding<String>,
-         shellClient: ShellClient
+    init(
+        isPresented: Binding<Bool>,
+        repoPath: Binding<String>,
+        shellClient: ShellClient
     ) {
         self.shellClient = shellClient
         self._isPresented = isPresented

--- a/CodeEdit/Features/Git/Clone/GitCloneView.swift
+++ b/CodeEdit/Features/Git/Clone/GitCloneView.swift
@@ -138,8 +138,10 @@ extension GitCloneView {
     private func cloneRepository() {
         do {
             if repoUrlStr == "" {
-                showAlert(alertMsg: "Url cannot be empty",
-                          infoText: "You must specify a repository to clone")
+                showAlert(
+                    alertMsg: "Url cannot be empty",
+                    infoText: "You must specify a repository to clone"
+                )
                 return
             }
             // Parsing repo name
@@ -164,9 +166,11 @@ extension GitCloneView {
                 showAlert(alertMsg: "Error", infoText: "Directory already exists")
                 return
             }
-            try FileManager.default.createDirectory(atPath: repoPath,
-                                                    withIntermediateDirectories: true,
-                                                    attributes: nil)
+            try FileManager.default.createDirectory(
+                atPath: repoPath,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
             gitClient = GitClient(directoryURL: dirUrl, shellClient: shellClient)
 
             cloneCancellable = gitClient?

--- a/CodeEdit/Features/InspectorSidebar/InspectorSidebarToolbarTop.swift
+++ b/CodeEdit/Features/InspectorSidebar/InspectorSidebarToolbarTop.swift
@@ -34,12 +34,16 @@ struct InspectorSidebarToolbarTop: View {
                         .opacity(draggingItem?.imageName == icon.imageName &&
                                  hasChangedLocation &&
                                  drugItemLocation != nil ? 0.0: 1.0)
-                        .onDrop(of: [.utf8PlainText],
-                                delegate: InspectorSidebarDockIconDelegate(item: icon,
-                                                                           current: $draggingItem,
-                                                                           icons: $icons,
-                                                                           hasChangedLocation: $hasChangedLocation,
-                                                                           drugItemLocation: $drugItemLocation))
+                        .onDrop(
+                            of: [.utf8PlainText],
+                            delegate: InspectorSidebarDockIconDelegate(
+                                item: icon,
+                                current: $draggingItem,
+                                icons: $icons,
+                                hasChangedLocation: $hasChangedLocation,
+                                drugItemLocation: $drugItemLocation
+                            )
+                        )
                 }
             }
             .frame(height: 29, alignment: .center)

--- a/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
+++ b/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
@@ -27,11 +27,15 @@ struct InspectorSidebarView: View {
                 if let codeFile = workspace.selectionState.openedCodeFiles[item] {
                     switch selection {
                     case 0:
-                        FileInspectorView(workspaceURL: workspace.fileURL!,
-                                          fileURL: codeFile.fileURL!.path)
+                        FileInspectorView(
+                            workspaceURL: workspace.fileURL!,
+                            fileURL: codeFile.fileURL!.path
+                        )
                     case 1:
-                        HistoryInspectorView(workspaceURL: workspace.fileURL!,
-                                         fileURL: codeFile.fileURL!.path)
+                        HistoryInspectorView(
+                            workspaceURL: workspace.fileURL!,
+                            fileURL: codeFile.fileURL!.path
+                        )
                     case 2:
                         QuickHelpInspectorView().padding(5)
                     default: EmptyView()

--- a/CodeEdit/Features/Keybindings/KeybindingManager.swift
+++ b/CodeEdit/Features/Keybindings/KeybindingManager.swift
@@ -20,8 +20,14 @@ final class KeybindingManager {
     static let shared: KeybindingManager = .init()
 
     // We need this fallback shortcut because optional shortcuts available only from 12.3, while we have target of 12.0x
-    var fallbackShortcut = KeyboardShortcutWrapper(name: "?", description: "Test", context: "Fallback",
-                                                   keybinding: "?", modifier: "shift", id: "fallback")
+    var fallbackShortcut = KeyboardShortcutWrapper(
+        name: "?",
+        description: "Test",
+        context: "Fallback",
+        keybinding: "?",
+        modifier: "shift",
+        id: "fallback"
+    )
 
     /// Adds new shortcut
     func addNewShortcut(shortcut: KeyboardShortcutWrapper, name: String) {

--- a/CodeEdit/Features/NavigatorSidebar/ExtensionNavigator/ExtensionInstallationView.swift
+++ b/CodeEdit/Features/NavigatorSidebar/ExtensionNavigator/ExtensionInstallationView.swift
@@ -43,9 +43,12 @@ struct ExtensionInstallationView: View {
                             do {
                                 if let release = self.model.release {
                                     try await ExtensionsManager.shared?.install(
-                                        plugin: self.model.plugin, release: release)
+                                        plugin: self.model.plugin,
+                                        release: release
+                                    )
                                     self.installed = ExtensionsManager.shared?.isInstalled(
-                                        plugin: model.plugin) ?? false
+                                        plugin: model.plugin
+                                    ) ?? false
                                     if self.installed {
                                         self.reopenAlert = true
                                     }
@@ -76,10 +79,11 @@ struct ExtensionInstallationView: View {
             Button("Reopen workspace") {
                 guard let url = document.fileURL else { return }
                 document.close()
-                CodeEditDocumentController.shared.reopenDocument(for: url,
-                                                                 withContentsOf: url,
-                                                                 display: true) { _, _, _ in
-                }
+                CodeEditDocumentController.shared.reopenDocument(
+                    for: url,
+                    withContentsOf: url,
+                    display: true
+                ) { _, _, _ in }
             }
             Button("Reopen later") {
                 self.reopenAlert = false

--- a/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultFileItem.swift
+++ b/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultFileItem.swift
@@ -23,11 +23,13 @@ struct FindNavigatorResultFileItem: View {
     private var results: [SearchResultModel]
     private var jumpToFile: () -> Void
 
-    init(state: WorkspaceDocument.SearchState,
-         isExpanded: Bool = true,
-         fileItem: WorkspaceClient.FileItem,
-         results: [SearchResultModel],
-         jumpToFile: @escaping () -> Void) {
+    init(
+        state: WorkspaceDocument.SearchState,
+        isExpanded: Bool = true,
+        fileItem: WorkspaceClient.FileItem,
+        results: [SearchResultModel],
+        jumpToFile: @escaping () -> Void
+    ) {
              self.state = state
              self.isExpanded = isExpanded
              self.fileItem = fileItem

--- a/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
+++ b/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
@@ -173,16 +173,19 @@ extension FindNavigatorListViewController: NSOutlineViewDelegate {
         guard let tableColumn = tableColumn else { return nil }
         if let item = item as? SearchResultMatchModel {
             let frameRect = NSRect(x: 0, y: 0, width: tableColumn.width, height: CGFloat.greatestFiniteMagnitude)
-            return FindNavigatorListMatchCell(frame: frameRect,
-                                              matchItem: item)
+            return FindNavigatorListMatchCell(frame: frameRect, matchItem: item)
         } else {
-            let frameRect = NSRect(x: 0,
-                                   y: 0,
-                                   width: tableColumn.width,
-                                   height: prefs.general.projectNavigatorSize.rowHeight)
-            let view = OutlineTableViewCell(frame: frameRect,
-                                            item: (item as? SearchResultModel)?.file,
-                                            isEditable: false)
+            let frameRect = NSRect(
+                x: 0,
+                y: 0,
+                width: tableColumn.width,
+                height: prefs.general.projectNavigatorSize.rowHeight
+            )
+            let view = OutlineTableViewCell(
+                frame: frameRect,
+                item: (item as? SearchResultModel)?.file,
+                isEditable: false
+            )
             // We're using a medium label for file names b/c it makes it easier to
             // distinguish quickly which results are from which files.
             view.label.font = .systemFont(ofSize: 13, weight: .medium)
@@ -222,8 +225,9 @@ extension FindNavigatorListViewController: NSOutlineViewDelegate {
             tempView.attributedStringValue = item.attributedLabel()
             tempView.layout()
             let width = outlineView.frame.width - outlineView.indentationPerLevel*2 - 24
-            return tempView.sizeThatFits(NSSize(width: width,
-                                                height: CGFloat.greatestFiniteMagnitude)).height + 8
+            return tempView.sizeThatFits(
+                NSSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+            ).height + 8
         } else {
             return rowHeight
         }

--- a/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
+++ b/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
@@ -157,9 +157,11 @@ extension FindNavigatorListViewController: NSOutlineViewDataSource {
 
 extension FindNavigatorListViewController: NSOutlineViewDelegate {
 
-    func outlineView(_ outlineView: NSOutlineView,
-                     shouldShowCellExpansionFor tableColumn: NSTableColumn?,
-                     item: Any) -> Bool {
+    func outlineView(
+        _ outlineView: NSOutlineView,
+        shouldShowCellExpansionFor tableColumn: NSTableColumn?,
+        item: Any
+    ) -> Bool {
         return item as? SearchResultModel != nil
     }
 

--- a/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorMatchListCell.swift
+++ b/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorMatchListCell.swift
@@ -16,10 +16,12 @@ final class FindNavigatorListMatchCell: NSTableCellView {
 
     init(frame: CGRect, matchItem: SearchResultMatchModel) {
         self.matchItem = matchItem
-        super.init(frame: CGRect(x: frame.origin.x,
-                                 y: frame.origin.y,
-                                 width: frame.width,
-                                 height: CGFloat.greatestFiniteMagnitude))
+        super.init(frame: CGRect(
+            x: frame.origin.x,
+            y: frame.origin.y,
+            width: frame.width,
+            height: CGFloat.greatestFiniteMagnitude
+        ))
 
         // Create the label
         setUpLabel()
@@ -69,9 +71,11 @@ final class FindNavigatorListMatchCell: NSTableCellView {
     private func setUpImageView() {
         self.icon = NSImageView(frame: .zero)
         self.icon.translatesAutoresizingMaskIntoConstraints = false
-        self.icon.symbolConfiguration = .init(pointSize: 13,
-                                              weight: .regular,
-                                              scale: .medium)
+        self.icon.symbolConfiguration = .init(
+            pointSize: 13,
+            weight: .regular,
+            scale: .medium
+        )
         self.icon.image = NSImage(systemSymbolName: "text.alignleft", accessibilityDescription: nil)
         self.icon.contentTintColor = NSColor.secondaryLabelColor
     }

--- a/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorResultList.swift
+++ b/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorResultList.swift
@@ -27,8 +27,10 @@ struct FindNavigatorResultList: NSViewControllerRepresentable {
     }
 
     func updateNSViewController(_ nsViewController: FindNavigatorListViewController, context: Context) {
-        nsViewController.updateNewSearchResults(workspace.searchState?.searchResult ?? [],
-                                                searchId: workspace.searchState?.searchId)
+        nsViewController.updateNewSearchResults(
+            workspace.searchState?.searchResult ?? [],
+            searchId: workspace.searchState?.searchId
+        )
         if nsViewController.rowHeight != prefs.preferences.general.projectNavigatorSize.rowHeight {
             nsViewController.rowHeight = prefs.preferences.general.projectNavigatorSize.rowHeight
         }
@@ -36,8 +38,10 @@ struct FindNavigatorResultList: NSViewControllerRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(state: workspace.searchState,
-                    controller: nil)
+        Coordinator(
+            state: workspace.searchState,
+            controller: nil
+        )
     }
 
     class Coordinator: NSObject {

--- a/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorSearchBar.swift
+++ b/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorSearchBar.swift
@@ -52,9 +52,11 @@ struct FindNavigatorSearchBar: View {
         }
     }
 
-    init(state: WorkspaceDocument.SearchState,
-         title: String,
-         text: Binding<String>) {
+    init(
+        state: WorkspaceDocument.SearchState,
+        title: String,
+        text: Binding<String>
+    ) {
         self.state = state
         self.title = title
         self._text = text

--- a/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorView.swift
+++ b/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorView.swift
@@ -82,8 +82,7 @@ struct FindNavigatorView: View {
             .padding(.vertical, 5)
             Divider()
             HStack(alignment: .center) {
-                Text(
-                    "\(state.searchResultCount) results in \(foundFilesCount) files")
+                Text("\(state.searchResultCount) results in \(foundFilesCount) files")
                     .font(.system(size: 10))
             }
             Divider()

--- a/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
+++ b/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
@@ -64,11 +64,13 @@ struct NavigatorSidebarToolbarTop: View {
         .fixedSize(horizontal: false, vertical: true)
     }
 
-    private func makeIcon(named: String,
-                          title: String,
-                          id: Int,
-                          scale: Image.Scale = .medium,
-                          sidebarWidth: CGFloat) -> some View {
+    private func makeIcon(
+        named: String,
+        title: String,
+        id: Int,
+        scale: Image.Scale = .medium,
+        sidebarWidth: CGFloat
+    ) -> some View {
         Button {
             selection = id
         } label: {

--- a/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
+++ b/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarTop.swift
@@ -42,12 +42,16 @@ struct NavigatorSidebarToolbarTop: View {
                         .opacity(draggingItem?.imageName == icon.imageName &&
                                  hasChangedLocation &&
                                  drugItemLocation != nil ? 0.0: icon.disabled ? 0.3 : 1.0)
-                        .onDrop(of: [.utf8PlainText],
-                                delegate: NavigatorSidebarDockIconDelegate(item: icon,
-                                                                            current: $draggingItem,
-                                                                            icons: $icons,
-                                                                            hasChangedLocation: $hasChangedLocation,
-                                                                            drugItemLocation: $drugItemLocation))
+                        .onDrop(
+                            of: [.utf8PlainText],
+                            delegate: NavigatorSidebarDockIconDelegate(
+                                item: icon,
+                                current: $draggingItem,
+                                icons: $icons,
+                                hasChangedLocation: $hasChangedLocation,
+                                drugItemLocation: $drugItemLocation
+                            )
+                        )
                         .disabled(icon.disabled)
                 }
             }

--- a/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -27,9 +27,11 @@ final class OutlineTableViewCell: NSTableCellView {
     ///   - frameRect: The frame of the cell.
     ///   - item: The file item the cell represents.
     ///   - isEditable: Set to true if the user should be able to edit the file name.
-    init(frame frameRect: NSRect, item: WorkspaceClient.FileItem?,
-         isEditable: Bool = true,
-         delegate: OutlineTableViewCellDelegate? = nil) {
+    init(
+        frame frameRect: NSRect, item: WorkspaceClient.FileItem?,
+        isEditable: Bool = true,
+        delegate: OutlineTableViewCellDelegate? = nil
+    ) {
         super.init(frame: frameRect)
 
         self.delegate = delegate

--- a/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -155,8 +155,11 @@ extension OutlineViewController: NSOutlineViewDataSource {
 // MARK: - NSOutlineViewDelegate
 
 extension OutlineViewController: NSOutlineViewDelegate {
-    func outlineView(_ outlineView: NSOutlineView,
-                     shouldShowCellExpansionFor tableColumn: NSTableColumn?, item: Any) -> Bool {
+    func outlineView(
+        _ outlineView: NSOutlineView,
+        shouldShowCellExpansionFor tableColumn: NSTableColumn?,
+        item: Any
+    ) -> Bool {
         true
     }
 

--- a/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
+++ b/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineViewController.swift
@@ -248,8 +248,10 @@ extension OutlineViewController: NSOutlineViewDelegate {
 
         if row < 0 {
             let alert = NSAlert()
-            alert.messageText = NSLocalizedString("Could not find file",
-                                                  comment: "Could not find file")
+            alert.messageText = NSLocalizedString(
+                "Could not find file",
+                comment: "Could not find file"
+            )
             alert.runModal()
             return
         } else {

--- a/CodeEdit/Features/NavigatorSidebar/SourceControlNavigator/SourceControlNavigatorView.swift
+++ b/CodeEdit/Features/NavigatorSidebar/SourceControlNavigator/SourceControlNavigatorView.swift
@@ -17,9 +17,11 @@ struct SourceControlNavigatorView: View {
 
     var body: some View {
         VStack {
-            SegmentedControl($selectedSection,
-                             options: ["Changes", "Repositories"],
-                             prominent: true)
+            SegmentedControl(
+                $selectedSection,
+                options: ["Changes", "Repositories"],
+                prominent: true
+            )
             .frame(maxWidth: .infinity)
             .frame(height: 27)
             .padding(.horizontal, 8)

--- a/CodeEdit/Features/NavigatorSidebar/SourceControlNavigator/Views/Changes/SourceControlNavigatorChangesView.swift
+++ b/CodeEdit/Features/NavigatorSidebar/SourceControlNavigator/Views/Changes/SourceControlNavigatorChangesView.swift
@@ -31,9 +31,11 @@ struct SourceControlNavigatorChangesView: View {
                 List(selection: $selectedFile) {
                     Section("Local Changes") {
                         ForEach(model.changed) { file in
-                            SourceControlNavigatorChangedFileView(changedFile: file,
-                                                selection: $selectedFile,
-                                                workspaceURL: model.workspaceURL)
+                            SourceControlNavigatorChangedFileView(
+                                changedFile: file,
+                                selection: $selectedFile,
+                                workspaceURL: model.workspaceURL
+                            )
                         }
                     }
                     .foregroundColor(.secondary)

--- a/CodeEdit/Features/QuickOpen/Views/QuickOpenView.swift
+++ b/CodeEdit/Features/QuickOpen/Views/QuickOpenView.swift
@@ -78,8 +78,10 @@ struct QuickOpenView: View {
         }
             .background(EffectView(.sidebar, blendingMode: .behindWindow))
             .edgesIgnoringSafeArea(.vertical)
-            .frame(minWidth: 600,
-               minHeight: self.state.isShowingOpenQuicklyFiles ? 400 : 28,
-               maxHeight: self.state.isShowingOpenQuicklyFiles ? .infinity : 28)
+            .frame(
+                minWidth: 600,
+                minHeight: self.state.isShowingOpenQuicklyFiles ? 400 : 28,
+                maxHeight: self.state.isShowingOpenQuicklyFiles ? .infinity : 28
+            )
     }
 }

--- a/CodeEdit/Features/Search/Extensions/String+SafeOffset.swift
+++ b/CodeEdit/Features/Search/Extensions/String+SafeOffset.swift
@@ -32,9 +32,7 @@ extension String {
 
             // Return the index offset by the given offset.
             // If this index is nil we return the limit index.
-            return index(idx,
-                         offsetBy: offset,
-                         limitedBy: limitedBy) ?? limitedBy
+            return index(idx, offsetBy: offset, limitedBy: limitedBy) ?? limitedBy
         } else if offset > 0 {
             // If the offset is going forwards, but the limit index
             // is behind in the string we return the original index.
@@ -44,9 +42,7 @@ extension String {
 
             // Return the index offset by the given offset.
             // If this index is nil we return the limit index.
-            return index(idx,
-                         offsetBy: offset,
-                         limitedBy: limitedBy) ?? limitedBy
+            return index(idx, offsetBy: offset, limitedBy: limitedBy) ?? limitedBy
         } else {
             // The offset is 0, so we return the limit index.
             return limitedBy

--- a/CodeEdit/Features/Search/Model/SearchModeModel.swift
+++ b/CodeEdit/Features/Search/Model/SearchModeModel.swift
@@ -14,43 +14,63 @@ struct SearchModeModel {
     let needSelectionHightlight: Bool
 
     static let Containing = SearchModeModel(title: "Containing", children: [], needSelectionHightlight: false)
-    static let MatchingWord = SearchModeModel(title: "Matching Word",
-                                                     children: [],
-                                                     needSelectionHightlight: true)
-    static let StartingWith = SearchModeModel(title: "Starting With",
-                                                     children: [],
-                                                     needSelectionHightlight: true)
+    static let MatchingWord = SearchModeModel(
+        title: "Matching Word",
+        children: [],
+        needSelectionHightlight: true
+    )
+    static let StartingWith = SearchModeModel(
+        title: "Starting With",
+        children: [],
+        needSelectionHightlight: true
+    )
     static let EndingWith = SearchModeModel(title: "Ending With", children: [], needSelectionHightlight: true)
 
-    static let Text = SearchModeModel(title: "Text",
-                                 children: [.Containing, .MatchingWord, .StartingWith, .EndingWith],
-                                 needSelectionHightlight: false)
-    static let References = SearchModeModel(title: "References",
-                                       children: [.Containing, .MatchingWord, .StartingWith, .EndingWith],
-                                       needSelectionHightlight: true)
-    static let Definitions = SearchModeModel(title: "Definitions",
-                                        children: [.Containing, .MatchingWord, .StartingWith, .EndingWith],
-                                        needSelectionHightlight: true)
-    static let RegularExpression = SearchModeModel(title: "Regular Expression",
-                                                   children: [],
-                                                   needSelectionHightlight: true)
-    static let CallHierarchy = SearchModeModel(title: "Call Hierarchy",
-                                                      children: [],
-                                                      needSelectionHightlight: true)
+    static let Text = SearchModeModel(
+        title: "Text",
+        children: [.Containing, .MatchingWord, .StartingWith, .EndingWith],
+        needSelectionHightlight: false
+    )
+    static let References = SearchModeModel(
+        title: "References",
+        children: [.Containing, .MatchingWord, .StartingWith, .EndingWith],
+        needSelectionHightlight: true
+    )
+    static let Definitions = SearchModeModel(
+        title: "Definitions",
+        children: [.Containing, .MatchingWord, .StartingWith, .EndingWith],
+        needSelectionHightlight: true
+    )
+    static let RegularExpression = SearchModeModel(
+        title: "Regular Expression",
+        children: [],
+        needSelectionHightlight: true
+    )
+    static let CallHierarchy = SearchModeModel(
+        title: "Call Hierarchy",
+        children: [],
+        needSelectionHightlight: true
+    )
 
-    static let Find = SearchModeModel(title: "Find",
-                                 children: [.Text, .References, .Definitions, .RegularExpression, .CallHierarchy],
-                                 needSelectionHightlight: false)
-    static let Replace = SearchModeModel(title: "Replace",
-                                    children: [.Text, .RegularExpression],
-                                    needSelectionHightlight: true)
+    static let Find = SearchModeModel(
+        title: "Find",
+        children: [.Text, .References, .Definitions, .RegularExpression, .CallHierarchy],
+        needSelectionHightlight: false
+    )
+    static let Replace = SearchModeModel(
+        title: "Replace",
+        children: [.Text, .RegularExpression],
+        needSelectionHightlight: true
+    )
 
     static let TextMatchingModes: [SearchModeModel] = [.Containing, .MatchingWord, .StartingWith, .EndingWith]
-    static let FindModes: [SearchModeModel] = [.Text,
-                                                      .References,
-                                                      .Definitions,
-                                                      .RegularExpression,
-                                                      .CallHierarchy]
+    static let FindModes: [SearchModeModel] = [
+        .Text,
+        .References,
+        .Definitions,
+        .RegularExpression,
+        .CallHierarchy
+    ]
     static let ReplaceModes: [SearchModeModel] = [.Text, .RegularExpression]
     static let SearchModes: [SearchModeModel] = [.Find, .Replace]
 }

--- a/CodeEdit/Features/Search/Model/SearchResultMatchModel.swift
+++ b/CodeEdit/Features/Search/Model/SearchResultMatchModel.swift
@@ -10,10 +10,11 @@ import Cocoa
 
 /// A struct for holding information about a search match.
 class SearchResultMatchModel: Hashable, Identifiable {
-    init(lineNumber: Int,
-         file: WorkspaceClient.FileItem,
-         lineContent: String,
-         keywordRange: Range<String.Index>
+    init(
+        lineNumber: Int,
+        file: WorkspaceClient.FileItem,
+        lineContent: String,
+        keywordRange: Range<String.Index>
     ) {
         self.id = UUID()
         self.file = file

--- a/CodeEdit/Features/Search/Model/SearchResultMatchModel.swift
+++ b/CodeEdit/Features/Search/Model/SearchResultMatchModel.swift
@@ -60,14 +60,18 @@ class SearchResultMatchModel: Hashable, Identifiable {
         paragraphStyle.lineBreakMode = .byCharWrapping
 
         let normalAttributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 13,
-                                     weight: .regular),
+            .font: NSFont.systemFont(
+                ofSize: 13,
+                weight: .regular
+            ),
             .foregroundColor: NSColor.secondaryLabelColor,
             .paragraphStyle: paragraphStyle
         ]
         let boldAttributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 13,
-                                     weight: .bold),
+            .font: NSFont.systemFont(
+                ofSize: 13,
+                weight: .bold
+            ),
             .foregroundColor: NSColor.labelColor,
             .paragraphStyle: paragraphStyle
         ]
@@ -84,13 +88,16 @@ class SearchResultMatchModel: Hashable, Identifiable {
 
         let attributedString = NSMutableAttributedString(
             string: prefix,
-            attributes: normalAttributes)
+            attributes: normalAttributes
+        )
         attributedString.append(NSAttributedString(
             string: searchMatch,
-            attributes: boldAttributes))
+            attributes: boldAttributes
+        ))
         attributedString.append(NSAttributedString(
             string: postfix,
-            attributes: normalAttributes))
+            attributes: normalAttributes
+        ))
 
         return attributedString
     }

--- a/CodeEdit/Features/StatusBar/Views/StatusBarDrawer/StatusBarDrawer.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarDrawer/StatusBarDrawer.swift
@@ -43,8 +43,10 @@ struct StatusBarDrawer: View {
             .frame(maxHeight: 29)
             .background(.bar)
         }
-        .frame(minHeight: 0,
-               idealHeight: height,
-               maxHeight: height)
+        .frame(
+            minHeight: 0,
+            idealHeight: height,
+            maxHeight: height
+        )
     }
 }

--- a/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarToggleDrawerButton.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarToggleDrawerButton.swift
@@ -16,7 +16,8 @@ internal struct StatusBarToggleDrawerButton: View {
             name: "Toggle Drawer",
             title: "Toggle Drawer",
             id: "open.drawer",
-            command: CommandClosureWrapper.init(closure: togglePanel))
+            command: CommandClosureWrapper.init(closure: togglePanel)
+        )
     }
 
     func togglePanel() {

--- a/CodeEdit/Features/TabBar/Views/TabBarContextMenu.swift
+++ b/CodeEdit/Features/TabBar/Views/TabBarContextMenu.swift
@@ -15,8 +15,10 @@ extension View {
 }
 
 struct TabBarContextMenu: ViewModifier {
-    init(item: TabBarItemRepresentable,
-         isTemporary: Bool) {
+    init(
+		item: TabBarItemRepresentable,
+        isTemporary: Bool
+	) {
         self.item = item
         self.isTemporary = isTemporary
     }

--- a/CodeEdit/Features/TabBar/Views/TabBarContextMenu.swift
+++ b/CodeEdit/Features/TabBar/Views/TabBarContextMenu.swift
@@ -16,9 +16,9 @@ extension View {
 
 struct TabBarContextMenu: ViewModifier {
     init(
-		item: TabBarItemRepresentable,
+        item: TabBarItemRepresentable,
         isTemporary: Bool
-	) {
+    ) {
         self.item = item
         self.isTemporary = isTemporary
     }

--- a/CodeEdit/Utils/Extensions/String/String+Ranges.swift
+++ b/CodeEdit/Utils/Extensions/String/String+Ranges.swift
@@ -18,7 +18,8 @@ extension StringProtocol where Index == String.Index {
             of: substring,
             options: options,
             range: (ranges.last?.upperBound ?? startIndex)..<endIndex,
-            locale: locale) {
+            locale: locale
+        ) {
             ranges.append(result)
         }
         return ranges

--- a/CodeEdit/Utils/Extensions/SwiftTerm/Color/SwiftTerm+Color+Init.swift
+++ b/CodeEdit/Utils/Extensions/SwiftTerm/Color/SwiftTerm+Color+Init.swift
@@ -12,17 +12,21 @@ extension SwiftTerm.Color {
     /// 0.0-1.0
     convenience init(dRed red: Double, green: Double, blue: Double) {
         let multiplier: Double = 65535
-        self.init(red: UInt16(red * multiplier),
-                  green: UInt16(green * multiplier),
-                  blue: UInt16(blue * multiplier))
+        self.init(
+            red: UInt16(red * multiplier),
+            green: UInt16(green * multiplier),
+            blue: UInt16(blue * multiplier)
+        )
     }
 
     /// 0-255
     convenience init(iRed red: UInt8, green: UInt8, blue: UInt8) {
         let divisor: Double = 255
-        self.init(dRed: Double(red) / divisor,
-                  green: Double(green) / divisor,
-                  blue: Double(blue) / divisor)
+        self.init(
+            dRed: Double(red) / divisor,
+            green: Double(green) / divisor,
+            blue: Double(blue) / divisor
+        )
     }
 
     /// 0x000000 - 0xFFFFFF

--- a/CodeEdit/Utils/KeyChain/CodeEditKeychain.swift
+++ b/CodeEdit/Utils/KeyChain/CodeEditKeychain.swift
@@ -48,8 +48,10 @@ class CodeEditKeychain {
      - returns: True if the text was successfully written to the keychain.
      */
     @discardableResult
-    func set(_ value: String, forKey key: String,
-             withAccess access: CodeEditKeychainAccessOptions? = nil
+    func set(
+        _ value: String,
+        forKey key: String,
+        withAccess access: CodeEditKeychainAccessOptions? = nil
     ) -> Bool {
         if let value = value.data(using: String.Encoding.utf8) {
             return set(value, forKey: key, withAccess: access)
@@ -67,8 +69,10 @@ class CodeEditKeychain {
      - returns: True if the text was successfully written to the keychain.
      */
     @discardableResult
-    func set(_ value: Data, forKey key: String,
-             withAccess access: CodeEditKeychainAccessOptions? = nil
+    func set(
+        _ value: Data,
+        forKey key: String,
+        withAccess access: CodeEditKeychainAccessOptions? = nil
     ) -> Bool {
         // The lock prevents the code to be run simultaneously
         // from multiple threads which may result in crashing
@@ -105,8 +109,10 @@ class CodeEditKeychain {
      - returns: True if the value was successfully written to the keychain.
      */
     @discardableResult
-    func set(_ value: Bool, forKey key: String,
-             withAccess access: CodeEditKeychainAccessOptions? = nil
+    func set(
+        _ value: Bool,
+        forKey key: String,
+        withAccess access: CodeEditKeychainAccessOptions? = nil
     ) -> Bool {
         let bytes: [UInt8] = value ? [1] : [0]
         let data = Data(bytes)

--- a/CodeEdit/Utils/WorkspaceClient/Live.swift
+++ b/CodeEdit/Utils/WorkspaceClient/Live.swift
@@ -22,8 +22,10 @@ extension WorkspaceClient {
         // - Parameter url: The URL of the directory to load the items of
         // - Returns: `[FileItem]` representing the contents of the directory
         func loadFiles(fromURL url: URL) throws -> [FileItem] {
-            let directoryContents = try fileManager.contentsOfDirectory(at: url.resolvingSymlinksInPath(),
-                                                                        includingPropertiesForKeys: nil)
+            let directoryContents = try fileManager.contentsOfDirectory(
+                at: url.resolvingSymlinksInPath(),
+                includingPropertiesForKeys: nil
+            )
             var items: [FileItem] = []
 
             for itemURL in directoryContents {
@@ -75,8 +77,10 @@ extension WorkspaceClient {
             var didChangeSomething = false
 
             // get the actual directory children
-            let directoryContentsUrls = try fileManager.contentsOfDirectory(at: fileItem.url.resolvingSymlinksInPath(),
-                                                                            includingPropertiesForKeys: nil)
+            let directoryContentsUrls = try fileManager.contentsOfDirectory(
+                at: fileItem.url.resolvingSymlinksInPath(),
+                includingPropertiesForKeys: nil
+            )
 
             // test for deleted children, and remove them from the index
             for oldContent in fileItem.children ?? [] where !directoryContentsUrls.contains(oldContent.url) {

--- a/CodeEdit/Utils/WorkspaceClient/Model/FileItem.swift
+++ b/CodeEdit/Utils/WorkspaceClient/Model/FileItem.swift
@@ -200,9 +200,11 @@ extension WorkspaceClient {
 
             // create the folder
             do {
-                try FileItem.fileManger.createDirectory(at: folderUrl,
-                                                        withIntermediateDirectories: true,
-                                                        attributes: [:])
+                try FileItem.fileManger.createDirectory(
+                    at: folderUrl,
+                    withIntermediateDirectories: true,
+                    attributes: [:]
+                )
             } catch {
                 fatalError(error.localizedDescription)
             }

--- a/OpenWithCodeEdit/FinderSync.swift
+++ b/OpenWithCodeEdit/FinderSync.swift
@@ -24,7 +24,8 @@ class CEOpenWith: FIFinderSync {
         let finderSync = FIFinderSyncController.default()
         if let mountedVolumes = FileManager.default.mountedVolumeURLs(
             includingResourceValuesForKeys: nil,
-            options: [.skipHiddenVolumes]) {
+            options: [.skipHiddenVolumes]
+        ) {
             finderSync.directoryURLs = Set<URL>(mountedVolumes)
         }
         // Monitor volumes
@@ -32,11 +33,12 @@ class CEOpenWith: FIFinderSync {
         notificationCenter.addObserver(
             forName: NSWorkspace.didMountNotification,
             object: nil,
-            queue: .main) { notification in
-                if let volumeURL = notification.userInfo?[NSWorkspace.volumeURLUserInfoKey] as? URL {
-                    finderSync.directoryURLs.insert(volumeURL)
-                }
+            queue: .main
+        ) { notification in
+            if let volumeURL = notification.userInfo?[NSWorkspace.volumeURLUserInfoKey] as? URL {
+                finderSync.directoryURLs.insert(volumeURL)
             }
+        }
     }
 
     /// Open in CodeEdit (menu) action
@@ -79,9 +81,10 @@ class CEOpenWith: FIFinderSync {
         defaults.register(defaults: ["enableOpenInCE": true])
 
         let menu = NSMenu(title: "")
-        let menuItem = NSMenuItem(title: "Open in CodeEdit",
-                                  action: #selector(openInCodeEditAction(_:)),
-                                  keyEquivalent: ""
+        let menuItem = NSMenuItem(
+            title: "Open in CodeEdit",
+            action: #selector(openInCodeEditAction(_:)),
+            keyEquivalent: ""
         )
         menuItem.image = NSImage.init(named: "icon")
 


### PR DESCRIPTION
# Description

Multiline parameter/argument indentation and alignment was all over the place which makes code very hard to read and maintain. This PR fixes and from now on enforces alignment of multiline arguments like shown below using the following two `swiftlint` rules:

- multiline_parameters_brackets
- multiline_arguments_brackets

```swift
/* Don't use this */
func aVeryLongFunctionName(_ with: String, 
                           multiple: Int, 
                           parameters: [String]) -> Bool {
    // function body
}

/* Use this instead */
func aVeryLongFunctionName(
    _ with: String, 
    multiple: Int, 
    parameters: [String]
) -> Bool {
    // function body
}

/* or this if there is enough space horizontally */
func aVeryLongFunctionName(_ with: String, multiple: Int, parameters: [String]) -> Bool {
    // function body
}
```

> I made no changes to the code apart from formatting and indenting the existing code