### PR TITLE
Redesigned Acknowledgements Window, small modifications to About Window

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -312,6 +312,8 @@
 		6C48D8F22972DAFC00D6D205 /* Env+IsFullscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F12972DAFC00D6D205 /* Env+IsFullscreen.swift */; };
 		6C48D8F42972DB1A00D6D205 /* Env+Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F32972DB1A00D6D205 /* Env+Window.swift */; };
 		6C48D8F72972E5F300D6D205 /* WindowObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F62972E5F300D6D205 /* WindowObserver.swift */; };
+		6C97EBCC2978760400302F95 /* AcknowledgementsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C97EBCB2978760400302F95 /* AcknowledgementsWindowController.swift */; };
+		6C97EBCF297876E500302F95 /* AboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C97EBCE297876E500302F95 /* AboutWindowController.swift */; };
 		6CDA84AD284C1BA000C1CC3A /* TabBarContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */; };
 		B62617282964924E00E866AB /* CodeEditKit in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 2801BB89290D5A8E00EBF552 /* CodeEditKit */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3327DA9E1000EA4DBD /* Assets.xcassets */; };
@@ -689,6 +691,8 @@
 		6C48D8F12972DAFC00D6D205 /* Env+IsFullscreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Env+IsFullscreen.swift"; sourceTree = "<group>"; };
 		6C48D8F32972DB1A00D6D205 /* Env+Window.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Env+Window.swift"; sourceTree = "<group>"; };
 		6C48D8F62972E5F300D6D205 /* WindowObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowObserver.swift; sourceTree = "<group>"; };
+		6C97EBCB2978760400302F95 /* AcknowledgementsWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsWindowController.swift; sourceTree = "<group>"; };
+		6C97EBCE297876E500302F95 /* AboutWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutWindowController.swift; sourceTree = "<group>"; };
 		6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarContextMenu.swift; sourceTree = "<group>"; };
 		B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodeEdit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = WorkspaceView.swift; sourceTree = "<group>"; tabWidth = 4; };
@@ -1010,6 +1014,7 @@
 			isa = PBXGroup;
 			children = (
 				582213EF291834A500EFE361 /* AboutView.swift */,
+				6C97EBCE297876E500302F95 /* AboutWindowController.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1214,6 +1219,7 @@
 			isa = PBXGroup;
 			children = (
 				5878DA81291863F900DD95A3 /* AcknowledgementsView.swift */,
+				6C97EBCB2978760400302F95 /* AcknowledgementsWindowController.swift */,
 				5878DA832918642000DD95A3 /* ParsePackagesResolved.swift */,
 			);
 			path = Views;
@@ -2668,6 +2674,7 @@
 				58822526292C280D00E83CDE /* StatusBarBreakpointButton.swift in Sources */,
 				58D01C96293167DC00C5B6B4 /* Date+Formatted.swift in Sources */,
 				587B9D9E29300ABD00AC7927 /* FontPickerView.swift in Sources */,
+				6C97EBCF297876E500302F95 /* AboutWindowController.swift in Sources */,
 				58822529292C280D00E83CDE /* StatusBarLineEndSelector.swift in Sources */,
 				58F2EAE7292FB2B0004A9BDE /* GeneralPreferencesView.swift in Sources */,
 				5C4BB1E128212B1E00A92FB2 /* World.swift in Sources */,
@@ -2746,6 +2753,7 @@
 				58F2EAEF292FB2B0004A9BDE /* ThemePreferencesView.swift in Sources */,
 				B6EE989027E8879A00CDD8AB /* InspectorSidebarView.swift in Sources */,
 				587B9DA229300ABD00AC7927 /* EffectView.swift in Sources */,
+				6C97EBCC2978760400302F95 /* AcknowledgementsWindowController.swift in Sources */,
 				58798250292E78D80085B254 /* CodeFile.swift in Sources */,
 				5878DAA5291AE76700DD95A3 /* QuickOpenView.swift in Sources */,
 				201169D72837B2E300F92B46 /* SourceControlNavigatorView.swift in Sources */,

--- a/CodeEdit/Features/About/Views/AboutView.swift
+++ b/CodeEdit/Features/About/Views/AboutView.swift
@@ -33,8 +33,10 @@ public struct AboutView: View {
                 bottomMetaData
                 actionButtons
             }
