### PR TITLE
Push newly created file into the workspace (#696)

### DIFF
--- a/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarBottom.swift
+++ b/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarBottom.swift
@@ -35,13 +35,11 @@ struct NavigatorSidebarToolbarBottom: View {
                 guard let root = try? workspace.workspaceClient?.getFileItem(folderURL.path) else { return }
                 let newFile = root.addFile(fileName: "untitled") // TODO: use currently selected file instead of root
 
-                DispatchQueue.global(qos: .background).async {
-                    DispatchQueue.main.sync {
-                        guard let newFileItem = try? workspace.workspaceClient?.getFileItem(newFile) else {
-                            return
-                        }
-                        workspace.openTab(item: newFileItem)
+                DispatchQueue.main.async {
+                    guard let newFileItem = try? workspace.workspaceClient?.getFileItem(newFile) else {
+                        return
                     }
+                    workspace.openTab(item: newFileItem)
                 }
 
             }

--- a/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarBottom.swift
+++ b/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarToolbarBottom.swift
@@ -33,7 +33,17 @@ struct NavigatorSidebarToolbarBottom: View {
             Button("Add File") {
                 guard let folderURL = workspace.workspaceClient?.folderURL() else { return }
                 guard let root = try? workspace.workspaceClient?.getFileItem(folderURL.path) else { return }
-                root.addFile(fileName: "untitled") // TODO: use currently selected file instead of root
+                let newFile = root.addFile(fileName: "untitled") // TODO: use currently selected file instead of root
+
+                DispatchQueue.global(qos: .background).async {
+                    DispatchQueue.main.sync {
+                        guard let newFileItem = try? workspace.workspaceClient?.getFileItem(newFile) else {
+                            return
+                        }
+                        workspace.openTab(item: newFileItem)
+                    }
+                }
+
             }
             Button("Add Folder") {
                 guard let folderURL = workspace.workspaceClient?.folderURL() else { return }

--- a/CodeEdit/Utils/WorkspaceClient/Model/FileItem.swift
+++ b/CodeEdit/Utils/WorkspaceClient/Model/FileItem.swift
@@ -212,7 +212,7 @@ extension WorkspaceClient {
 
         /// This function allows creating files in the selected folder or project main directory
         /// - Parameter fileName: The name of the new file
-        func addFile(fileName: String) {
+        func addFile(fileName: String) -> String {
             // check if folder, if it is create file under self
             var fileUrl = (self.isFolder ?
                        self.url.appendingPathComponent(fileName) :
@@ -231,6 +231,8 @@ extension WorkspaceClient {
                 contents: nil,
                 attributes: [FileAttributeKey.creationDate: Date()]
             )
+
+            return fileUrl.path
         }
 
         /// This function deletes the item or folder from the current project


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->

* In `FileItem.swift`, the `addFile` function was changed to return the newly created file's path.
* In `NavigationSidebarToolbarBottom.swift`, a bit of post-creation code was introduced, placed in the global DispatchQueue, which attempts to open the new file in a new tab in the workspace.

A related PR is being opened in CodeEditTextView, which works in tandem with this one, so the cursor becomes active in the new file after it is created and opened.

Particularly, I would like a review on the code added to `NavigationSidebarToolbarBottom.swift`, as I'm not 100% sure the DispatchQueue behavior is consistent in this case. Certainly without putting it on the queue, the behavior was completely non-deterministic, because the code would sometimes run before the completion of `rebuildFiles` in `Live.swift` (and thus the new FileItem was not yet available).

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #696 
* PR [#144](https://github.com/CodeEditApp/CodeEditTextView/pull/144) from CodeEditTextView.
* #700 (might have been resolved in the process)

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots