### PR TITLE
Files & folders dropped on Welcome Window are opened

### DIFF
--- a/CodeEdit/Features/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument.swift
@@ -90,7 +90,7 @@ import CodeEditKit
             workspace: self
         )
 
-        windowController.shouldCascadeWindows = false
+        windowController.shouldCascadeWindows = true
         windowController.window?.setFrameAutosaveName(self.fileURL?.absoluteString ?? "Untitled")
         self.addWindowController(windowController)
 

--- a/CodeEdit/Features/Welcome/Views/WelcomeWindowView.swift
+++ b/CodeEdit/Features/Welcome/Views/WelcomeWindowView.swift
@@ -37,5 +37,21 @@ struct WelcomeWindowView: View {
                 .frame(width: 300)
         }
         .edgesIgnoringSafeArea(.top)
+        .onDrop(of: [.fileURL], isTargeted: .constant(true)) { providers in
+            NSApp.activate(ignoringOtherApps: true)
+            providers.forEach {
+                _ = $0.loadDataRepresentation(for: .fileURL) { data, _ in
+                    if let data, let url = URL(dataRepresentation: data, relativeTo: nil) {
+                        Task {
+                            try? await CodeEditDocumentController
+                                .shared
+                                .openDocument(withContentsOf: url, display: true)
+                        }
+                    }
+                }
+            }
+            dismissWindow()
+            return true
+        }
     }
 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Files & Folders dropped on the Welcome Window are opened. Multiple items dropped at the same time is supported.

`shouldCascade` is also set to true, as disabling this overlaps workspace windows if multiple are opened

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1164 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://user-images.githubusercontent.com/62355975/226131098-3d919942-4c2c-4879-850d-10e6c28328a3.mov

