### PR TITLE
Update Clone From label in Account Preferences

### DIFF
--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/AccountPreferencesView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/AccountPreferencesView.swift
@@ -96,7 +96,7 @@ struct AccountPreferencesView: View {
                     }
                     .pickerStyle(.radioGroup)
 
-                    Text("New repositories will be cloned from Github using HTTPS.")
+                    Text("New repositories will be cloned from Github using \(cloneUsing ? "SSH" : "HTTPS").")
                         .lineLimit(2)
                         .font(.system(size: 11))
                         .foregroundColor(Color.secondary)


### PR DESCRIPTION
I updated the label to display the correct clone source. Instead of always displaying HTTPS, it will now display the correct provider.

# Description

Fixed the `Clone From` text in the `AccountPreferencesView`. Now, instead of always displaying `HTTPS`, it will display the correct source based on the above `Picker`'s selection. If the `Picker` is set to `SSH`, it will now say: 
> New repositories will be cloned from GitHub using SSH.

# Related Issue

* #986 - this fixes the part of this issue that mentions the label not showing the correct clone source.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<img width="662" alt="Screenshot 2023-01-16 at 1 28 32 PM" src="https://user-images.githubusercontent.com/104732280/212760834-88831120-a336-493a-82d5-43d29f4fc2b2.png">

