### PR TITLE
Save UI state per Workspace

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -65,6 +65,8 @@ final class CodeEditSplitViewController: NSSplitViewController {
                 key: isInspectorCollapsedStateName
             ) as? Bool ?? true
         }
+
+        self.insertToolbarItemIfNeeded()
     }
 
     // MARK: - NSSplitViewDelegate

--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -17,6 +17,10 @@ private extension CGFloat {
 final class CodeEditSplitViewController: NSSplitViewController {
     private var workspace: WorkspaceDocument
     private let widthStateName: String = "\(String(describing: CodeEditSplitViewController.self))-Width"
+    private let isNavigatorCollapsedStateName: String
+        = "\(String(describing: CodeEditSplitViewController.self))-IsNavigatorCollapsed"
+    private let isInspectorCollapsedStateName: String
+        = "\(String(describing: CodeEditSplitViewController.self))-IsInspectorCollapsed"
     private var setWidthFromState = false
 
     // Properties
@@ -49,6 +53,18 @@ final class CodeEditSplitViewController: NSSplitViewController {
         let width = workspace.getFromWorkspaceState(key: self.widthStateName) as? CGFloat
         splitView.setPosition(width ?? .snapWidth, ofDividerAt: .zero)
         setWidthFromState = true
+
+        if let firstSplitView = splitViewItems.first {
+            firstSplitView.isCollapsed = workspace.getFromWorkspaceState(
+                key: isNavigatorCollapsedStateName
+            ) as? Bool ?? false
+        }
+
+        if let lastSplitView = splitViewItems.last {
+            lastSplitView.isCollapsed = workspace.getFromWorkspaceState(
+                key: isInspectorCollapsedStateName
+            ) as? Bool ?? true
+        }
     }
 
     // MARK: - NSSplitViewDelegate
@@ -97,6 +113,14 @@ final class CodeEditSplitViewController: NSSplitViewController {
                 workspace.addToWorkspaceState(key: self.widthStateName, value: width)
             }
         }
+    }
+
+    func saveNavigatorCollapsedState(isCollapsed: Bool) {
+        workspace.addToWorkspaceState(key: isNavigatorCollapsedStateName, value: isCollapsed)
+    }
+
+    func saveInspectorCollapsedState(isCollapsed: Bool) {
+        workspace.addToWorkspaceState(key: isInspectorCollapsedStateName, value: isCollapsed)
     }
 
     /// Quick fix for list tracking separator needing to be added again after closing,

