### PR TITLE
Remove Welcome Window reopening after last document is closed

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
@@ -76,10 +76,6 @@ final class CodeEditDocumentController: NSDocumentController {
 
     override func removeDocument(_ document: NSDocument) {
         super.removeDocument(document)
-
-        if CodeEditDocumentController.shared.documents.isEmpty {
-            NSApp.openWindow(.welcome)
-        }
     }
 
     override func clearRecentDocuments(_ sender: Any?) {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This disables the Welcome Window showing after the last document is closed.

### Related Issues

* #1165 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
