### PR TITLE
Fix typo in documentation

### DIFF
--- a/Documentation.docc/CodeEditUI/FontPicker.md
+++ b/Documentation.docc/CodeEditUI/FontPicker.md
@@ -15,7 +15,7 @@ FontPicker("Font Picker", name: $fontName, size: $fontSize)
 
 ## Preview
 
-![FontPicker](Resources/FontPicker_View.png)
+![FontPicker](FontPicker_View.png)
 
 ## Topics
 

--- a/Documentation.docc/CodeEditUI/FontPicker.md
+++ b/Documentation.docc/CodeEditUI/FontPicker.md
@@ -15,7 +15,7 @@ FontPicker("Font Picker", name: $fontName, size: $fontSize)
 
 ## Preview
 
-![FontPicker](FontPicker_View.png)
+![FontPicker](Resources/FontPicker_View.png)
 
 ## Topics
 

--- a/Documentation.docc/CodeEditUI/SegmentedControl.md
+++ b/Documentation.docc/CodeEditUI/SegmentedControl.md
@@ -6,7 +6,7 @@
 @State var selected: Int = 0
 var items: [String] = ["Tab 1", "Tab 2"]
 
-SegementedControl($selected, options: items)
+SegmentedControl($selected, options: items)
 ```
 
 ## Preview

--- a/Documentation.docc/CodeEditUI/SegmentedControl.md
+++ b/Documentation.docc/CodeEditUI/SegmentedControl.md
@@ -11,7 +11,7 @@ SegmentedControl($selected, options: items)
 
 ## Preview
 
-![Segmented Control](Resources/SegmentedControl_View.png)
+![Segmented Control](SegmentedControl_View.png)
 
 ## Topics
 

--- a/Documentation.docc/CodeEditUI/SegmentedControl.md
+++ b/Documentation.docc/CodeEditUI/SegmentedControl.md
@@ -11,7 +11,7 @@ SegmentedControl($selected, options: items)
 
 ## Preview
 
-![Segmented Control](SegmentedControl_View.png)
+![Segmented Control](Resources/SegmentedControl_View.png)
 
 ## Topics
 

--- a/Documentation.docc/Keybindings/KeybindingManager.md
+++ b/Documentation.docc/Keybindings/KeybindingManager.md
@@ -23,7 +23,7 @@ Keybinding module exists as singleton, so you always can reference Keybindings u
 
 In order to fetch keybinding you need to call following function with string name ``KeybindingManager/named(with:)`` returning you ``KeyboardShortcutWrapper`` which contains ``KeyboardShortcutWrapper/keyboardShortcut`` which can be passed directly to  ``keyboardShortcut``. So the end code would look like `.keyboardShortcut(KeyboardShortcutWrapper.shared.named(with: "copy").keyboardShortcut`
 
-If shortcut wasnt found by name, it will return fallback shortcut which has following keybinding `Shift + ?`
+If shortcut wasn't found by name, it will return fallback shortcut which has following keybinding `Shift + ?`
 
 ### Adding new shortcut
 


### PR DESCRIPTION
# Description

This PR fixes a typos in two files: `SegmentedControl.md`, `KeybindingManager.md`.

# Related Issue

Not related with any issues

* #ISSUE_NUMBER
  No related issue
# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots
No new bugs, issues or UI modification.