-            .padding([.trailing, .bottom])
+            .padding([.trailing, .vertical])
         }
+        .background(.regularMaterial)
+        .edgesIgnoringSafeArea(.top)
     }
 
     // MARK: Sub-Views
@@ -73,16 +75,15 @@ public struct AboutView: View {
             Button {
                 AcknowledgementsView().showWindow(width: 300, height: 400)
             } label: {
-                Text("Acknowledgments")
-                    .frame(maxWidth: .infinity)
+                Text("Acknowledgements")
+                    .foregroundColor(.primary)
             }
+
             Button {
-                guard let url = URL(string: "https://github.com/CodeEditApp/CodeEdit/blob/main/LICENSE.md")
-                else { return }
-                openURL(url)
+                openURL(URL(string: "https://github.com/CodeEditApp/CodeEdit/blob/main/LICENSE.md")!)
             } label: {
                 Text("License Agreement")
-                    .frame(maxWidth: .infinity)
+                    .foregroundColor(.primary)
             }
         }
     }
@@ -93,53 +94,5 @@ public struct AboutView: View {
             size: NSSize(width: width, height: height)
         )
         .showWindow(nil)
-    }
-}
-
-final class AboutViewWindowController: NSWindowController {
-    convenience init<T: View>(view: T, size: NSSize) {
-        let hostingController = NSHostingController(rootView: view)
-        // New window holding our SwiftUI view
-        let window = NSWindow(contentViewController: hostingController)
-        self.init(window: window)
-        window.setContentSize(size)
-        window.styleMask.remove(.resizable)
-        window.styleMask.insert(.fullSizeContentView)
-        window.alphaValue = 0.5
-        window.styleMask.remove(.miniaturizable)
-    }
-
-    override func showWindow(_ sender: Any?) {
-        window?.center()
-        window?.alphaValue = 0.0
-
-        super.showWindow(sender)
-
-        window?.animator().alphaValue = 1.0
-
-        // close the window when the escape key is pressed
-        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard event.keyCode == 53 else { return event }
-
-            self.closeAnimated()
-
-            return nil
-        }
-
-        window?.collectionBehavior = [.transient, .ignoresCycle]
-        window?.isMovableByWindowBackground = true
-        window?.titlebarAppearsTransparent = true
-        window?.titleVisibility = .hidden
-        window?.isExcludedFromWindowsMenu = true
-    }
-
-    func closeAnimated() {
-        NSAnimationContext.beginGrouping()
-        NSAnimationContext.current.duration = 0.4
-        NSAnimationContext.current.completionHandler = {
-            self.close()
-        }
-        window?.animator().alphaValue = 0.0
-        NSAnimationContext.endGrouping()
     }
 }

--- a/CodeEdit/Features/About/Views/AboutWindowController.swift
+++ b/CodeEdit/Features/About/Views/AboutWindowController.swift
@@ -1,0 +1,58 @@
+//
+//  AboutWindowController.swift
+//  CodeEdit
+//
+//  Created by Wouter Hennen on 18/01/2023.
+//
+
+import SwiftUI
+
+final class AboutViewWindowController: NSWindowController {
+    convenience init<T: View>(view: T, size: NSSize) {
+        let hostingController = NSHostingController(rootView: view)
+        // New window holding our SwiftUI view
+        let window = NSWindow(contentViewController: hostingController)
+        self.init(window: window)
+        window.setContentSize(size)
+        window.styleMask = [.closable, .fullSizeContentView, .titled, .nonactivatingPanel]
+        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        window.standardWindowButton(.zoomButton)?.isHidden = true
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.backgroundColor = .gray.withAlphaComponent(0.2)
+    }
+
+    override func showWindow(_ sender: Any?) {
+        window?.center()
+        window?.alphaValue = 0.0
+
+        super.showWindow(sender)
+
+        window?.animator().alphaValue = 1.0
+
+        // close the window when the escape key is pressed
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.keyCode == 53 else { return event }
+
+            self.closeAnimated()
+
+            return nil
+        }
+
+        window?.collectionBehavior = [.transient, .ignoresCycle]
+        window?.isMovableByWindowBackground = true
+        window?.titlebarAppearsTransparent = true
+        window?.titleVisibility = .hidden
+        window?.isExcludedFromWindowsMenu = true
+    }
+
+    func closeAnimated() {
+        NSAnimationContext.beginGrouping()
+        NSAnimationContext.current.duration = 0.4
+        NSAnimationContext.current.completionHandler = {
+            self.close()
+        }
+        window?.animator().alphaValue = 0.0
+        NSAnimationContext.endGrouping()
+    }
+}

