### PR TITLE
Don't run haptic feedback when the UI is rendered.

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -22,11 +22,12 @@ final class CodeEditSplitViewController: NSSplitViewController {
     private let isInspectorCollapsedStateName: String
         = "\(String(describing: CodeEditSplitViewController.self))-IsInspectorCollapsed"
     private var setWidthFromState = false
+    private var viewIsReady = false
 
     // Properties
     private(set) var isSnapped: Bool = false {
         willSet {
-            if newValue, newValue != isSnapped {
+            if newValue, newValue != isSnapped && viewIsReady {
                 feedbackPerformer.perform(.alignment, performanceTime: .now)
             }
         }
@@ -50,6 +51,8 @@ final class CodeEditSplitViewController: NSSplitViewController {
 
     override func viewWillAppear() {
         super.viewWillAppear()
+
+        viewIsReady = false
         let width = workspace.getFromWorkspaceState(key: self.widthStateName) as? CGFloat
         splitView.setPosition(width ?? .snapWidth, ofDividerAt: .zero)
         setWidthFromState = true
@@ -67,6 +70,10 @@ final class CodeEditSplitViewController: NSSplitViewController {
         }
 
         self.insertToolbarItemIfNeeded()
+    }
+
+    override func viewDidAppear() {
+        viewIsReady = true
     }
 
     // MARK: - NSSplitViewDelegate


### PR DESCRIPTION
# Description
We are running haptic feedback when the isSnapped flag is set. This flag gets set when the UI is first rendered. Fix is to ignore the first render i.e. do not run the haptic feedback.

# Related Issue
* #916 

# Checklist
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

