### PR TITLE
Fix for runtime errors

### DIFF
--- a/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/Model/ThemeModel.swift
@@ -35,7 +35,9 @@ final class ThemeModel: ObservableObject {
     @Published
     var selectedLightTheme: Theme? {
         didSet {
-            AppPreferencesModel.shared.preferences.theme.selectedLightTheme = selectedLightTheme?.name ?? "Broken"
+            DispatchQueue.main.async {
+                AppPreferencesModel.shared.preferences.theme.selectedLightTheme = self.selectedLightTheme?.name ?? "Broken"
+            }
         }
     }
 
@@ -44,7 +46,9 @@ final class ThemeModel: ObservableObject {
     @Published
     var selectedDarkTheme: Theme? {
         didSet {
-            AppPreferencesModel.shared.preferences.theme.selectedDarkTheme = selectedDarkTheme?.name ?? "Broken"
+            DispatchQueue.main.async {
+                AppPreferencesModel.shared.preferences.theme.selectedDarkTheme = self.selectedDarkTheme?.name ?? "Broken"
+            }
         }
     }
 
@@ -66,7 +70,6 @@ final class ThemeModel: ObservableObject {
     var themes: [Theme] = [] {
         didSet {
             saveThemes()
-            objectWillChange.send()
         }
     }
 
@@ -74,7 +77,9 @@ final class ThemeModel: ObservableObject {
     @Published
     var selectedTheme: Theme? {
         didSet {
-            AppPreferencesModel.shared.preferences.theme.selectedTheme = selectedTheme?.name
+            DispatchQueue.main.async {
+                AppPreferencesModel.shared.preferences.theme.selectedTheme = self.selectedTheme?.name
+            }
             updateAppearanceTheme()
         }
     }
@@ -310,7 +315,9 @@ final class ThemeModel: ObservableObject {
                         newAttr["editor"]?[key] = value
                     }
                 }
-                AppPreferencesModel.shared.preferences.theme.overrides[theme.name] = newAttr
+                DispatchQueue.main.async {
+                    AppPreferencesModel.shared.preferences.theme.overrides[theme.name] = newAttr
+                }
 
             } catch {
                 print(error)

--- a/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/Model/ThemeModel.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/ThemePreferences/Model/ThemeModel.swift
@@ -36,7 +36,8 @@ final class ThemeModel: ObservableObject {
     var selectedLightTheme: Theme? {
         didSet {
             DispatchQueue.main.async {
-                AppPreferencesModel.shared.preferences.theme.selectedLightTheme = self.selectedLightTheme?.name ?? "Broken"
+                AppPreferencesModel.shared
+                    .preferences.theme.selectedLightTheme = self.selectedLightTheme?.name ?? "Broken"
             }
         }
     }
@@ -47,7 +48,8 @@ final class ThemeModel: ObservableObject {
     var selectedDarkTheme: Theme? {
         didSet {
             DispatchQueue.main.async {
-                AppPreferencesModel.shared.preferences.theme.selectedDarkTheme = self.selectedDarkTheme?.name ?? "Broken"
+                AppPreferencesModel.shared
+                    .preferences.theme.selectedDarkTheme = self.selectedDarkTheme?.name ?? "Broken"
             }
         }
     }


### PR DESCRIPTION
### Description

This PR fixes some annoying runtime errors we're getting. These errors were thrown because a `Published` property was being updated within a view update. This isn't allowed. There was also an `objectWillChange.send()` call in a `didSet` in a `Published` var, which essentially published the value twice, which results in the same error.

I've fixed the errors for now by wrapping them in an `DispatchQueue.main.async`. Ideally we wouldn't need to use this, but it'll do for now. I don't have enough knowledge about the whole preference structure to go ahead and fix it properly.

### Related Issues

#845 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

