### PR TITLE
Fix for background color of toolbar in inspector

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -85,6 +85,7 @@ final class CodeEditSplitViewController: NSSplitViewController {
 
     override func viewDidAppear() {
         viewIsReady = true
+        fixInspectorToolbarBackground()
     }
 
     // MARK: - NSSplitViewDelegate
@@ -162,5 +163,16 @@ final class CodeEditSplitViewController: NSSplitViewController {
             return
         }
         view.window?.toolbar?.removeItem(at: index)
+    }
+
+    func fixInspectorToolbarBackground() {
+        let controller = self.view.window?.perform(Selector(("titlebarViewController"))).takeUnretainedValue()
+        if let controller = controller as? NSViewController {
+            let effectViewCount = controller.view.subviews.filter { $0 is NSVisualEffectView }.count
+            guard effectViewCount > 2 else { return }
+            if let view = controller.view.subviews[0] as? NSVisualEffectView {
+                view.isHidden = true
+            }
+        }
     }
 }

--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -85,7 +85,7 @@ final class CodeEditSplitViewController: NSSplitViewController {
 
     override func viewDidAppear() {
         viewIsReady = true
-        fixInspectorToolbarBackground()
+        hideInspectorToolbarBackground()
     }
 
     // MARK: - NSSplitViewDelegate
@@ -165,7 +165,7 @@ final class CodeEditSplitViewController: NSSplitViewController {
         view.window?.toolbar?.removeItem(at: index)
     }
 
-    func fixInspectorToolbarBackground() {
+    func hideInspectorToolbarBackground() {
         let controller = self.view.window?.perform(Selector(("titlebarViewController"))).takeUnretainedValue()
         if let controller = controller as? NSViewController {
             let effectViewCount = controller.view.subviews.filter { $0 is NSVisualEffectView }.count

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -110,6 +110,8 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         inspector.isCollapsed = true
         inspector.canCollapse = true
         inspector.collapseBehavior = .useConstraints
+        inspector.isSpringLoaded = true
+        
         splitVC.addSplitViewItem(inspector)
 
         self.splitViewController = splitVC
@@ -232,14 +234,21 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
 
     @objc func toggleLastPanel() {
         guard let lastSplitView = splitViewController.splitViewItems.last else { return }
-        lastSplitView.animator().isCollapsed.toggle()
+
         if lastSplitView.isCollapsed {
-            window?.toolbar?.removeItem(at: 4)
-        } else {
             window?.toolbar?.insertItem(withItemIdentifier: .itemListTrackingSeparator, at: 4)
         }
+        NSAnimationContext.runAnimationGroup { context in
+            lastSplitView.animator().isCollapsed.toggle()
+        } completionHandler: { [weak self] in
+            if lastSplitView.isCollapsed {
+                self?.window?.animator().toolbar?.removeItem(at: 4)
+            }
+        }
+
         if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
             codeEditSplitVC.saveInspectorCollapsedState(isCollapsed: lastSplitView.isCollapsed)
+            codeEditSplitVC.fixInspectorToolbarBackground()
         }
     }
 

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -311,7 +311,7 @@ extension CodeEditWindowController {
 
         if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
             codeEditSplitVC.saveInspectorCollapsedState(isCollapsed: lastSplitView.isCollapsed)
-            codeEditSplitVC.fixInspectorToolbarBackground()
+            codeEditSplitVC.hideInspectorToolbarBackground()
         }
     }
 }

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -111,7 +111,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         inspector.canCollapse = true
         inspector.collapseBehavior = .useConstraints
         inspector.isSpringLoaded = true
-        
+
         splitVC.addSplitViewItem(inspector)
 
         self.splitViewController = splitVC
@@ -224,34 +224,6 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
         super.windowDidLoad()
     }
 
-    @objc func toggleFirstPanel() {
-        guard let firstSplitView = splitViewController.splitViewItems.first else { return }
-        firstSplitView.animator().isCollapsed.toggle()
-        if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
-            codeEditSplitVC.saveNavigatorCollapsedState(isCollapsed: firstSplitView.isCollapsed)
-        }
-    }
-
-    @objc func toggleLastPanel() {
-        guard let lastSplitView = splitViewController.splitViewItems.last else { return }
-
-        if lastSplitView.isCollapsed {
-            window?.toolbar?.insertItem(withItemIdentifier: .itemListTrackingSeparator, at: 4)
-        }
-        NSAnimationContext.runAnimationGroup { context in
-            lastSplitView.animator().isCollapsed.toggle()
-        } completionHandler: { [weak self] in
-            if lastSplitView.isCollapsed {
-                self?.window?.animator().toolbar?.removeItem(at: 4)
-            }
-        }
-
-        if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
-            codeEditSplitVC.saveInspectorCollapsedState(isCollapsed: lastSplitView.isCollapsed)
-            codeEditSplitVC.fixInspectorToolbarBackground()
-        }
-    }
-
     private func getSelectedCodeFile() -> CodeFileDocument? {
         workspace?.tabManager.activeTabGroup.selected?.fileDocument
     }