--- a/CodeEdit/Features/Acknowledgements/Views/AcknowledgementsView.swift
+++ b/CodeEdit/Features/Acknowledgements/Views/AcknowledgementsView.swift
@@ -9,104 +9,46 @@ import SwiftUI
 
 struct AcknowledgementsView: View {
 
+    @Environment(\.openURL) private var openURL
+
     @ObservedObject
-    private var model: AcknowledgementsViewModel
-
-    init() {
-        self.model = .init()
-    }
-
-    init(_ dependencies: [AcknowledgementDependency]) {
-        self.model = .init(dependencies)
-    }
+    private var model = AcknowledgementsViewModel()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 15) {
-            Text("Dependencies")
-                .font(.system(size: 18, weight: .semibold)).padding([.leading, .top], 10.0)
+        VStack {
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 70, height: 70)
+            Text("Acknowledgements")
+                .font(.largeTitle)
+                .fontWeight(.bold)
             ScrollView {
-                VStack(alignment: .leading, spacing: 10) {
-                    ForEach(model.acknowledgements, id: \.name) { acknowledgement in
-                        AcknowledgementRow(acknowledgement: acknowledgement)
-                            .listRowBackground(Color.clear)
+                ForEach(model.acknowledgements, id: \.name) { acknowledgement in
+                    HStack {
+                        Text(acknowledgement.name)
+                            .font(.title3)
+                            .fontWeight(.semibold)
+
+                        Spacer()
+
+                        Button {
+                            openURL(acknowledgement.repositoryURL)
+                        } label: {
+                            Image(systemName: "arrow.right.circle.fill")
+                                .foregroundColor(Color(nsColor: .tertiaryLabelColor))
+                        }
+                        .buttonStyle(.plain)
                     }
-                }.padding(.horizontal, 15)
+                    .frame(width: 200)
+                    .padding(.vertical, 2)
+                }
             }
         }
-        .frame(minWidth: 300, alignment: .leading)
+        .frame(width: 350, height: 420)
+        .background(.regularMaterial)
     }
 
     func showWindow(width: CGFloat, height: CGFloat) {
         AcknowledgementsViewWindowController(view: self, size: NSSize(width: width, height: height)).showWindow(nil)
-    }
-}
-
-struct AcknowledgementRow: View {
-    @Environment(\.openURL) var openURL
-
-    var acknowledgement: AcknowledgementDependency
-
-    var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 10) {
-            Text(acknowledgement.name)
-                .bold()
-            Text(acknowledgement.version)
-                .font(.subheadline)
-                .foregroundColor(.secondary)
-                .padding(.leading, -5.0)
-            Spacer()
-            Button(action: {
-                openURL(acknowledgement.repositoryURL)
-            }, label: {
-                Image(systemName: "arrow.right.circle.fill")
-                    .foregroundColor(Color(nsColor: .tertiaryLabelColor))
-            }).buttonStyle(.plain)
-        }
-    }
-}
-
-final class AcknowledgementsViewWindowController: NSWindowController {
-    convenience init<T: View>(view: T, size: NSSize) {
-        let hostingController = NSHostingController(rootView: view)
-        // New window holding our SwiftUI view
-        let window = NSWindow(contentViewController: hostingController)
-        self.init(window: window)
-        window.setContentSize(size)
-        window.styleMask.remove(.resizable)
-        window.styleMask.insert(.fullSizeContentView)
-        window.alphaValue = 0.5
-        window.styleMask.remove(.miniaturizable)
-    }
-
-    override func showWindow(_ sender: Any?) {
-        window?.center()
-        window?.alphaValue = 0.0
-
-        super.showWindow(sender)
-
-        window?.animator().alphaValue = 1.0
-
-        // close the window when the escape key is pressed
-        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard event.keyCode == 53 else { return event }
-
-            self.closeAnimated()
-
-            return nil
-        }
-
-        window?.collectionBehavior = [.transient, .ignoresCycle]
-        window?.isMovableByWindowBackground = true
-        window?.title = "Acknowledgements"
-    }
-
-    func closeAnimated() {
-        NSAnimationContext.beginGrouping()
-        NSAnimationContext.current.duration = 0.4
-        NSAnimationContext.current.completionHandler = {
-            self.close()
-        }
-        window?.animator().alphaValue = 0.0
-        NSAnimationContext.endGrouping()
     }
 }

