### PR TITLE
Resize inspector

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -7,7 +7,7 @@
 
 import Cocoa
 
-fileprivate extension CGFloat {
+private extension CGFloat {
     static let snapWidth: CGFloat = 272
 
     static let minSnapWidth: CGFloat = snapWidth - 10
@@ -58,22 +58,22 @@ final class CodeEditSplitViewController: NSSplitViewController {
                 return .snapWidth
             } else {
                 isSnapped = false
-                if proposedPosition <= 121 {
+                if proposedPosition <= CodeEditWindowController.minSidebarWidth / 2 {
                     splitViewItems.first?.isCollapsed = true
                     return 0
                 }
-                return max(242, proposedPosition)
+                return max(CodeEditWindowController.minSidebarWidth, proposedPosition)
             }
         } else if dividerIndex == 1 {
             let proposedWidth = view.frame.width - proposedPosition
-            if proposedWidth <= 121 {
+            if proposedWidth <= CodeEditWindowController.minSidebarWidth / 2 {
                 splitViewItems.last?.isCollapsed = true
                 removeToolbarItemIfNeeded()
                 return proposedPosition
             }
             splitViewItems.last?.isCollapsed = false
             insertToolbarItemIfNeeded()
-            return min(view.frame.width - 242, proposedPosition)
+            return min(view.frame.width - CodeEditWindowController.minSidebarWidth, proposedPosition)
         }
         return proposedPosition
     }

--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -78,7 +78,8 @@ final class CodeEditSplitViewController: NSSplitViewController {
         return proposedPosition
     }
 
-    /// Quick fix for list tracking separator needing to be added again after closing, then opening the inspector with a drag.
+    /// Quick fix for list tracking separator needing to be added again after closing,
+    /// then opening the inspector with a drag.
     private func insertToolbarItemIfNeeded() {
         guard !(
             view.window?.toolbar?.items.contains(where: { $0.itemIdentifier == .itemListTrackingSeparator }) ?? true

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -92,9 +92,9 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
             viewController: NSHostingController(rootView: inspectorView)
         )
         inspector.titlebarSeparatorStyle = .none
-        inspector.minimumThickness = 260
-        inspector.maximumThickness = 260
+        inspector.minimumThickness = 242
         inspector.isCollapsed = true
+        inspector.canCollapse = true
         inspector.collapseBehavior = .useConstraints
         splitVC.addSplitViewItem(inspector)
 
@@ -288,7 +288,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
     }
 }
 
-private extension NSToolbarItem.Identifier {
+extension NSToolbarItem.Identifier {
     static let toggleFirstSidebarItem: NSToolbarItem.Identifier = NSToolbarItem.Identifier("ToggleFirstSidebarItem")
     static let toggleLastSidebarItem: NSToolbarItem.Identifier = NSToolbarItem.Identifier("ToggleLastSidebarItem")
     static let itemListTrackingSeparator = NSToolbarItem.Identifier("ItemListTrackingSeparator")

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -9,6 +9,8 @@ import Cocoa
 import SwiftUI
 
 final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
+    static let minSidebarWidth: CGFloat = 242
+
     private var prefs: AppPreferencesModel = .shared
 
     var workspace: WorkspaceDocument?
@@ -73,7 +75,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
             sidebarWithViewController: NSHostingController(rootView: navigatorView)
         )
         navigator.titlebarSeparatorStyle = .none
-        navigator.minimumThickness = 242
+        navigator.minimumThickness = Self.minSidebarWidth
         navigator.collapseBehavior = .useConstraints
         splitVC.addSplitViewItem(navigator)
 
@@ -92,7 +94,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
             viewController: NSHostingController(rootView: inspectorView)
         )
         inspector.titlebarSeparatorStyle = .none
-        inspector.minimumThickness = 242
+        inspector.minimumThickness = Self.minSidebarWidth
         inspector.isCollapsed = true
         inspector.canCollapse = true
         inspector.collapseBehavior = .useConstraints

--- a/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
+++ b/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
@@ -42,7 +42,7 @@ struct InspectorSidebarView: View {
             }
         }
         .frame(
-            minWidth: 250,
+            minWidth: 242,
             idealWidth: 260,
             minHeight: 0,
             maxHeight: .infinity,

--- a/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
+++ b/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
@@ -42,7 +42,7 @@ struct InspectorSidebarView: View {
             }
         }
         .frame(
-            minWidth: 242,
+            minWidth: CodeEditWindowController.minSidebarWidth,
             idealWidth: 260,
             minHeight: 0,
             maxHeight: .infinity,

--- a/CodeEditTests/Features/Documents/DocumentsUnitTests.swift
+++ b/CodeEditTests/Features/Documents/DocumentsUnitTests.swift
@@ -46,7 +46,8 @@ final class DocumentsUnitTests: XCTestCase {
 
     func testSplitViewControllerStopSnappedWhenWidthIsLowerAppropriateRange() {
         // Given
-        let position = (0..<260).randomElement() ?? .zero
+        // 242 is the minimum width of the sidebar
+        let position = (242..<260).randomElement() ?? .zero
 
         // When
         let result = splitViewController.splitView(


### PR DESCRIPTION
# Description

Adds the ability for the inspector bar to resize.
- Modifies the relative `NSSplitViewItem` to be able to collapse and have a minimum width
- Fixes the default "close with drag" interaction.
  - By default the `itemListTrackingSeparator` toolbar item is left in the toolbar after the inspector is closed by dragging.
  - Dynamically adds or removes the item during the drag to make sure there are no duplicate `itemListTrackingSeparator` items and that it exists when it needs to.
- Slightly changes the `InspectorSidebarView`'s minimum frame to match the snap guides.

# Related Issue

* #927

# Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

https://user-images.githubusercontent.com/35942988/212501920-dbb4709b-d793-4f7c-a218-a3ec0bbf5fc2.mov
