### PR TITLE
Add text zoom shortcut

### DIFF
--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -8,16 +8,31 @@
 import SwiftUI
 
 struct ViewCommands: Commands {
+    private var prefs: AppPreferencesModel = .shared
+
     var body: some Commands {
         CommandGroup(after: .toolbar) {
             Button("Show Command Palette") {
                 NSApp.sendAction(#selector(CodeEditWindowController.openCommandPalette(_:)), to: nil, from: nil)
             }
-            .keyboardShortcut("p", modifiers: [.shift, .command])
+            .keyboardShortcut("p")
+
+            Button("Zoom in") {
+                prefs.preferences.textEditing.font.size += 1
+            }
+            .keyboardShortcut("+")
+
+            Button("Zoom out") {
+                if !(prefs.preferences.textEditing.font.size <= 1) {
+                    prefs.preferences.textEditing.font.size -= 1
+                }
+            }
+            .keyboardShortcut("-")
 
             Button("Customize Toolbar...") {
 
             }
+            .disabled(true)
         }
     }
 }

--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -15,7 +15,7 @@ struct ViewCommands: Commands {
             Button("Show Command Palette") {
                 NSApp.sendAction(#selector(CodeEditWindowController.openCommandPalette(_:)), to: nil, from: nil)
             }
-            .keyboardShortcut("p")
+            .keyboardShortcut("p", modifiers: [.shift, .command])
 
             Button("Zoom in") {
                 prefs.preferences.textEditing.font.size += 1


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This `PR` adds support for zooming in and zooming out and disables the customize toolbar button with `.disabled`. 

_NOTE: Xcode has a zoom button in the `WindowCommands` `CommandView` but since it only has one zoom button and the linked issue suggests we have **2** keybinds similar to safari, i have made 2 keybindings.
`_
### Related Issues

* closes #1122

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://user-images.githubusercontent.com/128280019/227040353-3a82b281-c5e1-4487-9fa5-f83e20a713b2.mov

<img width="311" alt="shot 2" src="https://user-images.githubusercontent.com/128280019/227118995-4b7be4dc-b1b7-494a-bcbf-eb8df5d82e32.png">

