### PR TITLE
fix: Remove Haptic Feedback on Launch (#916)

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -41,7 +41,6 @@ final class CodeEditSplitViewController: NSSplitViewController {
 
     override func viewWillAppear() {
         super.viewWillAppear()
-        splitView.setPosition(.snapWidth, ofDividerAt: .zero)
     }
 
     // MARK: - NSSplitViewDelegate

--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -39,6 +39,11 @@ final class CodeEditSplitViewController: NSSplitViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // TODO: Set user preferences width if it is not the snap width
+//    override func viewWillAppear() {
+//        super.viewWillAppear()
+//    }
+
     // MARK: - NSSplitViewDelegate
 
     override func splitView(

--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -39,10 +39,6 @@ final class CodeEditSplitViewController: NSSplitViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewWillAppear() {
-        super.viewWillAppear()
-    }
-
     // MARK: - NSSplitViewDelegate
 
     override func splitView(


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->
* Remove the `viewWillAppear` in `CodeEditSplitViewController` that resizes the sidebar when launches. This function is not needed and the resize will trigger the `splitView`, which triggers the haptic feedback.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #916 

# Checklist

<!--- Add things that are not yet implemented above -->
- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] I documented my code
- [x] Review requested