### PR TITLE
Improvements to breadcrumbs

### DIFF
--- a/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsMenu.swift
+++ b/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsMenu.swift
@@ -75,8 +75,12 @@ final class BreadcrumbsMenuItem: NSMenuItem {
         if fileItem.children != nil {
             let subMenu = NSMenu()
             submenu = subMenu
-            icon = "folder.fill"
-            color = .secondary
+            icon = fileItem.systemImage
+            if fileItem.parent == nil {
+                color = .accentColor
+            } else {
+                color = .secondary
+            }
         }
         let image = NSImage(
             systemSymbolName: icon,

--- a/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsView.swift
+++ b/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsView.swift
@@ -18,15 +18,24 @@ struct BreadcrumbsView: View {
     @Environment(\.controlActiveState)
     private var activeState
 
-    @State
-    private var fileItems: [WorkspaceClient.FileItem] = []
-
     init(
         file: WorkspaceClient.FileItem,
         tappedOpenFile: @escaping (WorkspaceClient.FileItem) -> Void
     ) {
         self.file = file
         self.tappedOpenFile = tappedOpenFile
+    }
+
+    var fileItems: [WorkspaceClient.FileItem] {
+        var treePath: [WorkspaceClient.FileItem] = []
+        var currentFile: WorkspaceClient.FileItem? = file
+
+        while let currentFileLoop = currentFile {
+            treePath.insert(currentFileLoop, at: 0)
+            currentFile = currentFileLoop.parent
+        }
+        
+        return treePath
     }
 
     var body: some View {
@@ -44,12 +53,6 @@ struct BreadcrumbsView: View {
         }
         .frame(height: 28, alignment: .center)
         .background(EffectView(.headerView).frame(height: 28))
-        .onAppear {
-            fileInfo(self.file)
-        }
-        .onChange(of: file) { newFile in
-            fileInfo(newFile)
-        }
     }
 
     private var chevron: some View {
@@ -59,14 +62,5 @@ struct BreadcrumbsView: View {
             .scaleEffect(x: 1.30, y: 1.0, anchor: .center)
             .imageScale(.large)
             .opacity(activeState != .inactive ? 0.8 : 0.5)
-    }
-
-    private func fileInfo(_ file: WorkspaceClient.FileItem) {
-        fileItems = []
-        var currentFile: WorkspaceClient.FileItem? = file
-        while let currentFileLoop = currentFile {
-            fileItems.insert(currentFileLoop, at: 0)
-            currentFile = currentFileLoop.parent
-        }
     }
 }

--- a/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsView.swift
+++ b/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsView.swift
@@ -34,7 +34,7 @@ struct BreadcrumbsView: View {
             treePath.insert(currentFileLoop, at: 0)
             currentFile = currentFileLoop.parent
         }
-        
+
         return treePath
     }
 

--- a/CodeEdit/Utils/WorkspaceClient/Model/FileItem.swift
+++ b/CodeEdit/Utils/WorkspaceClient/Model/FileItem.swift
@@ -116,6 +116,8 @@ extension WorkspaceClient {
             switch children {
             case nil:
                 return FileIcon.fileIcon(fileType: fileType)
+            case .some where parent == nil:
+                return "square.dashed.inset.filled"
             case let .some(children):
                 if self.watcher == nil && !self.activateWatcher() {
                     return "questionmark.folder"


### PR DESCRIPTION
# Description

This PR adds some small improvements to the breadcrumbs view, specifically:
- The root folder is now also clickable
- Fixed an issue with the click hitbox
- Click-and-drag works now
- Removed GeometryReader + custom method for calculating position to show menu

Most of these things were fixed by changing to an `NSPopUpButton`, which does all of these things out of the box. This also fixes a bug which would occur when split views are implemented, as the previous calculation of the position for the menu wouldn't be correct anymore.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->
<img width="438" alt="Scherm­afbeelding 2023-02-20 om 04 22 43" src="https://user-images.githubusercontent.com/62355975/220002285-8eac3c1d-fbf4-4c4e-a697-93887a984c60.png">

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