--- a/CodeEdit/Features/Acknowledgements/Views/AcknowledgementsWindowController.swift
+++ b/CodeEdit/Features/Acknowledgements/Views/AcknowledgementsWindowController.swift
@@ -1,0 +1,56 @@
+//
+//  AcknowledgementsWindowController.swift
+//  CodeEdit
+//
+//  Created by Wouter Hennen on 18/01/2023.
+//
+
+import SwiftUI
+
+final class AcknowledgementsViewWindowController: NSWindowController {
+    convenience init<T: View>(view: T, size: NSSize) {
+        let hostingController = NSHostingController(rootView: view)
+        // New window holding our SwiftUI view
+        let window = NSWindow(contentViewController: hostingController)
+        self.init(window: window)
+        window.setContentSize(size)
+        window.styleMask = [.closable, .fullSizeContentView, .titled, .nonactivatingPanel]
+        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        window.standardWindowButton(.zoomButton)?.isHidden = true
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.backgroundColor = .gray.withAlphaComponent(0.2)
+    }
+
+    override func showWindow(_ sender: Any?) {
+        window?.center()
+        window?.alphaValue = 0.0
+
+        super.showWindow(sender)
+
+        window?.animator().alphaValue = 1.0
+
+        // close the window when the escape key is pressed
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.keyCode == 53 else { return event }
+
+            self.closeAnimated()
+
+            return nil
+        }
+
+        window?.collectionBehavior = [.transient, .ignoresCycle]
+        window?.isMovableByWindowBackground = true
+        window?.title = "Acknowledgements"
+    }
+
+    func closeAnimated() {
+        NSAnimationContext.beginGrouping()
+        NSAnimationContext.current.duration = 0.4
+        NSAnimationContext.current.completionHandler = {
+            self.close()
+        }
+        window?.animator().alphaValue = 0.0
+        NSAnimationContext.endGrouping()
+    }
+}


### PR DESCRIPTION
Signed-off-by: Wouter01 <wouterhennen@gmail.com>

### About Window
- Added translucency
- Fixed vertical alignment of app icon
- Disabled minimize and zoom buttons are now hidden
- Moved Window Controller to separate file

### Acknowledgements Window
- Added translucency
- Added Icon
- Made titlebar transparent & without title
- Disabled minimize and zoom buttons are now hidden
- Centered Acknowledgements in view
- Bigger font
- Moved Window Controller to separate file

# Related Issue
None

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

### Before
<img width="633" alt="Scherm­afbeelding 2023-01-18 om 19 58 58" src="https://user-images.githubusercontent.com/62355975/213270299-beee6b03-9d59-44e9-8a63-1d58a1323825.png">
<img width="393" alt="Scherm­afbeelding 2023-01-18 om 19 59 13" src="https://user-images.githubusercontent.com/62355975/213270342-340f9eef-5d06-4555-8161-f07aa5347743.png">

### After
<img width="546" alt="Scherm­afbeelding 2023-01-18 om 19 59 40" src="https://user-images.githubusercontent.com/62355975/213270426-b0cde98c-38e8-4b6f-ada3-8629588ef1a2.png">
<img width="544" alt="Scherm­afbeelding 2023-01-18 om 20 00 09" src="https://user-images.githubusercontent.com/62355975/213270517-dd34743c-9a26-4064-82d5-5efe8dfb78bc.png">
<img width="419" alt="Scherm­afbeelding 2023-01-18 om 20 00 39" src="https://user-images.githubusercontent.com/62355975/213270627-1a42c8d6-400a-4c13-928f-23267459c78f.png">

<img width="430" alt="Scherm­afbeelding 2023-01-18 om 20 00 21" src="https://user-images.githubusercontent.com/62355975/213270559-ecd49292-e66f-4ae0-9a64-5100c79ad151.png">

