### PR TITLE
use theme background

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -3738,7 +3738,7 @@
 			repositoryURL = "https://github.com/CodeEditApp/CodeEditTextView.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.3.3;
+				version = 0.3.4;
 			};
 		};
 		58F2EB18292FB91C004A9BDE /* XCRemoteSwiftPackageReference "Preferences" */ = {

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "9f79fa8a77ac8708951ef08ccfd4e9ba2e2ba7b2",
-        "version" : "0.3.3"
+        "revision" : "58f794154e9a392a9ac5aae93c39631b79ca7b9c",
+        "version" : "0.3.4"
       }
     },
     {

--- a/CodeEdit/Features/AppPreferences/Model/Terminal/TerminalPreferences.swift
+++ b/CodeEdit/Features/AppPreferences/Model/Terminal/TerminalPreferences.swift
@@ -15,6 +15,9 @@ extension AppPreferences {
         /// If true terminal appearance will always be `dark`. Otherwise it adapts to the system setting.
         var darkAppearance: Bool = false
 
+        /// if true, the terminal uses the background color of the theme, otherwise it is clear
+        var useThemeBackground: Bool = true
+
         /// If true, the terminal treats the `Option` key as the `Meta` key
         var optionAsMeta: Bool = false
 

--- a/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/TerminalThemeView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/TerminalThemeView.swift
@@ -35,6 +35,7 @@ struct TerminalThemeView: View {
     private var topToggles: some View {
         VStack(alignment: .leading) {
             Toggle("Always use dark terminal appearance", isOn: $prefs.preferences.terminal.darkAppearance)
+            Toggle("Use theme background ", isOn: $prefs.preferences.terminal.useThemeBackground)
         }
     }
 

--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -65,6 +65,7 @@ struct CodeFileView: View {
             $codeFile.content,
             language: getLanguage(),
             theme: $selectedTheme.editor.editorTheme,
+            useThemeBackground: $prefs.preferences.theme.useThemeBackground,
             font: $font,
             tabWidth: $prefs.preferences.textEditing.defaultTabWidth,
             lineHeight: $prefs.preferences.textEditing.lineHeightMultiple,
@@ -72,7 +73,22 @@ struct CodeFileView: View {
             cursorPosition: codeFile.$cursorPosition
         )
         .id(codeFile.fileURL)
-        .background(selectedTheme.editor.background.swiftColor)
+        .background {
+            if colorScheme == .dark {
+                if prefs.preferences.theme.selectedTheme == prefs.preferences.theme.selectedLightTheme {
+                    Color.white
+                } else {
+                    EffectView(.underPageBackground)
+                }
+            } else {
+                if prefs.preferences.theme.selectedTheme == prefs.preferences.theme.selectedDarkTheme {
+                    Color.black
+                } else {
+                    EffectView(.contentBackground)
+                }
+
+            }
+        }
         .disabled(!editable)
         .frame(maxHeight: .infinity)
         .onChange(of: ThemeModel.shared.selectedTheme) { newValue in

--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -65,12 +65,12 @@ struct CodeFileView: View {
             $codeFile.content,
             language: getLanguage(),
             theme: $selectedTheme.editor.editorTheme,
-            useThemeBackground: $prefs.preferences.theme.useThemeBackground,
             font: $font,
             tabWidth: $prefs.preferences.textEditing.defaultTabWidth,
             lineHeight: $prefs.preferences.textEditing.lineHeightMultiple,
             wrapLines: $prefs.preferences.textEditing.wrapLinesToEditorWidth,
-            cursorPosition: codeFile.$cursorPosition
+            cursorPosition: codeFile.$cursorPosition,
+            useThemeBackground: prefs.preferences.theme.useThemeBackground
         )
         .id(codeFile.fileURL)
         .background {

--- a/CodeEdit/Features/StatusBar/Views/StatusBarDrawer/StatusBarDrawer.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarDrawer/StatusBarDrawer.swift
@@ -11,6 +11,12 @@ struct StatusBarDrawer: View {
     @EnvironmentObject
     private var model: StatusBarViewModel
 
+    @ObservedObject
+    private var prefs: AppPreferencesModel = .shared
+
+    @Environment(\.colorScheme)
+    private var colorScheme
+
     @State
     private var searchText = ""
 
@@ -27,7 +33,24 @@ struct StatusBarDrawer: View {
     var body: some View {
         VStack(spacing: 0) {
             switch model.selectedTab {
-            case 0: TerminalEmulatorView(url: model.workspaceURL)
+            case 0:
+                TerminalEmulatorView(url: model.workspaceURL)
+                    .background {
+                        if colorScheme == .dark {
+                            if prefs.preferences.theme.selectedTheme == prefs.preferences.theme.selectedLightTheme {
+                                Color.white
+                            } else {
+                                EffectView(.underPageBackground)
+                            }
+                        } else {
+                            if prefs.preferences.theme.selectedTheme == prefs.preferences.theme.selectedDarkTheme {
+                                Color.black
+                            } else {
+                                EffectView(.contentBackground)
+                            }
+
+                        }
+                    }
             default: Rectangle().foregroundColor(Color(nsColor: .textBackgroundColor))
             }
             HStack(alignment: .center, spacing: 10) {

--- a/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
+++ b/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
@@ -175,7 +175,8 @@ struct TerminalEmulatorView: NSViewRepresentable {
             terminal.caretColor = cursorColor
             terminal.selectedTextBackgroundColor = selectionColor
             terminal.nativeForegroundColor = textColor
-            terminal.nativeBackgroundColor = backgroundColor
+            terminal.nativeBackgroundColor = prefs.preferences.terminal.darkAppearance ? backgroundColor : .clear
+            terminal.layer?.backgroundColor = .clear
             terminal.optionAsMetaKey = optionAsMeta
         }
         terminal.appearance = colorAppearance
@@ -201,7 +202,8 @@ struct TerminalEmulatorView: NSViewRepresentable {
         view.caretColor = cursorColor
         view.selectedTextBackgroundColor = selectionColor
         view.nativeForegroundColor = textColor
-        view.nativeBackgroundColor = backgroundColor
+        view.nativeBackgroundColor = prefs.preferences.terminal.darkAppearance ? backgroundColor : .clear
+        view.layer?.backgroundColor = .clear
         view.optionAsMetaKey = optionAsMeta
         view.appearance = colorAppearance
         if TerminalEmulatorView.lastTerminal[url.path] != nil {

--- a/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
+++ b/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
@@ -175,7 +175,7 @@ struct TerminalEmulatorView: NSViewRepresentable {
             terminal.caretColor = cursorColor
             terminal.selectedTextBackgroundColor = selectionColor
             terminal.nativeForegroundColor = textColor
-            terminal.nativeBackgroundColor = prefs.preferences.terminal.darkAppearance ? backgroundColor : .clear
+            terminal.nativeBackgroundColor = prefs.preferences.terminal.useThemeBackground ? backgroundColor : .clear
             terminal.layer?.backgroundColor = .clear
             terminal.optionAsMetaKey = optionAsMeta
         }
@@ -202,7 +202,7 @@ struct TerminalEmulatorView: NSViewRepresentable {
         view.caretColor = cursorColor
         view.selectedTextBackgroundColor = selectionColor
         view.nativeForegroundColor = textColor
-        view.nativeBackgroundColor = prefs.preferences.terminal.darkAppearance ? backgroundColor : .clear
+        view.nativeBackgroundColor = prefs.preferences.terminal.useThemeBackground ? backgroundColor : .clear
         view.layer?.backgroundColor = .clear
         view.optionAsMetaKey = optionAsMeta
         view.appearance = colorAppearance


### PR DESCRIPTION
# Description

Passes theme background preference bindings to `TerminalEmulatorView` and `CodeEditTextView` to change their backgrounds based on these preferences.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* closes #982 
* depends on https://github.com/CodeEditApp/CodeEditTextView/pull/123

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots
With a dark system appearance, the light editor themes will default to a white background if the `use theme background` button is toggled off due to some of the text blending into the background and vice versa for the light system appearance with dark editor themes as mentioned in https://github.com/CodeEditApp/CodeEdit/issues/982#issuecomment-1396275115

https://user-images.githubusercontent.com/46465568/213632693-a4cfb80e-2098-4cc9-a518-ed2c5627663a.mov

https://user-images.githubusercontent.com/46465568/213632714-a80e5ccb-09b5-4388-a467-e1f96e36f465.mov

