### PR TITLE
fix: Select account provider dialog not closing

### DIFF
--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/AccountSelectionDialog.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/AccountSelectionDialog.swift
@@ -43,7 +43,6 @@ struct AccountSelectionDialog: View {
                     openAccountDialog.toggle()
                 }
                 Button("Continue") {
-                    openAccountDialog.toggle()
                     openGitLogin.toggle()
                 }
                 .sheet(isPresented: $openGitLogin, content: {
@@ -65,13 +64,13 @@ struct AccountSelectionDialog: View {
         case "bitbucketServer":
             implementationNeeded
         case "github":
-            GitHubLoginView(dismissDialog: $openGitLogin)
+            GitHubLoginView(dismissDialog: $openGitLogin, dismissParentDialog: $openAccountDialog)
         case "githubEnterprise":
-            GitHubEnterpriseLoginView(dismissDialog: $openGitLogin)
+            GitHubEnterpriseLoginView(dismissDialog: $openGitLogin, dismissParentDialog: $openAccountDialog)
         case "gitlab":
-            GitLabLoginView(dismissDialog: $openGitLogin)
+            GitLabLoginView(dismissDialog: $openGitLogin, dismissParentDialog: $openAccountDialog)
         case "gitlabSelfHosted":
-            GitLabHostedLoginView(dismissDialog: $openGitLogin)
+            GitLabHostedLoginView(dismissDialog: $openGitLogin, dismissParentDialog: $openAccountDialog)
         default:
             implementationNeeded
         }

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubEnterpriseLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubEnterpriseLoginView.swift
@@ -16,6 +16,7 @@ struct GitHubEnterpriseLoginView: View {
     @Environment(\.openURL) var createToken
 
     @Binding var dismissDialog: Bool
+    @Binding var dismissParentDialog: Bool
 
     @StateObject
     private var prefs: AppPreferencesModel = .shared
@@ -103,6 +104,7 @@ struct GitHubEnterpriseLoginView: View {
                     )
                     keychain.set(accountToken, forKey: "github_\(accountName)_enterprise")
                     dismissDialog = false
+                    dismissParentDialog = false
                 }
             case .failure(let error):
                 print(error)

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubLoginView.swift
@@ -17,6 +17,7 @@ struct GitHubLoginView: View {
     private let keychain = CodeEditKeychain()
 
     @Binding var dismissDialog: Bool
+    @Binding var dismissParentDialog: Bool
 
     @StateObject
     private var prefs: AppPreferencesModel = .shared
@@ -126,6 +127,7 @@ struct GitHubLoginView: View {
                     )
                     keychain.set(accountToken, forKey: "github_\(accountName)")
                     dismissDialog.toggle()
+                    dismissParentDialog.toggle()
                 }
             case .failure(let error):
                 print(error)

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabHostedLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabHostedLoginView.swift
@@ -15,6 +15,7 @@ struct GitLabHostedLoginView: View {
     @Environment(\.openURL) var createToken
 
     @Binding var dismissDialog: Bool
+    @Binding var dismissParentDialog: Bool
 
     @StateObject
     private var prefs: AppPreferencesModel = .shared
@@ -99,6 +100,7 @@ struct GitLabHostedLoginView: View {
                     )
                     keychain.set(accountToken, forKey: "gitlab_\(gitAccountName)_hosted")
                     dismissDialog = false
+                    dismissParentDialog = false
                 }
             case .failure(let error):
                 print(error)

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabLoginView.swift
@@ -17,6 +17,7 @@ struct GitLabLoginView: View {
     private let keychain = CodeEditKeychain()
 
     @Binding var dismissDialog: Bool
+    @Binding var dismissParentDialog: Bool
 
     @StateObject
     private var prefs: AppPreferencesModel = .shared
@@ -94,6 +95,7 @@ struct GitLabLoginView: View {
                     )
                     keychain.set(accountToken, forKey: "gitlab_\(accountName)")
                     dismissDialog = false
+                    dismissParentDialog = false
                 }
             case .failure(let error):
                 print(error)


### PR DESCRIPTION
# Description

The solution implemented basically does not toggle `openAccountDialog` off after selecting a git account until after a successful git account login since `AccountSelectionDialog` holds the state variable (`openGitLogin`) for `openAccountLoginDialog` to stay open

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* closes #931

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] I documented my code
- [ ] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

Note: Pay attention to the top of the recording, this is where I `ctrl + up arrow` to show that there isn't another account selection dialog hiding behind the preferences window similar to the video in the linked issue

https://user-images.githubusercontent.com/46465568/212588292-cc5984b6-c9c5-4611-a53d-7aac4b829522.mov

