### PR TITLE
[chore]: Adopt code edit symbols 0.1.2

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -3758,7 +3758,7 @@
 			repositoryURL = "https://github.com/CodeEditApp/CodeEditSymbols";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.1;
+				version = 0.1.2;
 			};
 		};
 		287136B1292A407E00E9F5F4 /* XCRemoteSwiftPackageReference "SwiftLintPlugin" */ = {

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditSymbols",
       "state" : {
-        "revision" : "bd23623a9c6100da03a213d2a0b38c0573e078c8",
-        "version" : "0.1.1"
+        "revision" : "fd704f0590489c10f28376dea2317e1b0c801024",
+        "version" : "0.1.2"
       }
     },
     {


### PR DESCRIPTION
# Description

CE symbols 0.1.2 will allow those who don't have v4 SF symbols on their mac yet to continue development (read: Monterey users) 


@lukepistrol addressed this in a comment in the  development discord channel.
<img width="499" alt="image" src="https://user-images.githubusercontent.com/5067237/214155797-50dacd1e-ba2d-4eef-890e-1f782a683645.png">


<img width="556" alt="image" src="https://user-images.githubusercontent.com/5067237/214155649-0aaff96d-d3c1-42de-aee8-6e626053432f.png">

# Screenshots

<img width="238" alt="image" src="https://user-images.githubusercontent.com/5067237/214155871-4fe99858-fc0a-4e2e-8c22-8895010abb7a.png">
