### PR TITLE
Fix for excessive files in recents list

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
@@ -37,6 +37,10 @@ final class CodeEditDocumentController: NSDocumentController {
         return panel.url
     }
 
+    override func noteNewRecentDocument(_ document: NSDocument) {
+        // The super method is run manually when opening new documents.
+    }
+
     override func openDocument(_ sender: Any?) {
         self.openDocument(onCompletion: { document, documentWasAlreadyOpen in
             // TODO: handle errors
@@ -55,6 +59,7 @@ final class CodeEditDocumentController: NSDocumentController {
         display displayDocument: Bool,
         completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void
     ) {
+        super.noteNewRecentDocumentURL(url)
         super.openDocument(withContentsOf: url, display: displayDocument) { document, documentWasAlreadyOpen, error in
 
             if let document = document {


### PR DESCRIPTION
# Description

Folders or files opened in a new window (via the welcomewindow, open menu, dragging to the icon) will be added to the recents list. Files opened in a windowcontroller from a workspace won't be added

# Related Issue

Fixes #1108 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested
