### PR TITLE
Fixed image paths in docs

### DIFF
--- a/Documentation.docc/CodeEditUI/FontPicker.md
+++ b/Documentation.docc/CodeEditUI/FontPicker.md
@@ -15,7 +15,7 @@ FontPicker("Font Picker", name: $fontName, size: $fontSize)
 
 ## Preview
 
-![FontPicker](FontPicker_View.png)
+![FontPicker](Resources/FontPicker_View.png)
 
 ## Topics
 

--- a/Documentation.docc/CodeEditUI/SegmentedControl.md
+++ b/Documentation.docc/CodeEditUI/SegmentedControl.md
@@ -11,7 +11,7 @@ SegementedControl($selected, options: items)
 
 ## Preview
 
-![Segmented Control](SegmentedControl_View.png)
+![Segmented Control](Resources/SegmentedControl_View.png)
 
 ## Topics
 


### PR DESCRIPTION
# Description

I simply fixed the image paths in documentation so that they properly render in the markdown files.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [ ] My code builds and runs on my machine
- [ ] I documented my code
- [ ] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
