### PR TITLE
[chore]: CI - Check CFBundleShortVersionString in Info.plist

### DIFF
--- a/.github/scripts/test_build_number.sh
+++ b/.github/scripts/test_build_number.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+VERS=$(xcrun agvtool mvers -terse1)
+
+if [ "$VERS" == "" ]; then
+  echo "No version number found"
+  echo "Make sure Info.plist has a CFBundleShortVersionString key"
+  echo ""
+  echo "If Info.plist does not have a CFBundleShortVersionString key, add the following to your Info.plist file:"
+  echo ""
+  echo "<key>CFBundleShortVersionString</key>"
+	echo "<string>0.0.1</string>"
+  exit 1
+else
+  echo "Version number is $VERS"
+  exit 0
+fi

--- a/.github/scripts/test_version_number.sh
+++ b/.github/scripts/test_version_number.sh
@@ -9,7 +9,9 @@ if [ "$VERS" == "" ]; then
   echo "If Info.plist does not have a CFBundleShortVersionString key, add the following to your Info.plist file:"
   echo ""
   echo "<key>CFBundleShortVersionString</key>"
-	echo "<string>0.0.1</string>"
+  echo "<string>0.0.1</string>"
+  echo ""
+  echo "For more information see https://github.com/CodeEditApp/CodeEdit/pull/1006"
   exit 1
 else
   echo "Version number is $VERS"

--- a/.github/scripts/test_version_number.sh
+++ b/.github/scripts/test_version_number.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+# get the version number from the Info.plist file using agvtool
 VERS=$(xcrun agvtool mvers -terse1)
 
+# if the version number is empty, exit with an error
 if [ "$VERS" == "" ]; then
   echo "No version number found"
   echo "Make sure Info.plist has a CFBundleShortVersionString key"
@@ -12,8 +14,8 @@ if [ "$VERS" == "" ]; then
   echo "<string>0.0.1</string>"
   echo ""
   echo "For more information see https://github.com/CodeEditApp/CodeEdit/pull/1006"
-  exit 1
+  exit 1 # exit with an error
 else
   echo "Version number is $VERS"
-  exit 0
+  exit 0 # exit with no error
 fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,5 +9,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Check Version Number exists
+        run: exec ./.github/scripts/test_version_number.sh
       - name: Testing App
         run: exec ./.github/scripts/test_app.sh arm

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -3004,7 +3004,7 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CodeEdit/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022-2023 CodeEdit";
 				INFOPLIST_KEY_NSPrincipalClass = CodeEdit.CodeEditApplication;
@@ -3013,7 +3013,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = "Change in Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = austincondiff.CodeEdit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3091,7 +3091,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = OpenWithCodeEdit/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OpenWithCodeEdit;
 				INFOPLIST_KEY_LSUIElement = YES;
@@ -3189,7 +3189,7 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CodeEdit/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022-2023 CodeEdit";
 				INFOPLIST_KEY_NSPrincipalClass = CodeEdit.CodeEditApplication;
@@ -3198,7 +3198,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = "Change in Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = austincondiff.CodeEdit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3276,7 +3276,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = OpenWithCodeEdit/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OpenWithCodeEdit;
 				INFOPLIST_KEY_LSUIElement = YES;
@@ -3309,7 +3309,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = OpenWithCodeEdit/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OpenWithCodeEdit;
 				INFOPLIST_KEY_LSUIElement = YES;
@@ -3342,7 +3342,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = OpenWithCodeEdit/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OpenWithCodeEdit;
 				INFOPLIST_KEY_LSUIElement = YES;
@@ -3507,7 +3507,7 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CodeEdit/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022-2023 CodeEdit";
 				INFOPLIST_KEY_NSPrincipalClass = CodeEdit.CodeEditApplication;
@@ -3516,7 +3516,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = "Change in Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = austincondiff.CodeEdit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3542,7 +3542,7 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CodeEdit/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022-2023 CodeEdit";
 				INFOPLIST_KEY_NSPrincipalClass = CodeEdit.CodeEditApplication;
@@ -3551,7 +3551,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = "Change in Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = austincondiff.CodeEdit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -2,6 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>NSPrincipalClass</key>
+	<string>CodeEdit.CodeEditApplication</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>${CE_COPYRIGHT}</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.0.1</string>
 	<key>CE_VERSION_POSTFIX</key>

--- a/Configs/Alpha.xcconfig
+++ b/Configs/Alpha.xcconfig
@@ -10,3 +10,4 @@
 
 CE_APPICON_NAME = AppIconAlpha
 CE_VERSION_POSTFIX = -alpha
+CE_COPYRIGHT = Copyright © 2022-2023 CodeEdit

--- a/Configs/Beta.xcconfig
+++ b/Configs/Beta.xcconfig
@@ -10,3 +10,4 @@
 
 CE_APPICON_NAME = AppIconBeta
 CE_VERSION_POSTFIX = -beta
+CE_COPYRIGHT = Copyright © 2022-2023 CodeEdit

--- a/Configs/Debug.xcconfig
+++ b/Configs/Debug.xcconfig
@@ -10,3 +10,4 @@
 
 CE_APPICON_NAME = AppIconDev
 CE_VERSION_POSTFIX = -dev
+CE_COPYRIGHT = Copyright © 2022-2023 CodeEdit

--- a/Configs/Release.xcconfig
+++ b/Configs/Release.xcconfig
@@ -10,3 +10,4 @@
 
 CE_APPICON_NAME = AppIcon
 // CE_VERSION_POSTFIX = // this is a placeholder since we don't want a postfix in final release
+CE_COPYRIGHT = Copyright © 2022-2023 CodeEdit

--- a/OpenWithCodeEdit/Info.plist
+++ b/OpenWithCodeEdit/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>
@@ -13,5 +11,27 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>$(PRODUCT_MODULE_NAME).CEOpenWith</string>
 	</dict>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>OpenWithCodeEdit</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>${CE_COPYRIGHT}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.1</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

This PR implements an additional check in the `Tests` workflow to ensure that the manual set `CFBundleShortVersionString` is actually present in `Info.plist`.

This is just a sanity check which helps us catch this unexpected Xcode behavior as early as possible.

## Background

The background of this is, that a couple versions back Xcode moved from having a dedicated `Info.plist` to embedding it into the Target settings. This sometimes causes the deletion of an explicitly set `CFBundleShortVersionString` key in the dedicated `Info.plist` file.

## Fix "No version number found" Error

In order to resolve this issue simply add the following to the `CodeEdit/Info.plist` file:

```xml
<key>CFBundleShortVersionString</key>
<string>0.0.1</string>
```

> The important part is to add it to the `CodeEdit/Info.plist` file instead of selecting the target and using the `Info` tab.

## Additional Changes

- disable Info.plist file generation (use the dedicated file instead)
- migrated all Info properties to static Info.plist file
- use `xcconfig` for copyright string