### PR TITLE
[feat] Default Themes: Solarized (dark/light)

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -63,8 +63,8 @@
 		28A51006281701B40087B0CC /* codeedit-github-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 28A51004281701B40087B0CC /* codeedit-github-dark.json */; };
 		28B0A19827E385C300B73177 /* NavigatorSidebarToolbarTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B0A19727E385C300B73177 /* NavigatorSidebarToolbarTop.swift */; };
 		28B8F884280FFE4600596236 /* NSTableView+Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B8F883280FFE4600596236 /* NSTableView+Background.swift */; };
-		28F43DDC2973840A008BBA45 /* codeedit-solarized-light.json in Resources */ = {isa = PBXBuildFile; fileRef = 28F43DDA2973840A008BBA45 /* codeedit-solarized-light.json */; };
 		28F43DE029738792008BBA45 /* codeedit-solarized-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 28F43DDF29738792008BBA45 /* codeedit-solarized-dark.json */; };
+		28F43DE2297388C5008BBA45 /* codeedit-solarized-light.json in Resources */ = {isa = PBXBuildFile; fileRef = 28F43DE1297388C5008BBA45 /* codeedit-solarized-light.json */; };
 		28FFE1BF27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FFE1BE27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift */; };
 		2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* AppDelegate.swift */; };
 		2B7AC06B282452FB0082A5B8 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B7AC06A282452FB0082A5B8 /* Media.xcassets */; };
@@ -441,8 +441,8 @@
 		28A51004281701B40087B0CC /* codeedit-github-dark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-github-dark.json"; sourceTree = "<group>"; };
 		28B0A19727E385C300B73177 /* NavigatorSidebarToolbarTop.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarTop.swift; sourceTree = "<group>"; tabWidth = 4; };
 		28B8F883280FFE4600596236 /* NSTableView+Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Background.swift"; sourceTree = "<group>"; };
-		28F43DDA2973840A008BBA45 /* codeedit-solarized-light.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-solarized-light.json"; sourceTree = "<group>"; };
 		28F43DDF29738792008BBA45 /* codeedit-solarized-dark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-solarized-dark.json"; sourceTree = "<group>"; };
+		28F43DE1297388C5008BBA45 /* codeedit-solarized-light.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-solarized-light.json"; sourceTree = "<group>"; };
 		28FFE1BE27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarBottom.swift; sourceTree = "<group>"; tabWidth = 4; };
 		2B15CA0028254139004E8F22 /* OpenWithCodeEdit.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = OpenWithCodeEdit.entitlements; sourceTree = "<group>"; };
 		2B7AC06A282452FB0082A5B8 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
@@ -885,7 +885,7 @@
 			isa = PBXGroup;
 			children = (
 				28F43DDF29738792008BBA45 /* codeedit-solarized-dark.json */,
-				28F43DDA2973840A008BBA45 /* codeedit-solarized-light.json */,
+				28F43DE1297388C5008BBA45 /* codeedit-solarized-light.json */,
 				28A50FFF281673530087B0CC /* codeedit-xcode-dark.json */,
 				28A51000281673530087B0CC /* codeedit-xcode-light.json */,
 				28A51004281701B40087B0CC /* codeedit-github-dark.json */,
@@ -2425,9 +2425,9 @@
 				28A51002281673530087B0CC /* codeedit-xcode-light.json in Resources */,
 				28A51005281701B40087B0CC /* codeedit-github-light.json in Resources */,
 				D7211D4727E06BFE008F2ED7 /* Localizable.strings in Resources */,
+				28F43DE2297388C5008BBA45 /* codeedit-solarized-light.json in Resources */,
 				28A51001281673530087B0CC /* codeedit-xcode-dark.json in Resources */,
 				B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */,
-				28F43DDC2973840A008BBA45 /* codeedit-solarized-light.json in Resources */,
 				474397C52893AC4B00518C8C /* codeedit-midnight.json in Resources */,
 				043C321A27E32295006AE443 /* MainMenu.xib in Resources */,
 			);

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		28B0A19827E385C300B73177 /* NavigatorSidebarToolbarTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B0A19727E385C300B73177 /* NavigatorSidebarToolbarTop.swift */; };
 		28B8F884280FFE4600596236 /* NSTableView+Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B8F883280FFE4600596236 /* NSTableView+Background.swift */; };
 		28F43DDC2973840A008BBA45 /* codeedit-solarized-light.json in Resources */ = {isa = PBXBuildFile; fileRef = 28F43DDA2973840A008BBA45 /* codeedit-solarized-light.json */; };
