### PR TITLE
Fix for the window cannot be focused when creating a new file(#1158)

### DIFF
--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -98,7 +98,8 @@ struct CodeFileView: View {
         }
         .disabled(!editable)
         // minHeight zero fixes a bug where the app would freeze if the contents of the file are empty.
-        .frame(minHeight: .zero, maxHeight: .infinity)
+        //if the minHeight is zero, the issue #1158  will happen. 600 is the height set in CodeFileDocument.swift
+        .frame(minHeight: 600, maxHeight: .infinity)
         .onChange(of: ThemeModel.shared.selectedTheme) { newValue in
             guard let theme = newValue else { return }
             self.selectedTheme = theme


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
Fix a bug that the new file cannot not be focused. This happens because the minHeight of CodeEditTextView is set as zero
<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* close #1158 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://user-images.githubusercontent.com/22514420/226173987-2184efc4-1c5c-46b4-bb44-070ae1cfb14e.mp4


<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