--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -47,7 +47,7 @@ final class CodeEditSplitViewController: NSSplitViewController {
     override func viewWillAppear() {
         super.viewWillAppear()
         let width = workspace.getFromWorkspaceState(key: self.widthStateName) as? CGFloat
-        splitView.setPosition(width ?? CodeEditWindowController.minSidebarWidth, ofDividerAt: .zero)
+        splitView.setPosition(width ?? .snapWidth, ofDividerAt: .zero)
         setWidthFromState = true
     }
 

--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -46,8 +46,8 @@ final class CodeEditSplitViewController: NSSplitViewController {
 
     override func viewWillAppear() {
         super.viewWillAppear()
-        let width = workspace.getFromWorkspaceState(key: self.widthStateName) as? CGFloat ?? 0
-        splitView.setPosition(width, ofDividerAt: .zero)
+        let width = workspace.getFromWorkspaceState(key: self.widthStateName) as? CGFloat
+        splitView.setPosition(width ?? CodeEditWindowController.minSidebarWidth, ofDividerAt: .zero)
         setWidthFromState = true
     }
 

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -215,6 +215,9 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
     @objc func toggleFirstPanel() {
         guard let firstSplitView = splitViewController.splitViewItems.first else { return }
         firstSplitView.animator().isCollapsed.toggle()
+        if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
+            codeEditSplitVC.saveNavigatorCollapsedState(isCollapsed: firstSplitView.isCollapsed)
+        }
     }
 
     @objc func toggleLastPanel() {
@@ -224,6 +227,9 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
             window?.toolbar?.removeItem(at: 4)
         } else {
             window?.toolbar?.insertItem(withItemIdentifier: .itemListTrackingSeparator, at: 4)
+        }
+        if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
+            codeEditSplitVC.saveInspectorCollapsedState(isCollapsed: lastSplitView.isCollapsed)
         }
     }
 

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -68,7 +68,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
 
     private func setupSplitView(with workspace: WorkspaceDocument) {
         let feedbackPerformer = NSHapticFeedbackManager.defaultPerformer
-        let splitVC = CodeEditSplitViewController(feedbackPerformer: feedbackPerformer)
+        let splitVC = CodeEditSplitViewController(workspace: workspace, feedbackPerformer: feedbackPerformer)
 
         let navigatorView = NavigatorSidebarView(workspace: workspace)
         let navigator = NSSplitViewItem(

--- a/CodeEdit/Features/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument.swift
@@ -22,6 +22,17 @@ import CodeEditKit
     @Published var selectionState: WorkspaceSelectionState = .init()
     @Published var fileItems: [WorkspaceClient.FileItem] = []
 
+    var workspaceState: [String: Any] {
+        get {
+            let key = "workspaceState-\(self.fileURL?.absoluteString ?? "")"
+            return UserDefaults.standard.object(forKey: key) as? [String: Any] ?? [:]
+        }
+        set {
+            let key = "workspaceState-\(self.fileURL?.absoluteString ?? "")"
+            UserDefaults.standard.set(newValue, forKey: key)
+        }
+    }
+
     var statusBarModel: StatusBarViewModel?
     var searchState: SearchState?
     var quickOpenViewModel: QuickOpenViewModel?
@@ -34,6 +45,14 @@ import CodeEditKit
     deinit {
         cancellables.forEach { $0.cancel() }
         NotificationCenter.default.removeObserver(self)
+    }
+
+    func getFromWorkspaceState(key: String) -> Any? {
+        return workspaceState[key]
+    }
+
+    func addToWorkspaceState(key: String, value: Any) {
+        workspaceState.updateValue(value, forKey: key)
     }
 
     // MARK: Open Tabs

--- a/CodeEdit/Features/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument.swift
@@ -177,6 +177,22 @@ import CodeEditKit
         self.addToWorkspaceState(key: activeTabStateName, value: fileItem.url.absoluteString)
     }
 
+    /// Tabs reordered
+    /// - Parameter openedTabs: reordered tabs
+    func reorderedTabs(openedTabs: [TabBarItemID]) {
+        selectionState.openedTabs = openedTabs
+
+        if openedTabsFromState {
+            var openTabsInState: [String] = []
+            for openTabId in openedTabs {
+                guard let item = selectionState.getItemByTab(id: openTabId) as? WorkspaceClient.FileItem
+                else { continue }
+                openTabsInState.append(item.url.absoluteString)
+            }
+            self.addToWorkspaceState(key: openTabsStateName, value: openTabsInState)
+        }
+    }
+
     /// Closes an open temporary tab,  does not save the temporary tab's file.
     /// Removes the tab item from `openedCodeFiles`, `openedExtensions`, and `openFileItems`.
     private func closeTemporaryTab() {

--- a/CodeEdit/Features/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument.swift
@@ -173,6 +173,7 @@ import CodeEditKit
     /// Switched the active tab to current tab
     /// - Parameter item: tab item that is now active.
     func switchedTab(item: TabBarItemRepresentable) {
+        selectionState.selectedId = item.tabID
         guard let fileItem = item as? WorkspaceClient.FileItem else { return }
         self.addToWorkspaceState(key: activeTabStateName, value: fileItem.url.absoluteString)
     }

--- a/CodeEdit/Features/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument.swift
@@ -368,7 +368,7 @@ import CodeEditKit
         self.searchState = .init(self)
         self.quickOpenViewModel = .init(fileURL: url)
         self.commandsPaletteState = .init()
-        self.statusBarModel = .init(workspaceURL: url)
+        self.statusBarModel = .init(workspace: self, workspaceURL: url)
 
         NotificationCenter.default.addObserver(
             self,

--- a/CodeEdit/Features/StatusBar/ViewModels/StatusBarViewModel.swift
+++ b/CodeEdit/Features/StatusBar/ViewModels/StatusBarViewModel.swift
@@ -12,6 +12,10 @@ import SwiftUI
 /// A model class to host and manage data for the ``StatusBarView``
 ///
 class StatusBarViewModel: ObservableObject {
+    private let isStatusBarDrawerCollapsedStateName: String
+        = "\(String(describing: StatusBarViewModel.self))-IsStatusBarDrawerCollapsed"
+    private let statusBarDrawerHeightStateName: String
+        = "\(String(describing: StatusBarViewModel.self))-StatusBarDrawerHeight"
 
     // TODO: Implement logic for updating values
     // TODO: Add @Published vars for indentation, encoding, linebreak
@@ -54,6 +58,8 @@ class StatusBarViewModel: ObservableObject {
     /// Returns the font for status bar items to use
     private(set) var toolbarFont: Font = .system(size: 11)
 
+    private(set) var workspace: WorkspaceDocument
+
     /// The base URL of the workspace
     private(set) var workspaceURL: URL
 
@@ -69,7 +75,24 @@ class StatusBarViewModel: ObservableObject {
 
     /// Initialize with a GitClient
     /// - Parameter workspaceURL: the current workspace URL
-    init(workspaceURL: URL) {
+    init(workspace: WorkspaceDocument, workspaceURL: URL) {
+        self.workspace = workspace
         self.workspaceURL = workspaceURL
+
+        var currentHeight = workspace.getFromWorkspaceState(key: statusBarDrawerHeightStateName) as? Double
+                            ?? self.standardHeight
+
+        self.isExpanded = workspace.getFromWorkspaceState(key: isStatusBarDrawerCollapsedStateName) as? Bool ?? false
+        if self.isExpanded {
+            self.currentHeight = currentHeight
+        }
+    }
+
+    func saveIsExpandedToState() {
+        self.workspace.addToWorkspaceState(key: isStatusBarDrawerCollapsedStateName, value: self.isExpanded)
+    }
+
+    func saveHeightToState(height: Double) {
+        self.workspace.addToWorkspaceState(key: statusBarDrawerHeightStateName, value: height)
     }
 }

--- a/CodeEdit/Features/StatusBar/ViewModels/StatusBarViewModel.swift
+++ b/CodeEdit/Features/StatusBar/ViewModels/StatusBarViewModel.swift
@@ -81,6 +81,9 @@ class StatusBarViewModel: ObservableObject {
 
         var currentHeight = workspace.getFromWorkspaceState(key: statusBarDrawerHeightStateName) as? Double
                             ?? self.standardHeight
+        if currentHeight == 0 {
+            currentHeight = self.standardHeight
+        }
 
         self.isExpanded = workspace.getFromWorkspaceState(key: isStatusBarDrawerCollapsedStateName) as? Bool ?? false
         if self.isExpanded {

--- a/CodeEdit/Features/StatusBar/Views/StatusBarDrawer/StatusBarDrawer.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarDrawer/StatusBarDrawer.swift
@@ -11,12 +11,6 @@ struct StatusBarDrawer: View {
     @EnvironmentObject
     private var model: StatusBarViewModel
 
-    @ObservedObject
-    private var prefs: AppPreferencesModel = .shared
-
-    @Environment(\.colorScheme)
-    private var colorScheme
-
     @State
     private var searchText = ""
 
@@ -32,26 +26,31 @@ struct StatusBarDrawer: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            switch model.selectedTab {
-            case 0:
-                TerminalEmulatorView(url: model.workspaceURL)
-                    .background {
-                        if colorScheme == .dark {
-                            if prefs.preferences.theme.selectedTheme == prefs.preferences.theme.selectedLightTheme {
-                                Color.white
+            GeometryReader { geometryProxy in
+                switch model.selectedTab {
+                case 0:
+                    TerminalEmulatorView(url: model.workspaceURL)
+                        .background {
+                            if colorScheme == .dark {
+                                if prefs.preferences.theme.selectedTheme == prefs.preferences.theme.selectedLightTheme {
+                                    Color.white
+                                } else {
+                                    EffectView(.underPageBackground)
+                                }
                             } else {
-                                EffectView(.underPageBackground)
+                                if prefs.preferences.theme.selectedTheme == prefs.preferences.theme.selectedDarkTheme {
+                                    Color.black
+                                } else {
+                                    EffectView(.contentBackground)
+                                }
                             }
-                        } else {
-                            if prefs.preferences.theme.selectedTheme == prefs.preferences.theme.selectedDarkTheme {
-                                Color.black
-                            } else {
-                                EffectView(.contentBackground)
-                            }
-
                         }
-                    }
-            default: Rectangle().foregroundColor(Color(nsColor: .textBackgroundColor))
+                        // When size changes, save new height to workspace state.
+                        .onChange(of: geometryProxy.size.height) { _ in
+                            model.saveHeightToState(height: geometryProxy.size.height)
+                        }
+                default: Rectangle().foregroundColor(Color(nsColor: .textBackgroundColor))
+                }
             }
             HStack(alignment: .center, spacing: 10) {
                 FilterTextField(title: "Filter", text: $searchText)

--- a/CodeEdit/Features/StatusBar/Views/StatusBarDrawer/StatusBarDrawer.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarDrawer/StatusBarDrawer.swift
@@ -11,6 +11,12 @@ struct StatusBarDrawer: View {
     @EnvironmentObject
     private var model: StatusBarViewModel
 
+    @ObservedObject
+    private var prefs: AppPreferencesModel = .shared
+
+    @Environment(\.colorScheme)
+    private var colorScheme
+
     @State
     private var searchText = ""
 

--- a/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarToggleDrawerButton.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarToggleDrawerButton.swift
@@ -27,6 +27,7 @@ internal struct StatusBarToggleDrawerButton: View {
                 model.currentHeight = 300
             }
         }
+        self.model.saveIsExpandedToState()
     }
 
     internal var body: some View {

--- a/CodeEdit/Features/TabBar/Views/TabBarItemView.swift
+++ b/CodeEdit/Features/TabBar/Views/TabBarItemView.swift
@@ -95,7 +95,6 @@ struct TabBarItemView: View {
     private func switchAction() {
         // Only set the `selectedId` when they are not equal to avoid performance issue for now.
         if workspace.selectionState.selectedId != item.tabID {
-            workspace.selectionState.selectedId = item.tabID
             workspace.switchedTab(item: item)
         }
     }

--- a/CodeEdit/Features/TabBar/Views/TabBarItemView.swift
+++ b/CodeEdit/Features/TabBar/Views/TabBarItemView.swift
@@ -96,6 +96,7 @@ struct TabBarItemView: View {
         // Only set the `selectedId` when they are not equal to avoid performance issue for now.
         if workspace.selectionState.selectedId != item.tabID {
             workspace.selectionState.selectedId = item.tabID
+            workspace.switchedTab(item: item)
         }
     }
 

--- a/CodeEdit/Features/TabBar/Views/TabBarView.swift
+++ b/CodeEdit/Features/TabBar/Views/TabBarView.swift
@@ -237,7 +237,7 @@ struct TabBarView: View {
                 // In order to avoid the lag due to the update of workspace state.
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.40) {
                     if draggingStartLocation == nil {
-                        workspace.selectionState.openedTabs = openedTabs
+                        workspace.reorderedTabs(openedTabs: openedTabs)
                     }
                 }
             })

--- a/CodeEditTests/Features/Documents/DocumentsUnitTests.swift
+++ b/CodeEditTests/Features/Documents/DocumentsUnitTests.swift
@@ -18,7 +18,7 @@ final class DocumentsUnitTests: XCTestCase {
     override func setUp() {
         super.setUp()
         hapticFeedbackPerformerMock = .init()
-        splitViewController = .init(feedbackPerformer: hapticFeedbackPerformerMock)
+        splitViewController = .init(workspace: WorkspaceDocument(), feedbackPerformer: hapticFeedbackPerformerMock)
     }
 
     override func tearDown() {


### PR DESCRIPTION
# Description

Save UI state per Workspace.
- [x] sidebar width
- [x] which files are open
- [x] which editor tab is active
- [x] order of editor tabs
- [ ] the navigator sidebar, inspector sidebar, or debugger drawer
    - [x] opened/closed state
    - [ ] active tab,
    - [ ] tab order in each
- [ ] editor layout (when we build split editor layout in - does not need to be done now consequently)

# Related Issue

* #917

# Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

