### PR TITLE
Changed project symbol

### DIFF
--- a/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsComponent.swift
+++ b/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsComponent.swift
@@ -53,7 +53,9 @@ struct BreadcrumbsComponent: View {
             (button.cell as? NSPopUpButtonCell)?.arrowPosition = .noArrow
             return button
         }
+        .padding(.top, -0.5)
         .padding(.leading, -5)
+        .padding(.trailing, -3)
     }
 
     struct NSPopUpButtonView<ItemType>: NSViewRepresentable where ItemType: Equatable {

--- a/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsMenu.swift
+++ b/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsMenu.swift
@@ -69,23 +69,19 @@ final class BreadcrumbsMenuItem: NSMenuItem {
         super.init(title: fileItem.fileName, action: #selector(openFile), keyEquivalent: "")
 
         var icon = fileItem.systemImage
-        var color = fileItem.iconColor
+        var color = NSColor(fileItem.iconColor)
         isEnabled = true
         target = self
         if fileItem.children != nil {
             let subMenu = NSMenu()
             submenu = subMenu
             icon = fileItem.systemImage
-            if fileItem.parent == nil {
-                color = .accentColor
-            } else {
-                color = .secondary
-            }
+            color = NSColor(named: "FolderBlue") ?? NSColor(.secondary)
         }
         let image = NSImage(
             systemSymbolName: icon,
             accessibilityDescription: icon
-        )?.withSymbolConfiguration(.init(paletteColors: [NSColor(color)]))
+        )?.withSymbolConfiguration(.init(paletteColors: [color]))
         self.image = image
         representedObject = fileItem
         if fileItem.isFolder {

--- a/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsView.swift
+++ b/CodeEdit/Features/Breadcrumbs/Views/BreadcrumbsView.swift
@@ -51,8 +51,8 @@ struct BreadcrumbsView: View {
             }
             .padding(.horizontal, 10)
         }
-        .frame(height: 28, alignment: .center)
-        .background(EffectView(.headerView).frame(height: 28))
+        .frame(height: 27, alignment: .center)
+        .background(EffectView(.headerView).frame(height: 27))
     }
 
     private var chevron: some View {

--- a/CodeEdit/Utils/WorkspaceClient/Model/FileItem.swift
+++ b/CodeEdit/Utils/WorkspaceClient/Model/FileItem.swift
@@ -117,7 +117,7 @@ extension WorkspaceClient {
             case nil:
                 return FileIcon.fileIcon(fileType: fileType)
             case .some where parent == nil:
-                return "square.dashed.inset.filled"
+                return "folder.fill.badge.gearshape"
             case let .some(children):
                 if self.watcher == nil && !self.activateWatcher() {
                     return "questionmark.folder"


### PR DESCRIPTION
# Description

Changed project symbol to `folder.fill.badge.gearshape` and adjusted breadcrumb dimensions to align closer to Xcode.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

Before
<img width="598" alt="Screenshot 2023-03-03 at 1 05 03 PM" src="https://user-images.githubusercontent.com/806104/222828870-6b47fe87-9e84-4ce0-b08a-ea1f754a3b19.png">

After
<img width="677" alt="image" src="https://user-images.githubusercontent.com/806104/222826387-9377034c-e1bb-4b0f-aa07-fa3f414adaf4.png">