-		28F43DDD2973840A008BBA45 /* codeedit-solarized-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 28F43DDB2973840A008BBA45 /* codeedit-solarized-dark.json */; };
+		28F43DE029738792008BBA45 /* codeedit-solarized-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 28F43DDF29738792008BBA45 /* codeedit-solarized-dark.json */; };
 		28FFE1BF27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FFE1BE27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift */; };
 		2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* AppDelegate.swift */; };
 		2B7AC06B282452FB0082A5B8 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B7AC06A282452FB0082A5B8 /* Media.xcassets */; };
@@ -442,7 +442,7 @@
 		28B0A19727E385C300B73177 /* NavigatorSidebarToolbarTop.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarTop.swift; sourceTree = "<group>"; tabWidth = 4; };
 		28B8F883280FFE4600596236 /* NSTableView+Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Background.swift"; sourceTree = "<group>"; };
 		28F43DDA2973840A008BBA45 /* codeedit-solarized-light.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-solarized-light.json"; sourceTree = "<group>"; };
-		28F43DDB2973840A008BBA45 /* codeedit-solarized-dark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-solarized-dark.json"; sourceTree = "<group>"; };
+		28F43DDF29738792008BBA45 /* codeedit-solarized-dark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-solarized-dark.json"; sourceTree = "<group>"; };
 		28FFE1BE27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarBottom.swift; sourceTree = "<group>"; tabWidth = 4; };
 		2B15CA0028254139004E8F22 /* OpenWithCodeEdit.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = OpenWithCodeEdit.entitlements; sourceTree = "<group>"; };
 		2B7AC06A282452FB0082A5B8 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
@@ -884,7 +884,7 @@
 		28069DA527F5BD320016BC47 /* DefaultThemes */ = {
 			isa = PBXGroup;
 			children = (
-				28F43DDB2973840A008BBA45 /* codeedit-solarized-dark.json */,
+				28F43DDF29738792008BBA45 /* codeedit-solarized-dark.json */,
 				28F43DDA2973840A008BBA45 /* codeedit-solarized-light.json */,
 				28A50FFF281673530087B0CC /* codeedit-xcode-dark.json */,
 				28A51000281673530087B0CC /* codeedit-xcode-light.json */,
@@ -2420,7 +2420,7 @@
 				283BDCBD2972EEBD002AFF81 /* Package.resolved in Resources */,
 				B658FB3727DA9E1000EA4DBD /* Preview Assets.xcassets in Resources */,
 				28A51006281701B40087B0CC /* codeedit-github-dark.json in Resources */,
-				28F43DDD2973840A008BBA45 /* codeedit-solarized-dark.json in Resources */,
+				28F43DE029738792008BBA45 /* codeedit-solarized-dark.json in Resources */,
 				58A5DFA529339F6400D1BD5D /* default_keybindings.json in Resources */,
 				28A51002281673530087B0CC /* codeedit-xcode-light.json in Resources */,
 				28A51005281701B40087B0CC /* codeedit-github-light.json in Resources */,

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		28A51006281701B40087B0CC /* codeedit-github-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 28A51004281701B40087B0CC /* codeedit-github-dark.json */; };
 		28B0A19827E385C300B73177 /* NavigatorSidebarToolbarTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B0A19727E385C300B73177 /* NavigatorSidebarToolbarTop.swift */; };
 		28B8F884280FFE4600596236 /* NSTableView+Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B8F883280FFE4600596236 /* NSTableView+Background.swift */; };
+		28F43DDC2973840A008BBA45 /* codeedit-solarized-light.json in Resources */ = {isa = PBXBuildFile; fileRef = 28F43DDA2973840A008BBA45 /* codeedit-solarized-light.json */; };
+		28F43DDD2973840A008BBA45 /* codeedit-solarized-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 28F43DDB2973840A008BBA45 /* codeedit-solarized-dark.json */; };
 		28FFE1BF27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FFE1BE27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift */; };
 		2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* AppDelegate.swift */; };
 		2B7AC06B282452FB0082A5B8 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B7AC06A282452FB0082A5B8 /* Media.xcassets */; };
