### PR TITLE
Remove Change in selection animation on tabs

### DIFF
--- a/CodeEdit/Features/Documents/Views/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Features/Documents/Views/WorkspaceCodeFileView.swift
@@ -16,6 +16,7 @@ struct WorkspaceCodeFileView: View {
     @EnvironmentObject
     private var tabgroup: TabGroupData
 
+    @Binding
     var file: WorkspaceClient.FileItem
 
     @StateObject

--- a/CodeEdit/Features/Tabs/TabGroup/TabGroupData.swift
+++ b/CodeEdit/Features/Tabs/TabGroup/TabGroupData.swift
@@ -8,6 +8,7 @@
 import Foundation
 import OrderedCollections
 import DequeModule
+import SwiftUI
 
 final class TabGroupData: ObservableObject, Identifiable {
     typealias Tab = WorkspaceClient.FileItem
@@ -15,18 +16,20 @@ final class TabGroupData: ObservableObject, Identifiable {
     /// Set of open tabs.
     @Published var tabs: OrderedSet<Tab> = [] {
         didSet {
-            let change = tabs.symmetricDifference(oldValue)
+            withAnimation(.linear(duration: 0)) {
+                let change = tabs.symmetricDifference(oldValue)
 
-            if tabs.count > oldValue.count {
-                // Amount of tabs grew, so set the first new as selected.
-                selected = change.first
-            } else {
-                // Selected file was removed
-                if let selected, change.contains(selected) {
-                    if let oldIndex = oldValue.firstIndex(of: selected), oldIndex - 1 < tabs.count, !tabs.isEmpty {
-                        self.selected = tabs[max(0, oldIndex-1)]
-                    } else {
-                        self.selected = nil
+                if tabs.count > oldValue.count {
+                    // Amount of tabs grew, so set the first new as selected.
+                    selected = change.first
+                } else {
+                    // Selected file was removed
+                    if let selected, change.contains(selected) {
+                        if let oldIndex = oldValue.firstIndex(of: selected), oldIndex - 1 < tabs.count, !tabs.isEmpty {
+                            self.selected = tabs[max(0, oldIndex-1)]
+                        } else {
+                            self.selected = nil
+                        }
                     }
                 }
             }

--- a/CodeEdit/Features/Tabs/TabGroup/WorkspaceTabGroupView.swift
+++ b/CodeEdit/Features/Tabs/TabGroup/WorkspaceTabGroupView.swift
@@ -20,7 +20,7 @@ struct WorkspaceTabGroupView: View {
     var body: some View {
         VStack {
             if let selected = tabgroup.selected {
-                WorkspaceCodeFileView(file: selected)
+                WorkspaceCodeFileView(file: .init(get: { selected }, set: { _ in }))
                     .transformEnvironment(\.edgeInsets) { insets in
                         insets.top += TabBarView.height + PathBarView.height + 1 + 1
                     }

--- a/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
@@ -308,11 +308,11 @@ struct TabBarItemView: View {
             // This padding is to avoid background color overlapping with top divider.
             .top, prefs.preferences.general.tabBarStyle == .xcode ? 1 : 0
         )
-//        .offset(
-//            x: isAppeared || prefs.preferences.general.tabBarStyle == .native ? 0 : -14,
-//            y: 0
-//        )
-//        .opacity(isAppeared && onDragTabId != item.id ? 1.0 : 0.0)
+        .offset(
+            x: isAppeared || prefs.preferences.general.tabBarStyle == .native ? 0 : -14,
+            y: 0
+        )
+        .opacity(isAppeared && onDragTabId != item.id ? 1.0 : 0.0)
         .zIndex(
             isActive
             ? (prefs.preferences.general.tabBarStyle == .native ? -1 : 2)
@@ -330,7 +330,7 @@ struct TabBarItemView: View {
             withAnimation(
                 .easeOut(duration: prefs.preferences.general.tabBarStyle == .native ? 0.15 : 0.20)
             ) {
-//                isAppeared = true
+                isAppeared = true
             }
         }
         .id(item.id)


### PR DESCRIPTION
### Description

Previously tabs had animations in highlighting when changing tab selection. This behavior is now removed

### Related Issues

#1073 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://user-images.githubusercontent.com/46418077/224548710-dcd35e85-94b0-4676-859d-576f0bf5f601.mov

The top version is with animations and the bottom version is the new updates version without the animation