### PR TITLE
Search overlay preview toggle

### DIFF
--- a/CodeEdit/Features/CodeEditUI/Views/OverlayView.swift
+++ b/CodeEdit/Features/CodeEditUI/Views/OverlayView.swift
@@ -9,23 +9,18 @@ import Foundation
 import SwiftUI
 
 struct OverlayView<RowView: View, PreviewView: View, Option: Identifiable & Hashable>: View {
-    @ViewBuilder
-    let rowViewBuilder: ((Option) -> RowView)
+    @ViewBuilder let rowViewBuilder: ((Option) -> RowView)
+    @ViewBuilder let previewViewBuilder: ((Option) -> PreviewView)?
 
-    @ViewBuilder
-    let previewViewBuilder: ((Option) -> PreviewView)?
+    @Binding var options: [Option]
+    @Binding var text: String
 
-    @Binding
-    var options: [Option]
+    @State var selection: Option?
+    @State var previewVisible: Bool = true
 
-    @State
-    var selection: Option?
-
-    @Binding
-    var text: String
     let title: String
     let image: Image
-    let showsPreview: Bool
+    let hasPreview: Bool
     let onRowClick: ((Option) -> Void)
     let onClose: (() -> Void)
     let alwaysShowOptions: Bool
@@ -51,7 +46,7 @@ struct OverlayView<RowView: View, PreviewView: View, Option: Identifiable & Hash
         self.previewViewBuilder = preview
         self.onRowClick = onRowClick
         self.onClose = onClose
-        self.showsPreview = preview != nil
+        self.hasPreview = preview != nil
         self.alwaysShowOptions = alwaysShowOptions
         self.optionRowHeight = optionRowHeight
     }
@@ -84,6 +79,12 @@ struct OverlayView<RowView: View, PreviewView: View, Option: Identifiable & Hash
                                 }
                             }
                         }
+                    if hasPreview {
+                        PreviewToggle(previewVisible: $previewVisible)
+                            .onTapGesture {
+                                previewVisible = !previewVisible
+                            }
+                    }
                 }
                 .padding(.vertical, 12)
                 .padding(.horizontal, 12)
@@ -98,7 +99,7 @@ struct OverlayView<RowView: View, PreviewView: View, Option: Identifiable & Hash
                         Text("No matching options")
                             .font(.system(size: 17))
                             .foregroundColor(.secondary)
-                            .frame(maxWidth: showsPreview ? 272 : .infinity, maxHeight: .infinity)
+                            .frame(maxWidth: hasPreview ? 272 : .infinity, maxHeight: .infinity)
                     } else {
                         NSTableViewWrapper(
                             data: options,
@@ -106,9 +107,9 @@ struct OverlayView<RowView: View, PreviewView: View, Option: Identifiable & Hash
                             selection: $selection,
                             itemView: rowViewBuilder
                         )
-                        .frame(maxWidth: showsPreview ? 272 : .infinity)
+                        .frame(maxWidth: hasPreview && previewVisible ? 272 : .infinity)
                     }
-                    if showsPreview {
+                    if hasPreview && previewVisible {
                         Divider()
                         if options.isEmpty {
                             Spacer()
@@ -173,5 +174,30 @@ struct OverlayView<RowView: View, PreviewView: View, Option: Identifiable & Hash
             .opacity(0)
             .keyboardShortcut(.downArrow, modifiers: [])
             .accessibilityLabel("Select Down")
+    }
+}
+
+struct PreviewToggle: View {
+    @Binding var previewVisible: Bool
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(Color(NSColor.secondaryLabelColor))
+                .frame(width: previewVisible ? 12 : 14, height: 1)
+                .offset(CGSize(width: 0, height: -2.5))
+            if !previewVisible {
+                Rectangle()
+                    .fill(Color(NSColor.secondaryLabelColor))
+                    .frame(width: 1, height: 8)
+                    .offset(CGSize(width: -2.5, height: 2))
+            }
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .strokeBorder(Color(NSColor.secondaryLabelColor), lineWidth: 1)
+                .frame(width: previewVisible ? 14 : 16, height: 14)
+        }
+        .frame(width: 16, height: 16)
+        .padding(4)
+        .contentShape(Rectangle())
     }
 }

--- a/CodeEdit/Features/CodeEditUI/Views/OverlayView.swift
+++ b/CodeEdit/Features/CodeEditUI/Views/OverlayView.swift
@@ -82,7 +82,9 @@ struct OverlayView<RowView: View, PreviewView: View, Option: Identifiable & Hash
                     if hasPreview {
                         PreviewToggle(previewVisible: $previewVisible)
                             .onTapGesture {
-                                previewVisible = !previewVisible
+                                withAnimation {
+                                    previewVisible.toggle()
+                                }
                             }
                     }
                 }
@@ -118,6 +120,7 @@ struct OverlayView<RowView: View, PreviewView: View, Option: Identifiable & Hash
                             if let selection, let previewViewBuilder {
                                 previewViewBuilder(selection)
                                     .frame(maxWidth: .infinity)
+                                    .transition(.move(edge: .trailing))
                             } else {
                                 Text("Select an option to preview")
                                     .frame(maxWidth: .infinity)

--- a/CodeEdit/Features/CodeEditUI/Views/OverlayView.swift
+++ b/CodeEdit/Features/CodeEditUI/Views/OverlayView.swift
@@ -82,9 +82,7 @@ struct OverlayView<RowView: View, PreviewView: View, Option: Identifiable & Hash
                     if hasPreview {
                         PreviewToggle(previewVisible: $previewVisible)
                             .onTapGesture {
-                                withAnimation {
-                                    previewVisible.toggle()
-                                }
+                                previewVisible.toggle()
                             }
                     }
                 }
@@ -120,7 +118,6 @@ struct OverlayView<RowView: View, PreviewView: View, Option: Identifiable & Hash
                             if let selection, let previewViewBuilder {
                                 previewViewBuilder(selection)
                                     .frame(maxWidth: .infinity)
-                                    .transition(.move(edge: .trailing))
                             } else {
                                 Text("Select an option to preview")
                                     .frame(maxWidth: .infinity)

--- a/CodeEdit/Features/QuickOpen/Views/QuickOpenView.swift
+++ b/CodeEdit/Features/QuickOpen/Views/QuickOpenView.swift
@@ -41,6 +41,7 @@ struct QuickOpenView: View {
             QuickOpenPreviewView(item: file)
         } onRowClick: { file in
             openFile(file)
+            state.openQuicklyQuery = ""
             onClose()
         } onClose: {
             onClose()


### PR DESCRIPTION
### Description

Added preview toggle to search overlay view. Displaying the toggle button if a preview exists.

### Related Issues

* closes #1180

### Checklist
- [x] Create custom preview toggle icons
- [x] Add preview toggle to search overlay that shows and hides preview visibility
- [ ] ~Animate showing and hiding the preview~ @Wouter01 will do this in a future PR
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="764" alt="image" src="https://user-images.githubusercontent.com/806104/226801074-e5486fa9-6613-4507-bcea-2f981e9bd62a.png">

<img width="766" alt="Screenshot 2023-03-21 at 10 29 53 PM" src="https://user-images.githubusercontent.com/806104/226800773-34822c20-9b1e-4884-8f27-4c6ae206043a.png">

<img width="770" alt="Screenshot 2023-03-21 at 10 29 15 PM" src="https://user-images.githubusercontent.com/806104/226800788-39e6cd33-1375-4ca9-91d8-1516dd0a91c8.png">