### PR TITLE
Drag and drop file

### DIFF
--- a/CodeEdit/Utils/WorkspaceClient/Model/FileItem.swift
+++ b/CodeEdit/Utils/WorkspaceClient/Model/FileItem.swift
@@ -287,7 +287,14 @@ extension WorkspaceClient {
                 try FileItem.fileManger.moveItem(at: self.url, to: newLocation)
                 self.url = newLocation
             } catch {
-                fatalError(error.localizedDescription)
+                let errorCode = (error as NSError).code
+                let errorAlert = NSAlert()
+                errorAlert.messageText = """
+                The operation can’t be completed because an unexpected error occurred (error code \(String(errorCode))).
+                """
+                errorAlert.alertStyle = .critical
+                errorAlert.addButton(withTitle: "OK")
+                errorAlert.runModal()
             }
         }
     }


### PR DESCRIPTION
# Description

Implement methods for `NSOutlineViewDelegate` to allow for file drag and drop. Also added alerts for replacing files/folders of the same name and when something throws an error like when dragging a folder and trying to drop it into one of it's own descendants

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #1018

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->


https://user-images.githubusercontent.com/46465568/215415796-6e41afdb-77c4-4e22-8cde-3519ac6f3876.mov


https://user-images.githubusercontent.com/46465568/215415863-08fd8748-a8fa-4c27-9dfb-4a3f5559d893.mov