@@ -308,6 +280,38 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate {
                 window?.addChildWindow(panel, ordered: .above)
                 panel.makeKeyAndOrderFront(self)
             }
+        }
+    }
+}
+
+extension CodeEditWindowController {
+    @objc
+    func toggleFirstPanel() {
+        guard let firstSplitView = splitViewController.splitViewItems.first else { return }
+        firstSplitView.animator().isCollapsed.toggle()
+        if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
+            codeEditSplitVC.saveNavigatorCollapsedState(isCollapsed: firstSplitView.isCollapsed)
+        }
+    }
+
+    @objc
+    func toggleLastPanel() {
+        guard let lastSplitView = splitViewController.splitViewItems.last else { return }
+
+        if lastSplitView.isCollapsed {
+            window?.toolbar?.insertItem(withItemIdentifier: .itemListTrackingSeparator, at: 4)
+        }
+        NSAnimationContext.runAnimationGroup { _ in
+            lastSplitView.animator().isCollapsed.toggle()
+        } completionHandler: { [weak self] in
+            if lastSplitView.isCollapsed {
+                self?.window?.animator().toolbar?.removeItem(at: 4)
+            }
+        }
+
+        if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
+            codeEditSplitVC.saveInspectorCollapsedState(isCollapsed: lastSplitView.isCollapsed)
+            codeEditSplitVC.fixInspectorToolbarBackground()
         }
     }
 }

--- a/CodeEdit/Features/InspectorSidebar/InspectorSidebarToolbarTop.swift
+++ b/CodeEdit/Features/InspectorSidebar/InspectorSidebarToolbarTop.swift
@@ -27,7 +27,8 @@ struct InspectorSidebarToolbarTop: View {
     }
 
     var body: some View {
-        ScrollView {
+        VStack(alignment: .center, spacing: 0) {
+            Divider()
             HStack(spacing: 10) {
                 ForEach(icons) { icon in
                     makeInspectorIcon(systemImage: icon.imageName, title: icon.title, id: icon.id)
@@ -46,18 +47,11 @@ struct InspectorSidebarToolbarTop: View {
                         )
                 }
             }
-            .frame(height: 29, alignment: .center)
-            .frame(maxWidth: .infinity)
-            .overlay(alignment: .top) {
-                Divider()
-            }
-            .overlay(alignment: .bottom) {
-                Divider()
-            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             .animation(.default, value: icons)
+            Divider()
         }
-        .frame(height: 32, alignment: .center)
-        .frame(maxWidth: .infinity)
+        .frame(height: TabBarView.height)
     }
 
     func makeInspectorIcon(systemImage: String, title: String, id: Int) -> some View {

--- a/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
+++ b/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
@@ -52,12 +52,9 @@ struct InspectorSidebarView: View {
             maxHeight: .infinity,
             alignment: .top
         )
-        .safeAreaInset(edge: .top) {
+        .safeAreaInset(edge: .top, spacing: 0) {
             InspectorSidebarToolbarTop(selection: $selection)
-                .padding(.bottom, -8)
+                .background(.ultraThinMaterial)
         }
-        .background(
-            EffectView(.windowBackground, blendingMode: .withinWindow)
-        )
     }
 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This PR fixes the background of the toolbar in the inspector view, so it has the same color as the inspector.
A blur is applied for scrollviews.

### Related Issues

Discussed with @austincondiff 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
<img width="1097" alt="Scherm­afbeelding 2023-03-15 om 15 10 22" src="https://user-images.githubusercontent.com/62355975/225334681-aa66ca90-29a4-42be-a608-bf8dc6ca6d0a.png">
<img width="1097" alt="Scherm­afbeelding 2023-03-15 om 15 11 22" src="https://user-images.githubusercontent.com/62355975/225334961-2484b611-89ca-426b-adea-63c3a52e34fb.png">
<img width="1097" alt="Scherm­afbeelding 2023-03-15 om 15 12 05" src="https://user-images.githubusercontent.com/62355975/225335167-c66faa49-354c-4d00-b9b4-19ce30c7a23d.png">
<img width="1097" alt="Scherm­afbeelding 2023-03-15 om 15 12 18" src="https://user-images.githubusercontent.com/62355975/225335237-2cd58be3-7947-4d25-b90c-e0a83e6cb2ac.png">
