### PR TITLE
Add 71 new File icons and create new opacity preference

### DIFF
--- a/CodeEdit/Utils/WorkspaceClient/Model/FileIcon.swift
+++ b/CodeEdit/Utils/WorkspaceClient/Model/FileIcon.swift
@@ -1,6 +1,5 @@
 //
 //  FileIcon.swift
-//  
 //
 //  Created by Nanashi Li on 2022/05/20.
 //
@@ -13,10 +12,81 @@ enum FileIcon {
 
     // swiftlint:disable identifier_name
     enum FileType: String {
+        case pyw
+        case pyc
+        case docx
+        case docm
+        case doc
+        case lz
+        case gcode
+        case pns
+        case pnm
+        case jng
+        case xml
+        case gsh
+        case gy
+        case gvy
+        case groovy
+        case pkg
+        case dmg
+        case htm
+        case gzip
+        case obj
+        case dae
+        case abc
+        case glb
+        case stl
+        case ply
+        case blend
+        case ai
+        case heic
+        case gif
+        case tga
+        case bmp
+        case psd
+        case hdr
+        case pic
+        case webp
+        case avif
+        case ppm
+        case pgm
+        case pbm
+        case tiff
+        case tif
+        case pdf
+        case mp3
+        case wav
+        case mov
+        case mp4
+        case asm
+        case app
+        case s
+        case inc
+        case wla
+        case src
         case json
         case js
+        case ruby
+        case c
+        case cc
+        case hpp
+        case cpp
+        case cobol
+        case cs
         case css
+        case d
+        case kotlin
+        case julia
         case jsx
+        case php
+        case perl
+        case lua
+        case scala
+        case sql
+        case svelte
+        case zip
+        case gz
+        case tar
         case swift
         case env
         case example
@@ -31,11 +101,14 @@ enum FileIcon {
         case md
         case txt = "text"
         case rtf
+        case r
+        case rust
         case html
         case py
         case sh
         case LICENSE
         case java
+        case jar
         case h
         case m
         case vue
@@ -44,25 +117,60 @@ enum FileIcon {
         case mod
         case Makefile
         case ts
+        case warningRemover // Removes warning
     }
 
+    // swiftlint:disable function_body_length
     /// Returns a string describing a SFSymbol for files
     /// If not specified otherwise this will return `"doc"`
     static func fileIcon(fileType: FileType) -> String {
         switch fileType {
-        case .json, .js:
+        case .doc, .docm, .docx:
+            return "doc.text"
+        case .lz:
+            return "arrowtriangle.right.fill"
+        case .groovy, .gvy, .gy, .gsh:
+            return "star"
+        case .pkg:
+            return "archivebox"
+        case .dmg:
+            return "externaldrive"
+        case .obj, .dae, .abc, .glb, .stl, .ply, .blend, .gcode:
+            return "move.3d"
+        case .mp3, .wav:
+            return "waveform"
+        case .mov, .mp4:
+            return "video.square"
+        case .app:
+            return "app.dashed"
+        case .asm, .s, .inc, .wla, .src:
+            return "doc.text"
+        case .zip, .tar, .gz, .gzip:
+            return "doc.zipper"
+        case .json, .js, .xml:
             return "curlybraces"
+        case .cobol:
+            return "c.square.fill"
+        case .cs:
+            return "number.square"
         case .css:
             return "number"
         case .jsx:
             return "atom"
+        case .lua:
+            return "l.circle"
+        case .julia:
+            return "j.square"
         case .swift:
             return "swift"
+        case .sql, .scala:
+            return "cylinder.split.1x2"
         case .env, .example:
             return "gearshape.fill"
         case .gitignore:
             return "arrow.triangle.branch"
-        case .png, .jpg, .jpeg, .ico:
+        // swiftlint:disable line_length
+        case .png, .jpg, .jpeg, .ico, .heic, .gif, .tga, .bmp, .psd, .hdr, .pic, .webp, .avif, .ppm, .pgm, .pbm, .pnm, .tiff, .pdf, .ai, .jng, .pns:
             return "photo"
         case .svg:
             return "square.fill.on.circle.fill"
@@ -70,28 +178,44 @@ enum FileIcon {
             return "checkmark.seal"
         case .plist:
             return "tablecells"
+        case .php:
+            return "oval.fill"
         case .md, .txt, .rtf:
             return "doc.plaintext"
-        case .html, .py, .sh:
+        case .html, .py, .sh, .htm, .pyc, .pyw:
             return "chevron.left.forwardslash.chevron.right"
+        case .kotlin:
+            return "chevron.left.to.line"
         case .LICENSE:
             return "key.fill"
         case .java:
             return "cup.and.saucer"
+        case .c:
+            return "c.square"
+        case .cpp, .cc, .hpp:
+            return "plus.app"
+        case .d:
+            return "d.square"
         case .h:
             return "h.square"
         case .m:
             return "m.square"
+        case .perl:
+            return "p.square"
         case .vue:
             return "v.square"
         case .go:
             return "g.square"
-        case .sum:
+        case .sum, .svelte:
             return "s.square"
         case .mod:
             return "m.square"
         case .Makefile:
             return "terminal"
+        case .r, .rust, .ruby:
+            return "r.square"
+        case .ts:
+            return "t.square"
         default:
             return "doc"
         }
@@ -101,24 +225,36 @@ enum FileIcon {
     /// If not specified otherwise this will return `Color.accentColor`
     static func iconColor(fileType: FileType) -> Color {
         switch fileType {
-        case .swift, .html:
+        case .julia, .perl, .app, .mov, .mp4:
+            return .gray
+        case .swift, .html, .sql, .htm:
             return .orange
-        case .java:
+        case .java, .svelte, .scala, .ruby, .d:
             return .red
         case .js, .entitlements, .json, .LICENSE:
             return Color("SidebarYellow")
-        case .css, .ts, .jsx, .md, .py:
+        case .c, .cpp, .css, .ts, .jsx, .r, .md, .py, .lua, .cobol, .cc, .groovy, .gvy, .gy, .gsh, .xml:
             return .blue
-        case .sh:
+        case .cs, .sh, .lz:
             return .green
+        case .doc, .docm, .docx:
+            return Color(red: 0.168, green: 0.336, blue: 0.690, opacity: 1.0)
+        case .mp3, .wav:
+            return Color(red: 0.227, green: 0.494, blue: 0.780, opacity: 1.0)
+        case .zip, .tar, .gz:
+            return Color(red: 0.278, green: 0.329, blue: 0.882, opacity: 1.0)
+        case .asm, .s, .inc, .wla, .src:
+            return Color(red: 0.152, green: 0.196, blue: 0.282, opacity: 1.0)
+        case .php:
+            return Color(red: 0.470, green: 0.482, blue: 0.686, opacity: 1.0)
         case .vue:
-            return Color(red: 0.255, green: 0.722, blue: 0.514, opacity: 1.000)
-        case .h:
-            return Color(red: 0.667, green: 0.031, blue: 0.133, opacity: 1.000)
+            return Color(red: 0.255, green: 0.722, blue: 0.514, opacity: 1.0)
+        case .h, .hpp:
+            return Color(red: 0.667, green: 0.031, blue: 0.133, opacity: 1.0)
         case .m:
-            return Color(red: 0.271, green: 0.106, blue: 0.525, opacity: 1.000)
+            return Color(red: 0.271, green: 0.106, blue: 0.525, opacity: 1.0)
         case .go:
-            return Color(red: 0.02, green: 0.675, blue: 0.757, opacity: 1.0)
+            return Color(red: 0.020, green: 0.675, blue: 0.757, opacity: 1.0)
         case .sum, .mod:
             return Color(red: 0.925, green: 0.251, blue: 0.478, opacity: 1.0)
         case .Makefile:

--- a/CodeEdit/Utils/WorkspaceClient/Model/FileIcon.swift
+++ b/CodeEdit/Utils/WorkspaceClient/Model/FileIcon.swift
@@ -10,6 +10,7 @@ import SwiftUI
 // swiftlint:disable cyclomatic_complexity
 enum FileIcon {
 
+    // Contributors, remember to alphabetically sort the cases.
     // swiftlint:disable identifier_name
     enum FileType: String {
         case abc
@@ -27,6 +28,7 @@ enum FileIcon {
         case css
         case d
         case dae
+        case dat
         case dmg
         case doc
         case docm
@@ -125,6 +127,8 @@ enum FileIcon {
     /// If not specified otherwise this will return `"doc"`
     static func fileIcon(fileType: FileType) -> String {
         switch fileType {
+        case .dat:
+            return "doc.fill"
         case .groovy, .gvy, .gy, .gsh:
             return "star"
         case .pkg:

--- a/CodeEdit/Utils/WorkspaceClient/Model/FileIcon.swift
+++ b/CodeEdit/Utils/WorkspaceClient/Model/FileIcon.swift
@@ -12,112 +12,112 @@ enum FileIcon {
 
     // swiftlint:disable identifier_name
     enum FileType: String {
-        case pyw
-        case pyc
-        case docx
-        case docm
-        case doc
-        case lz
-        case gcode
-        case pns
-        case pnm
-        case jng
-        case xml
-        case gsh
-        case gy
-        case gvy
-        case groovy
-        case pkg
-        case dmg
-        case htm
-        case gzip
-        case obj
-        case dae
         case abc
-        case glb
-        case stl
-        case ply
-        case blend
         case ai
-        case heic
-        case gif
-        case tga
-        case bmp
-        case psd
-        case hdr
-        case pic
-        case webp
-        case avif
-        case ppm
-        case pgm
-        case pbm
-        case tiff
-        case tif
-        case pdf
-        case mp3
-        case wav
-        case mov
-        case mp4
-        case asm
         case app
-        case s
-        case inc
-        case wla
-        case src
-        case json
-        case js
-        case ruby
+        case asm
+        case avif
+        case blend
+        case bmp
         case c
         case cc
-        case hpp
-        case cpp
         case cobol
+        case cpp
         case cs
         case css
         case d
-        case kotlin
-        case julia
-        case jsx
-        case php
-        case perl
-        case lua
-        case scala
-        case sql
-        case svelte
-        case zip
-        case gz
-        case tar
-        case swift
+        case dae
+        case dmg
+        case doc
+        case docm
+        case docx
+        case entitlements
         case env
         case example
+        case gcode
+        case gif
         case gitignore
-        case png
-        case jpg
-        case jpeg
-        case ico
-        case svg
-        case entitlements
-        case plist
-        case md
-        case txt = "text"
-        case rtf
-        case r
-        case rust
-        case html
-        case py
-        case sh
-        case LICENSE
-        case java
-        case jar
-        case h
-        case m
-        case vue
+        case glb
         case go
-        case sum
-        case mod
+        case groovy
+        case gsh
+        case gvy
+        case gy
+        case gz
+        case gzip
+        case h
+        case hdr
+        case heic
+        case hpp
+        case htm
+        case html
+        case ico
+        case inc
+        case jar
+        case java
+        case jng
+        case jpeg
+        case jpg
+        case js
+        case json
+        case jsx
+        case julia
+        case kotlin
+        case LICENSE
+        case lua
+        case lz
+        case m
         case Makefile
+        case md
+        case mod
+        case mov
+        case mp3
+        case mp4
+        case obj
+        case pbm
+        case pdf
+        case perl
+        case pgm
+        case php
+        case pic
+        case pkg
+        case plist
+        case ply
+        case png
+        case pnm
+        case pns
+        case ppm
+        case psd
+        case py
+        case pyc
+        case pyw
+        case r
+        case rtf
+        case ruby
+        case rust
+        case s
+        case scala
+        case sh
+        case sql
+        case src
+        case stl
+        case sum
+        case svelte
+        case svg
+        case swift
+        case tar
+        case tga
+        case tif
+        case tiff
         case ts
+        case txt = "text"
+        case vue
         case warningRemover // Removes warning
+        case wav
+        case webp
+        case wla
+        case xml
+        case zip
     }
 
     // swiftlint:disable function_body_length

--- a/CodeEdit/Utils/WorkspaceClient/Model/FileIcon.swift
+++ b/CodeEdit/Utils/WorkspaceClient/Model/FileIcon.swift
@@ -125,10 +125,6 @@ enum FileIcon {
     /// If not specified otherwise this will return `"doc"`
     static func fileIcon(fileType: FileType) -> String {
         switch fileType {
-        case .doc, .docm, .docx:
-            return "doc.text"
-        case .lz:
-            return "arrowtriangle.right.fill"
         case .groovy, .gvy, .gy, .gsh:
             return "star"
         case .pkg:
@@ -143,9 +139,9 @@ enum FileIcon {
             return "video.square"
         case .app:
             return "app.dashed"
-        case .asm, .s, .inc, .wla, .src:
+        case .asm, .s, .inc, .wla, .src, .doc, .docm, .docx:
             return "doc.text"
-        case .zip, .tar, .gz, .gzip:
+        case .zip, .tar, .gz, .gzip, .lz:
             return "doc.zipper"
         case .json, .js, .xml:
             return "curlybraces"
@@ -185,7 +181,7 @@ enum FileIcon {
         case .html, .py, .sh, .htm, .pyc, .pyw:
             return "chevron.left.forwardslash.chevron.right"
         case .kotlin:
-            return "chevron.left.to.line"
+            return "k.square"
         case .LICENSE:
             return "key.fill"
         case .java:


### PR DESCRIPTION
# Description
This PR adds 71 new file icons `FileIcon.swift`, this PR is a draft and file icons are being added.

# Related Issue

Closes #1115
* #1115

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots
I cannot add all the file icons but here are 3:

<img width="67" alt="shot 1" src="https://user-images.githubusercontent.com/98705626/223222460-2f62a6ce-59ca-44ca-92f5-c70ba66bfa5e.png">
<img width="67" alt="shot 2" src="https://user-images.githubusercontent.com/98705626/223222463-15465507-aca4-46fc-9f9c-b9298ea19f97.png">
<img width="67" alt="shot 3" src="https://user-images.githubusercontent.com/98705626/223222464-ab3afbd1-c860-4806-9bf7-843ee268675a.png">


