### PR TITLE
Fixed bug where about window wouldn’t open

### DIFF
--- a/CodeEdit/Features/WindowCommands/MainCommands.swift
+++ b/CodeEdit/Features/WindowCommands/MainCommands.swift
@@ -15,7 +15,7 @@ struct MainCommands: Commands {
     var body: some Commands {
         CommandGroup(replacing: .appInfo) {
             Button("About CodeEdit") {
-                openWindow(id: "About")
+                openWindow(id: SceneID.about.rawValue)
             }
 
             Button("Check for updates...") {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

The about window doesn't open anymore on the latest main. This PR fixes that.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code


