### PR TITLE
Removed close animations on tabs

### DIFF
--- a/CodeEdit/Features/TabBar/Views/TabBarItemView.swift
+++ b/CodeEdit/Features/TabBar/Views/TabBarItemView.swift
@@ -101,9 +101,7 @@ struct TabBarItemView: View {
 
     /// Close the current tab.
     func closeAction() {
-        if prefs.preferences.general.tabBarStyle == .native {
-            isAppeared = false
-        }
+        isAppeared = false
         withAnimation(
             .easeOut(duration: prefs.preferences.general.tabBarStyle == .native ? 0.15 : 0.20)
         ) {

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -70,6 +70,7 @@ struct WorkspaceView: View {
             if workspace.workspaceClient != nil, let model = workspace.statusBarModel {
                 ZStack {
                     tabContent
+                        .animation(nil, value: UUID())
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .safeAreaInset(edge: .top, spacing: 0) {


### PR DESCRIPTION
# Description

Removed animations when closing tabs

# Related Issue

* #1073

# Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots


https://user-images.githubusercontent.com/46418077/221214377-eabcedc9-aced-434a-a3ab-2827f0faa511.mov