@@ -439,6 +441,8 @@
 		28A51004281701B40087B0CC /* codeedit-github-dark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-github-dark.json"; sourceTree = "<group>"; };
 		28B0A19727E385C300B73177 /* NavigatorSidebarToolbarTop.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarTop.swift; sourceTree = "<group>"; tabWidth = 4; };
 		28B8F883280FFE4600596236 /* NSTableView+Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Background.swift"; sourceTree = "<group>"; };
+		28F43DDA2973840A008BBA45 /* codeedit-solarized-light.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-solarized-light.json"; sourceTree = "<group>"; };
+		28F43DDB2973840A008BBA45 /* codeedit-solarized-dark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-solarized-dark.json"; sourceTree = "<group>"; };
 		28FFE1BE27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarBottom.swift; sourceTree = "<group>"; tabWidth = 4; };
 		2B15CA0028254139004E8F22 /* OpenWithCodeEdit.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = OpenWithCodeEdit.entitlements; sourceTree = "<group>"; };
 		2B7AC06A282452FB0082A5B8 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
@@ -880,6 +884,8 @@
 		28069DA527F5BD320016BC47 /* DefaultThemes */ = {
 			isa = PBXGroup;
 			children = (
+				28F43DDB2973840A008BBA45 /* codeedit-solarized-dark.json */,
+				28F43DDA2973840A008BBA45 /* codeedit-solarized-light.json */,
 				28A50FFF281673530087B0CC /* codeedit-xcode-dark.json */,
 				28A51000281673530087B0CC /* codeedit-xcode-light.json */,
 				28A51004281701B40087B0CC /* codeedit-github-dark.json */,
@@ -2414,12 +2420,14 @@
 				283BDCBD2972EEBD002AFF81 /* Package.resolved in Resources */,
 				B658FB3727DA9E1000EA4DBD /* Preview Assets.xcassets in Resources */,
 				28A51006281701B40087B0CC /* codeedit-github-dark.json in Resources */,
+				28F43DDD2973840A008BBA45 /* codeedit-solarized-dark.json in Resources */,
 				58A5DFA529339F6400D1BD5D /* default_keybindings.json in Resources */,
 				28A51002281673530087B0CC /* codeedit-xcode-light.json in Resources */,
 				28A51005281701B40087B0CC /* codeedit-github-light.json in Resources */,
 				D7211D4727E06BFE008F2ED7 /* Localizable.strings in Resources */,
 				28A51001281673530087B0CC /* codeedit-xcode-dark.json in Resources */,
 				B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */,
+				28F43DDC2973840A008BBA45 /* codeedit-solarized-light.json in Resources */,
 				474397C52893AC4B00518C8C /* codeedit-midnight.json in Resources */,
 				043C321A27E32295006AE443 /* MainMenu.xib in Resources */,
 			);

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -441,8 +441,8 @@
 		28A51004281701B40087B0CC /* codeedit-github-dark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-github-dark.json"; sourceTree = "<group>"; };
 		28B0A19727E385C300B73177 /* NavigatorSidebarToolbarTop.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarTop.swift; sourceTree = "<group>"; tabWidth = 4; };
 		28B8F883280FFE4600596236 /* NSTableView+Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Background.swift"; sourceTree = "<group>"; };
-		28F43DDF29738792008BBA45 /* codeedit-solarized-dark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-solarized-dark.json"; sourceTree = "<group>"; };
-		28F43DE1297388C5008BBA45 /* codeedit-solarized-light.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "codeedit-solarized-light.json"; sourceTree = "<group>"; };
+		28F43DDF29738792008BBA45 /* codeedit-solarized-dark.json */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = text.json; path = "codeedit-solarized-dark.json"; sourceTree = "<group>"; tabWidth = 2; };
+		28F43DE1297388C5008BBA45 /* codeedit-solarized-light.json */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = text.json; path = "codeedit-solarized-light.json"; sourceTree = "<group>"; tabWidth = 2; };
 		28FFE1BE27E3A441001939DB /* NavigatorSidebarToolbarBottom.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = NavigatorSidebarToolbarBottom.swift; sourceTree = "<group>"; tabWidth = 4; };
 		2B15CA0028254139004E8F22 /* OpenWithCodeEdit.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = OpenWithCodeEdit.entitlements; sourceTree = "<group>"; };
 		2B7AC06A282452FB0082A5B8 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };

--- a/CodeEdit/DefaultThemes/codeedit-solarized-dark.json
+++ b/CodeEdit/DefaultThemes/codeedit-solarized-dark.json
@@ -1,125 +1,125 @@
 {
-  "author" : "CodeEdit",
-  "displayName" : "Solarized Dark",
-  "editor" : {
-    "characters" : {
-      "color" : "#DC322F"
+  "author": "CodeEdit",
+  "description": "Solarized dark theme.",
+  "displayName": "Solarized Dark",
+  "distributionURL": "https://github.com/CodeEditApp/CodeEdit",
+  "editor": {
+    "attributes": {
+      "color": "#6C71C4"
     },
-    "comments" : {
-      "color" : "#586E75"
+    "background": {
+      "color": "#002B36"
     },
-    "numbers" : {
-      "color" : "#DC322F"
+    "characters": {
+      "color": "#DC322F"
     },
-    "commands" : {
-      "color" : "#CB4B16"
+    "commands": {
+      "color": "#CB4B16"
     },
-    "lineHighlight" : {
-      "color" : "#073642"
+    "comments": {
+      "color": "#586E75"
     },
-    "values" : {
-      "color" : "#D33682"
+    "insertionPoint": {
+      "color": "#839496"
     },
-    "background" : {
-      "color" : "#002B36"
+    "invisibles": {
+      "color": "#073642"
     },
-    "keywords" : {
-      "color" : "#859900"
+    "keywords": {
+      "color": "#859900"
     },
-    "text" : {
-      "color" : "#839496"
+    "lineHighlight": {
+      "color": "#073642"
     },
-    "invisibles" : {
-      "color" : "#073642"
+    "numbers": {
+      "color": "#DC322F"
     },
-    "insertionPoint" : {
-      "color" : "#839496"
+    "selection": {
+      "color": "#586E75"
     },
-    "strings" : {
-      "color" : "#2AA198"
+    "strings": {
+      "color": "#2AA198"
     },
-    "selection" : {
-      "color" : "#586E75"
+    "text": {
+      "color": "#839496"
     },
-    "types" : {
-      "color" : "#268BD2"
+    "types": {
+      "color": "#268BD2"
     },
-    "variables" : {
-      "color" : "#B58900"
+    "values": {
+      "color": "#D33682"
     },
-    "attributes" : {
-      "color" : "#6C71C4"
+    "variables": {
+      "color": "#B58900"
     }
   },
-  "distributionURL" : "https:\/\/github.com\/CodeEditApp\/CodeEdit",
-  "terminal" : {
-    "white" : {
-      "color" : "#EEE8D5"
+  "license": "MIT",
+  "name": "codeedit-solarized-dark",
+  "terminal": {
+    "background": {
+      "color": "#002B36"
     },
-    "brightMagenta" : {
-      "color" : "#6C71C4"
+    "black": {
+      "color": "#073642"
     },
-    "brightRed" : {
-      "color" : "#CB4B16"
+    "blue": {
+      "color": "#268BD2"
     },
-    "blue" : {
-      "color" : "#268BD2"
+    "boldText": {
+      "color": "#839496"
     },
-    "red" : {
-      "color" : "#DC322F"
+    "brightBlack": {
+      "color": "#002B36"
     },
-    "green" : {
-      "color" : "#859900"
+    "brightBlue": {
+      "color": "#839496"
     },
-    "boldText" : {
-      "color" : "#839496"
+    "brightCyan": {
+      "color": "#93A1A1"
     },
-    "brightGreen" : {
-      "color" : "#586E75"
+    "brightGreen": {
+      "color": "#586E75"
     },
-    "background" : {
-      "color" : "#002B36"
+    "brightMagenta": {
+      "color": "#6C71C4"
     },
-    "cursor" : {
-      "color" : "#839496"
+    "brightRed": {
+      "color": "#CB4B16"
     },
-    "selection" : {
-      "color" : "#073642"
+    "brightWhite": {
+      "color": "#FDF6E3"
     },
-    "magenta" : {
-      "color" : "#D33682"
+    "brightYellow": {
+      "color": "#657B83"
     },
-    "black" : {
-      "color" : "#073642"
+    "cursor": {
+      "color": "#839496"
     },
-    "text" : {
-      "color" : "#839496"
+    "cyan": {
+      "color": "#2AA198"
     },
-    "brightWhite" : {
-      "color" : "#FDF6E3"
+    "green": {
+      "color": "#859900"
     },
-    "brightBlue" : {
-      "color" : "#839496"
+    "magenta": {
+      "color": "#D33682"
     },
-    "brightYellow" : {
-      "color" : "#657B83"
+    "red": {
+      "color": "#DC322F"
     },
-    "cyan" : {
-      "color" : "#2AA198"
+    "selection": {
+      "color": "#073642"
     },
-    "yellow" : {
-      "color" : "#B58900"
+    "text": {
+      "color": "#839496"
     },
-    "brightCyan" : {
-      "color" : "#93A1A1"
+    "white": {
+      "color": "#EEE8D5"
     },
-    "brightBlack" : {
-      "color" : "#002B36"
+    "yellow": {
+      "color": "#B58900"
     }
   },
-  "version" : "0.0.1",
-  "license" : "MIT",
-  "type" : "dark",
-  "name" : "codeedit-solarized-dark",
-  "description" : "Solarized dark theme."
+  "type": "dark",
+  "version": "0.0.1"
 }

--- a/CodeEdit/DefaultThemes/codeedit-solarized-dark.json
+++ b/CodeEdit/DefaultThemes/codeedit-solarized-dark.json
@@ -1,0 +1,125 @@
+{
+  "author" : "CodeEdit",
+  "displayName" : "Solarized Dark",
+  "editor" : {
+    "invisibles" : {
+      "color" : "#073642"
+    },
+    "comments" : {
+      "color" : "#586E75"
+    },
+    "numbers" : {
+      "color" : "#DC322F"
+    },
+    "commands" : {
+      "color" : "#CB4B16"
+    },
+    "lineHighlight" : {
+      "color" : "#073642"
+    },
+    "values" : {
+      "color" : "#D33682"
+    },
+    "background" : {
+      "color" : "#002B36"
+    },
+    "keywords" : {
+      "color" : "#859900"
+    },
+    "text" : {
+      "color" : "#839496"
+    },
+    "insertionPoint" : {
+      "color" : "#839496"
+    },
+    "strings" : {
+      "color" : "#2AA198"
+    },
+    "selection" : {
+      "color" : "#586E75"
+    },
+    "types" : {
+      "color" : "#268BD2"
+    },
+    "variables" : {
+      "color" : "#B58900"
+    },
+    "attributes" : {
+      "color" : "#6C71C4"
+    },
+    "characters" : {
+      "color" : "#DC322F"
+    }
+  },
+  "distributionURL" : "https:\/\/github.com\/CodeEditApp\/CodeEdit",
+  "terminal" : {
+    "white" : {
+      "color" : "#D9D9D9"
+    },
+    "brightMagenta" : {
+      "color" : "#AF52DE"
+    },
+    "brightRed" : {
+      "color" : "#FF3B30"
+    },
+    "blue" : {
+      "color" : "#007AFF"
+    },
+    "red" : {
+      "color" : "#FF3B30"
+    },
+    "green" : {
+      "color" : "#28CD41"
+    },
+    "boldText" : {
+      "color" : "#D9D9D9"
+    },
+    "brightGreen" : {
+      "color" : "#28CD41"
+    },
+    "background" : {
+      "color" : "#1F2024"
+    },
+    "cursor" : {
+      "color" : "#D9D9D9"
+    },
+    "selection" : {
+      "color" : "#515B70"
+    },
+    "magenta" : {
+      "color" : "#AF52DE"
+    },
+    "black" : {
+      "color" : "#1F2024"
+    },
+    "text" : {
+      "color" : "#D9D9D9"
+    },
+    "brightWhite" : {
+      "color" : "#FFFFFF"
+    },
+    "brightBlue" : {
+      "color" : "#007AFF"
+    },
+    "brightYellow" : {
+      "color" : "#FFFF00"
+    },
+    "cyan" : {
+      "color" : "#59ADC4"
+    },
+    "yellow" : {
+      "color" : "#FFCC00"
+    },
+    "brightCyan" : {
+      "color" : "#55BEF0"
+    },
+    "brightBlack" : {
+      "color" : "#8E8E93"
+    }
+  },
+  "version" : "0.0.1",
+  "license" : "MIT",
+  "type" : "dark",
+  "name" : "codeedit-solarized-dark",
+  "description" : "Solarized dark theme."
+}

--- a/CodeEdit/DefaultThemes/codeedit-solarized-dark.json
+++ b/CodeEdit/DefaultThemes/codeedit-solarized-dark.json
@@ -2,8 +2,8 @@
   "author" : "CodeEdit",
   "displayName" : "Solarized Dark",
   "editor" : {
-    "invisibles" : {
-      "color" : "#073642"
+    "characters" : {
+      "color" : "#DC322F"
     },
     "comments" : {
       "color" : "#586E75"
@@ -29,6 +29,9 @@
     "text" : {
       "color" : "#839496"
     },
+    "invisibles" : {
+      "color" : "#073642"
+    },
     "insertionPoint" : {
       "color" : "#839496"
     },
@@ -46,75 +49,72 @@
     },
     "attributes" : {
       "color" : "#6C71C4"
-    },
-    "characters" : {
-      "color" : "#DC322F"
     }
   },
   "distributionURL" : "https:\/\/github.com\/CodeEditApp\/CodeEdit",
   "terminal" : {
     "white" : {
-      "color" : "#D9D9D9"
+      "color" : "#EEE8D5"
     },
     "brightMagenta" : {
-      "color" : "#AF52DE"
+      "color" : "#6C71C4"
     },
     "brightRed" : {
-      "color" : "#FF3B30"
+      "color" : "#CB4B16"
     },
     "blue" : {
-      "color" : "#007AFF"
+      "color" : "#268BD2"
     },
     "red" : {
-      "color" : "#FF3B30"
+      "color" : "#DC322F"
     },
     "green" : {
-      "color" : "#28CD41"
+      "color" : "#859900"
     },
     "boldText" : {
-      "color" : "#D9D9D9"
+      "color" : "#839496"
     },
     "brightGreen" : {
-      "color" : "#28CD41"
+      "color" : "#586E75"
     },
     "background" : {
-      "color" : "#1F2024"
+      "color" : "#002B36"
     },
     "cursor" : {
-      "color" : "#D9D9D9"
+      "color" : "#839496"
     },
     "selection" : {
-      "color" : "#515B70"
+      "color" : "#073642"
     },
     "magenta" : {
-      "color" : "#AF52DE"
+      "color" : "#D33682"
     },
     "black" : {
-      "color" : "#1F2024"
+      "color" : "#073642"
     },
     "text" : {
-      "color" : "#D9D9D9"
+      "color" : "#839496"
     },
     "brightWhite" : {
-      "color" : "#FFFFFF"
+      "color" : "#FDF6E3"
     },
     "brightBlue" : {
-      "color" : "#007AFF"
+      "color" : "#839496"
     },
     "brightYellow" : {
-      "color" : "#FFFF00"
+      "color" : "#657B83"
     },
     "cyan" : {
-      "color" : "#59ADC4"
+      "color" : "#2AA198"
     },
     "yellow" : {
-      "color" : "#FFCC00"
+      "color" : "#B58900"
     },
     "brightCyan" : {
-      "color" : "#55BEF0"
+      "color" : "#93A1A1"
     },
     "brightBlack" : {
-      "color" : "#8E8E93"
+      "color" : "#002B36"
     }
   },
   "version" : "0.0.1",

--- a/CodeEdit/DefaultThemes/codeedit-solarized-light.json
+++ b/CodeEdit/DefaultThemes/codeedit-solarized-light.json
@@ -1,0 +1,125 @@
+{
+  "author" : "CodeEdit",
+  "displayName" : "Solarized Light",
+  "editor" : {
+    "invisibles" : {
+      "color" : "#EEE8D5"
+    },
+    "comments" : {
+      "color" : "#93A1A1"
+    },
+    "numbers" : {
+      "color" : "#DC322F"
+    },
+    "commands" : {
+      "color" : "#CB4B16"
+    },
+    "lineHighlight" : {
+      "color" : "#EEE8D5"
+    },
+    "values" : {
+      "color" : "#D33682"
+    },
+    "background" : {
+      "color" : "#FDF6E3"
+    },
+    "keywords" : {
+      "color" : "#859900"
+    },
+    "text" : {
+      "color" : "#657B83"
+    },
+    "insertionPoint" : {
+      "color" : "#657B83"
+    },
+    "strings" : {
+      "color" : "#2AA198"
+    },
+    "selection" : {
+      "color" : "#93A1A1"
+    },
+    "types" : {
+      "color" : "#268BD2"
+    },
+    "variables" : {
+      "color" : "#B58900"
+    },
+    "attributes" : {
+      "color" : "#6C71C4"
+    },
+    "characters" : {
+      "color" : "#DC322F"
+    }
+  },
+  "distributionURL" : "https:\/\/github.com\/CodeEditApp\/CodeEdit",
+  "terminal" : {
+    "white" : {
+      "color" : "#D9D9D9"
+    },
+    "brightMagenta" : {
+      "color" : "#AF52DE"
+    },
+    "brightRed" : {
+      "color" : "#FF3B30"
+    },
+    "blue" : {
+      "color" : "#007AFF"
+    },
+    "red" : {
+      "color" : "#FF3B30"
+    },
+    "green" : {
+      "color" : "#28CD41"
+    },
+    "boldText" : {
+      "color" : "#D9D9D9"
+    },
+    "brightGreen" : {
+      "color" : "#28CD41"
+    },
+    "background" : {
+      "color" : "#1F2024"
+    },
+    "cursor" : {
+      "color" : "#D9D9D9"
+    },
+    "selection" : {
+      "color" : "#515B70"
+    },
+    "magenta" : {
+      "color" : "#AF52DE"
+    },
+    "black" : {
+      "color" : "#1F2024"
+    },
+    "text" : {
+      "color" : "#D9D9D9"
+    },
+    "brightWhite" : {
+      "color" : "#FFFFFF"
+    },
+    "brightBlue" : {
+      "color" : "#007AFF"
+    },
+    "brightYellow" : {
+      "color" : "#FFFF00"
+    },
+    "cyan" : {
+      "color" : "#59ADC4"
+    },
+    "yellow" : {
+      "color" : "#FFCC00"
+    },
+    "brightCyan" : {
+      "color" : "#55BEF0"
+    },
+    "brightBlack" : {
+      "color" : "#8E8E93"
+    }
+  },
+  "version" : "0.0.1",
+  "license" : "MIT",
+  "type" : "light",
+  "name" : "codeedit-solarized-light",
+  "description" : "Solarized light theme."
+}

--- a/CodeEdit/DefaultThemes/codeedit-solarized-light.json
+++ b/CodeEdit/DefaultThemes/codeedit-solarized-light.json
@@ -2,8 +2,8 @@
   "author" : "CodeEdit",
   "displayName" : "Solarized Light",
   "editor" : {
-    "invisibles" : {
-      "color" : "#EEE8D5"
+    "characters" : {
+      "color" : "#DC322F"
     },
     "comments" : {
       "color" : "#93A1A1"
@@ -29,6 +29,9 @@
     "text" : {
       "color" : "#657B83"
     },
+    "invisibles" : {
+      "color" : "#EEE8D5"
+    },
     "insertionPoint" : {
       "color" : "#657B83"
     },
@@ -46,75 +49,72 @@
     },
     "attributes" : {
       "color" : "#6C71C4"
-    },
-    "characters" : {
-      "color" : "#DC322F"
     }
   },
   "distributionURL" : "https:\/\/github.com\/CodeEditApp\/CodeEdit",
   "terminal" : {
     "white" : {
-      "color" : "#D9D9D9"
+      "color" : "#EEE8D5"
     },
     "brightMagenta" : {
-      "color" : "#AF52DE"
+      "color" : "#6C71C4"
     },
     "brightRed" : {
-      "color" : "#FF3B30"
+      "color" : "#CB4B16"
     },
     "blue" : {
-      "color" : "#007AFF"
+      "color" : "#268BD2"
     },
     "red" : {
-      "color" : "#FF3B30"
+      "color" : "#DC322F"
     },
     "green" : {
-      "color" : "#28CD41"
+      "color" : "#859900"
     },
     "boldText" : {
-      "color" : "#D9D9D9"
+      "color" : "#586E75"
     },
     "brightGreen" : {
-      "color" : "#28CD41"
+      "color" : "#586E75"
     },
     "background" : {
-      "color" : "#1F2024"
+      "color" : "#FDF6E3"
     },
     "cursor" : {
-      "color" : "#D9D9D9"
+      "color" : "#657B83"
     },
     "selection" : {
-      "color" : "#515B70"
+      "color" : "#EEE8D5"
     },
     "magenta" : {
-      "color" : "#AF52DE"
+      "color" : "#D33682"
     },
     "black" : {
-      "color" : "#1F2024"
+      "color" : "#073642"
     },
     "text" : {
-      "color" : "#D9D9D9"
+      "color" : "#657B83"
     },
     "brightWhite" : {
-      "color" : "#FFFFFF"
+      "color" : "#FDF6E3"
     },
     "brightBlue" : {
-      "color" : "#007AFF"
+      "color" : "#839496"
     },
     "brightYellow" : {
-      "color" : "#FFFF00"
+      "color" : "#657B83"
     },
     "cyan" : {
-      "color" : "#59ADC4"
+      "color" : "#2AA198"
     },
     "yellow" : {
-      "color" : "#FFCC00"
+      "color" : "#B58900"
     },
     "brightCyan" : {
-      "color" : "#55BEF0"
+      "color" : "#93A1A1"
     },
     "brightBlack" : {
-      "color" : "#8E8E93"
+      "color" : "#002B36"
     }
   },
   "version" : "0.0.1",

--- a/CodeEdit/DefaultThemes/codeedit-solarized-light.json
+++ b/CodeEdit/DefaultThemes/codeedit-solarized-light.json
@@ -1,125 +1,125 @@
 {
-  "author" : "CodeEdit",
-  "displayName" : "Solarized Light",
-  "editor" : {
-    "characters" : {
-      "color" : "#DC322F"
+  "author": "CodeEdit",
+  "description": "Solarized light theme.",
+  "displayName": "Solarized Light",
+  "distributionURL": "https://github.com/CodeEditApp/CodeEdit",
+  "editor": {
+    "attributes": {
+      "color": "#6C71C4"
     },
-    "comments" : {
-      "color" : "#93A1A1"
+    "background": {
+      "color": "#FDF6E3"
     },
-    "numbers" : {
-      "color" : "#DC322F"
+    "characters": {
+      "color": "#DC322F"
     },
-    "commands" : {
-      "color" : "#CB4B16"
+    "commands": {
+      "color": "#CB4B16"
     },
-    "lineHighlight" : {
-      "color" : "#EEE8D5"
+    "comments": {
+      "color": "#93A1A1"
     },
-    "values" : {
-      "color" : "#D33682"
+    "insertionPoint": {
+      "color": "#657B83"
     },
-    "background" : {
-      "color" : "#FDF6E3"
+    "invisibles": {
+      "color": "#EEE8D5"
     },
-    "keywords" : {
-      "color" : "#859900"
+    "keywords": {
+      "color": "#859900"
     },
-    "text" : {
-      "color" : "#657B83"
+    "lineHighlight": {
+      "color": "#EEE8D5"
     },
-    "invisibles" : {
-      "color" : "#EEE8D5"
+    "numbers": {
+      "color": "#DC322F"
     },
-    "insertionPoint" : {
-      "color" : "#657B83"
+    "selection": {
+      "color": "#93A1A1"
     },
-    "strings" : {
-      "color" : "#2AA198"
+    "strings": {
+      "color": "#2AA198"
     },
-    "selection" : {
-      "color" : "#93A1A1"
+    "text": {
+      "color": "#657B83"
     },
-    "types" : {
-      "color" : "#268BD2"
+    "types": {
+      "color": "#268BD2"
     },
-    "variables" : {
-      "color" : "#B58900"
+    "values": {
+      "color": "#D33682"
     },
-    "attributes" : {
-      "color" : "#6C71C4"
+    "variables": {
+      "color": "#B58900"
     }
   },
-  "distributionURL" : "https:\/\/github.com\/CodeEditApp\/CodeEdit",
-  "terminal" : {
-    "white" : {
-      "color" : "#EEE8D5"
+  "license": "MIT",
+  "name": "codeedit-solarized-light",
+  "terminal": {
+    "background": {
+      "color": "#FDF6E3"
     },
-    "brightMagenta" : {
-      "color" : "#6C71C4"
+    "black": {
+      "color": "#073642"
     },
-    "brightRed" : {
-      "color" : "#CB4B16"
+    "blue": {
+      "color": "#268BD2"
     },
-    "blue" : {
-      "color" : "#268BD2"
+    "boldText": {
+      "color": "#586E75"
     },
-    "red" : {
-      "color" : "#DC322F"
+    "brightBlack": {
+      "color": "#002B36"
     },
-    "green" : {
-      "color" : "#859900"
+    "brightBlue": {
+      "color": "#839496"
     },
-    "boldText" : {
-      "color" : "#586E75"
+    "brightCyan": {
+      "color": "#93A1A1"
     },
-    "brightGreen" : {
-      "color" : "#586E75"
+    "brightGreen": {
+      "color": "#586E75"
     },
-    "background" : {
-      "color" : "#FDF6E3"
+    "brightMagenta": {
+      "color": "#6C71C4"
     },
-    "cursor" : {
-      "color" : "#657B83"
+    "brightRed": {
+      "color": "#CB4B16"
     },
-    "selection" : {
-      "color" : "#EEE8D5"
+    "brightWhite": {
+      "color": "#FDF6E3"
     },
-    "magenta" : {
-      "color" : "#D33682"
+    "brightYellow": {
+      "color": "#657B83"
     },
-    "black" : {
-      "color" : "#073642"
+    "cursor": {
+      "color": "#657B83"
     },
-    "text" : {
-      "color" : "#657B83"
+    "cyan": {
+      "color": "#2AA198"
     },
-    "brightWhite" : {
-      "color" : "#FDF6E3"
+    "green": {
+      "color": "#859900"
     },
-    "brightBlue" : {
-      "color" : "#839496"
+    "magenta": {
+      "color": "#D33682"
     },
-    "brightYellow" : {
-      "color" : "#657B83"
+    "red": {
+      "color": "#DC322F"
     },
-    "cyan" : {
-      "color" : "#2AA198"
+    "selection": {
+      "color": "#EEE8D5"
     },
-    "yellow" : {
-      "color" : "#B58900"
+    "text": {
+      "color": "#657B83"
     },
-    "brightCyan" : {
-      "color" : "#93A1A1"
+    "white": {
+      "color": "#EEE8D5"
     },
-    "brightBlack" : {
-      "color" : "#002B36"
+    "yellow": {
+      "color": "#B58900"
     }
   },
-  "version" : "0.0.1",
-  "license" : "MIT",
-  "type" : "light",
-  "name" : "codeedit-solarized-light",
-  "description" : "Solarized light theme."
+  "type": "light",
+  "version": "0.0.1"
 }

--- a/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/Model/ThemeModel.swift
@@ -214,7 +214,9 @@ final class ThemeModel: ObservableObject {
             "codeedit-xcode-light",
             "codeedit-github-dark",
             "codeedit-github-light",
-            "codeedit-midnight"
+            "codeedit-midnight",
+            "codeedit-solarized-dark",
+            "codeedit-solarized-light"
         ]
         for themeName in bundledThemeNames {
             guard let defaultUrl = Bundle.main.url(forResource: themeName, withExtension: "json") else {


### PR DESCRIPTION
## Description

Add `Solarized` default themes in both dark and light variant.

## Screenshots

### Dark

#### Editor

<img width="1016" alt="Screenshot 2023-01-15 at 01 41 23" src="https://user-images.githubusercontent.com/9460130/212503908-b80ce721-3970-4a86-aa53-40865b647582.png">

#### Terminal

<img width="1016" alt="Screenshot 2023-01-15 at 02 05 56" src="https://user-images.githubusercontent.com/9460130/212503915-290e5a46-4038-4a6e-a527-bd592855da0d.png">

### Light

#### Editor

<img width="1016" alt="Screenshot 2023-01-15 at 01 41 32" src="https://user-images.githubusercontent.com/9460130/212503923-ed2ba00b-bf42-4ba1-8e5c-5587567924f1.png">

#### Terminal

<img width="1016" alt="Screenshot 2023-01-15 at 02 05 50" src="https://user-images.githubusercontent.com/9460130/212503927-cc26a8ba-6d59-48f9-872d-7fb765862cf5.png">

