### PR TITLE
fix: Allow multiple account with same username (#1012)

### DIFF
--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/AccountPreferencesView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/AccountPreferencesView.swift
@@ -88,6 +88,8 @@ struct AccountPreferencesView: View {
                     .padding(.bottom, 5)
 
                 PreferencesSection("Clone Using", width: 100) {
+                    let account = getSourceControlAccount(selectedAccountId: accountSelection ?? "")
+
                     Picker("", selection: $cloneUsing) {
                         Text("HTTPS")
                             .tag(false) // temporary
@@ -96,7 +98,8 @@ struct AccountPreferencesView: View {
                     }
                     .pickerStyle(.radioGroup)
 
-                    Text("New repositories will be cloned from GitHub using \(cloneUsing ? "SSH" : "HTTPS").")
+                    Text("New repositories will be cloned from \(account?.gitProviderDescription ?? "")"
+                         + " using \(cloneUsing ? "SSH" : "HTTPS").")
                         .lineLimit(2)
                         .font(.system(size: 11))
                         .foregroundColor(Color.secondary)

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubEnterpriseLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubEnterpriseLoginView.swift
@@ -86,13 +86,15 @@ struct GitHubEnterpriseLoginView: View {
         GitHubAccount(config).me { response in
             switch response {
             case .success(let user):
-                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased() }) {
-                    print("Account with the username already exists!")
+                if gitAccounts.contains(
+                    where: { $0.id == "\(eneterpriseLink)_\(gitAccountName.lowercased())" }
+                ) {
+                    print("Account with the username and provider already exists!")
                 } else {
                     print(user)
                     prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
                         SourceControlAccounts(
-                            id: gitAccountName.lowercased(),
+                            id: "\(eneterpriseLink)_\(gitAccountName.lowercased())",
                             gitProvider: "GitHub",
                             gitProviderLink: eneterpriseLink,
                             gitProviderDescription: "GitHub",

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubEnterpriseLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubEnterpriseLoginView.swift
@@ -87,7 +87,10 @@ struct GitHubEnterpriseLoginView: View {
             switch response {
             case .success(let user):
                 if gitAccounts.contains(
-                    where: { $0.id == "\(eneterpriseLink)_\(gitAccountName.lowercased())" }
+                    where: {
+                        $0.gitProviderLink == eneterpriseLink &&
+                        $0.gitAccountName.lowercased() == gitAccountName.lowercased()
+                    }
                 ) {
                     print("Account with the username and provider already exists!")
                 } else {

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubLoginView.swift
@@ -106,18 +106,22 @@ struct GitHubLoginView: View {
         let gitAccounts = prefs.preferences.accounts.sourceControlAccounts.gitAccount
 
         let config = GitHubTokenConfiguration(accountToken)
+
+        let providerLink = "https://github.com"
         GitHubAccount(config).me { response in
             switch response {
             case .success(let user):
-                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased() }) {
-                    print("Account with the username already exists!")
+                if gitAccounts.contains(
+                    where: { $0.id == "\(providerLink)_\(gitAccountName.lowercased())" }
+                ) {
+                    print("Account with the username and provider already exists!")
                 } else {
                     print(user)
                     prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
                         SourceControlAccounts(
-                            id: gitAccountName.lowercased(),
+                            id: "\(providerLink)_\(gitAccountName.lowercased())",
                             gitProvider: "GitHub",
-                            gitProviderLink: "https://github.com",
+                            gitProviderLink: providerLink,
                             gitProviderDescription: "GitHub",
                             gitAccountName: gitAccountName,
                             gitCloningProtocol: true,

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Github/GitHubLoginView.swift
@@ -112,7 +112,10 @@ struct GitHubLoginView: View {
             switch response {
             case .success(let user):
                 if gitAccounts.contains(
-                    where: { $0.id == "\(providerLink)_\(gitAccountName.lowercased())" }
+                    where: {
+                        $0.gitProviderLink == providerLink &&
+                        $0.gitAccountName.lowercased() == gitAccountName.lowercased()
+                    }
                 ) {
                     print("Account with the username and provider already exists!")
                 } else {

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabHostedLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabHostedLoginView.swift
@@ -83,7 +83,10 @@ struct GitLabHostedLoginView: View {
             switch response {
             case .success(let user):
                 if gitAccounts.contains(
-                    where: { $0.id == "\(eneterpriseLink)_\(gitAccountName.lowercased())" }
+                    where: {
+                        $0.gitProviderLink == eneterpriseLink &&
+                        $0.gitAccountName.lowercased() == gitAccountName.lowercased()
+                    }
                 ) {
                     print("Account with the username and provider already exists!")
                 } else {

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabHostedLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabHostedLoginView.swift
@@ -82,13 +82,15 @@ struct GitLabHostedLoginView: View {
         GitLabAccount(config).me { response in
             switch response {
             case .success(let user):
-                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased() }) {
-                    print("Account with the username already exists!")
+                if gitAccounts.contains(
+                    where: { $0.id == "\(eneterpriseLink)_\(gitAccountName.lowercased())" }
+                ) {
+                    print("Account with the username and provider already exists!")
                 } else {
                     print(user)
                     prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
                         SourceControlAccounts(
-                            id: gitAccountName.lowercased(),
+                            id: "\(eneterpriseLink)_\(gitAccountName.lowercased())",
                             gitProvider: "GitLab",
                             gitProviderLink: eneterpriseLink,
                             gitProviderDescription: "GitLab",

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabLoginView.swift
@@ -80,7 +80,10 @@ struct GitLabLoginView: View {
             switch response {
             case .success(let user):
                 if gitAccounts.contains(
-                    where: { $0.id == "\(providerLink)_\(gitAccountName.lowercased())" }
+                    where: {
+                        $0.gitProviderLink == providerLink &&
+                        $0.gitAccountName.lowercased() == gitAccountName.lowercased()
+                    }
                 ) {
                     print("Account with the username and provider already exists!")
                 } else {

--- a/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabLoginView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/AccountsPreferences/Accounts/Login/Gitlab/GitLabLoginView.swift
@@ -74,18 +74,22 @@ struct GitLabLoginView: View {
         let gitAccounts = prefs.preferences.accounts.sourceControlAccounts.gitAccount
 
         let config = GitLabTokenConfiguration(accountToken)
+
+        let providerLink = "https://gitlab.com"
         GitLabAccount(config).me { response in
             switch response {
             case .success(let user):
-                if gitAccounts.contains(where: { $0.id == gitAccountName.lowercased() }) {
-                    print("Account with the username already exists!")
+                if gitAccounts.contains(
+                    where: { $0.id == "\(providerLink)_\(gitAccountName.lowercased())" }
+                ) {
+                    print("Account with the username and provider already exists!")
                 } else {
                     print(user)
                     prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
                         SourceControlAccounts(
-                            id: gitAccountName.lowercased(),
+                            id: "\(providerLink)_\(gitAccountName.lowercased())",
                             gitProvider: "GitLab",
-                            gitProviderLink: "https://gitlab.com",
+                            gitProviderLink: providerLink,
                             gitProviderDescription: "GitLab",
                             gitAccountName: gitAccountName,
                             gitCloningProtocol: true,


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->

- Add the `gitProviderLink` as a part of the `SourceControlAccounts`'s ID, which allows us to easily distinguish accounts having the same username but from different git providers (account types)

	- P.S.: I did not use the method mentioned in the issue (add a `gitProviderLink` check) because that solution caused other problems like showing the same account multiple times in settings.

- Check `gitProviderLink` and `gitAccountName` instead of `id` before adding a new account. (Otherwise, changes to the `id` format will partially brake the old accounts added in earlier versions).
- Change how the description below `Clone Using` so it won't always show `New repositories will be cloned from **GitHub** using...`.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #1012

# Checklist

<!--- Add things that are not yet implemented above -->
- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

![image](https://user-images.githubusercontent.com/72877496/213886528-62a1bf61-928c-4220-b027-9a5fa20c1c51.png)

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->