### PR TITLE
Fix #1158 Using Delayed Appearance and Focus

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 		6C5228B529A868BD00AC48F6 /* Environment+ContentInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5228B429A868BD00AC48F6 /* Environment+ContentInsets.swift */; };
 		6C53AAD829A6C4FD00EE9ED6 /* SplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C53AAD729A6C4FD00EE9ED6 /* SplitView.swift */; };
 		6C5AB9D729C1496E003B5F96 /* SceneID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5AB9D629C1496E003B5F96 /* SceneID.swift */; };
+		6C5B63DE29C76213005454BA /* WindowCodeFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5B63DD29C76213005454BA /* WindowCodeFileView.swift */; };
 		6C7256D729A3D7D000C2D3E0 /* SplitViewControllerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7256D629A3D7D000C2D3E0 /* SplitViewControllerView.swift */; };
 		6C81916729B3E80700B75C92 /* ModifierKeysObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C81916629B3E80700B75C92 /* ModifierKeysObserver.swift */; };
 		6C81916B29B41DD300B75C92 /* DequeModule in Frameworks */ = {isa = PBXBuildFile; productRef = 6C81916A29B41DD300B75C92 /* DequeModule */; };
@@ -735,6 +736,7 @@
 		6C5228B429A868BD00AC48F6 /* Environment+ContentInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Environment+ContentInsets.swift"; sourceTree = "<group>"; };
 		6C53AAD729A6C4FD00EE9ED6 /* SplitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitView.swift; sourceTree = "<group>"; };
 		6C5AB9D629C1496E003B5F96 /* SceneID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneID.swift; sourceTree = "<group>"; };
+		6C5B63DD29C76213005454BA /* WindowCodeFileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowCodeFileView.swift; sourceTree = "<group>"; };
 		6C7256D629A3D7D000C2D3E0 /* SplitViewControllerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewControllerView.swift; sourceTree = "<group>"; };
 		6C81916629B3E80700B75C92 /* ModifierKeysObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifierKeysObserver.swift; sourceTree = "<group>"; };
 		6C82D6B229BFD88700495C54 /* NavigateCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateCommands.swift; sourceTree = "<group>"; };
@@ -1411,6 +1413,7 @@
 				5879824A292E78D80085B254 /* Other */,
 				58798249292E78D80085B254 /* CodeFile.swift */,
 				58798248292E78D80085B254 /* CodeFileView.swift */,
+				6C5B63DD29C76213005454BA /* WindowCodeFileView.swift */,
 			);
 			path = CodeFile;
 			sourceTree = "<group>";
@@ -2701,6 +2704,7 @@
 				201169D92837B31200F92B46 /* SourceControlSearchToolbar.swift in Sources */,
 				0483E35027FDB17700354AC0 /* ExtensionNavigatorView.swift in Sources */,
 				587B9DA729300ABD00AC7927 /* HelpButton.swift in Sources */,
+				6C5B63DE29C76213005454BA /* WindowCodeFileView.swift in Sources */,
 				58F2EB08292FB2B0004A9BDE /* TextEditingPreferences.swift in Sources */,
 				201169DB2837B34000F92B46 /* SourceControlNavigatorChangedFileView.swift in Sources */,
 				5882252E292C280D00E83CDE /* StatusBarMaximizeButton.swift in Sources */,

--- a/CodeEdit/Features/CodeFile/CodeFile.swift
+++ b/CodeEdit/Features/CodeFile/CodeFile.swift
@@ -72,17 +72,18 @@ final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem {
     }
 
     override func makeWindowControllers() {
-        // Returns the Storyboard that contains your Document window.
-        let contentView = CodeFileView(codeFile: self)
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1400, height: 600),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered, defer: false
         )
-        window.center()
-        window.contentView = NSHostingView(rootView: contentView)
         let windowController = NSWindowController(window: window)
         addWindowController(windowController)
+
+        window.contentView = NSHostingView(rootView: WindowCodeFileView(codeFile: self))
+
+        window.makeKeyAndOrderFront(nil)
+        window.center()
     }
 
     override func data(ofType _: String) throws -> Data {

--- a/CodeEdit/Features/CodeFile/WindowCodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/WindowCodeFileView.swift
@@ -1,0 +1,32 @@
+//
+//  WindowCodeFileView.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 3/19/23.
+//
+
+import Foundation
+import SwiftUI
+
+/// View that fixes [#1158](https://github.com/CodeEditApp/CodeEdit/issues/1158)
+/// # Should **not** be used other than in a single file window.
+struct WindowCodeFileView: View {
+    var codeFile: CodeFileDocument
+
+    @State var hasAppeared = false
+    @FocusState var focused: Bool
+
+    var body: some View {
+        Group {
+            if !hasAppeared {
+                Color.clear.onAppear {
+                    hasAppeared = true
+                    focused = true
+                }
+            } else {
+                CodeFileView(codeFile: codeFile)
+                    .focused($focused)
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Adds a `WindowCodeFileView` that wraps `CodeFileView` but delays it's appearance until a window is available. It also focuses the code file on appearance. These changes are isolated to a single-file window and `CodeFileView` is left unchanged as to not break any workspace windows.

Thank you to @garethng for the initial work on this in #1174.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->
- closes #1158 
- closes #1147 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://user-images.githubusercontent.com/35942988/226187343-20d95773-8f1e-46b3-a386-f0da8fc4174d.mov
