### PR TITLE
[chore]: Update `CodeEditTextView`, Remove unused `GRDB`

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -112,7 +112,6 @@
 		58798250292E78D80085B254 /* CodeFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58798249292E78D80085B254 /* CodeFile.swift */; };
 		58798251292E78D80085B254 /* OtherFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5879824B292E78D80085B254 /* OtherFileView.swift */; };
 		58798252292E78D80085B254 /* ImageFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5879824D292E78D80085B254 /* ImageFileView.swift */; };
-		5879826F292EC9870085B254 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 5879826E292EC9870085B254 /* GRDB */; };
 		58798284292ED0FB0085B254 /* TerminalEmulatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58798280292ED0FB0085B254 /* TerminalEmulatorView.swift */; };
 		58798285292ED0FB0085B254 /* TerminalEmulatorView+Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58798281292ED0FB0085B254 /* TerminalEmulatorView+Coordinator.swift */; };
 		58798286292ED0FB0085B254 /* SwiftTerm+Color+Init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58798283292ED0FB0085B254 /* SwiftTerm+Color+Init.swift */; };
@@ -778,7 +777,6 @@
 			files = (
 				58F2EB1A292FB91C004A9BDE /* Preferences in Frameworks */,
 				58F2EB17292FB74D004A9BDE /* CodeEditTextView in Frameworks */,
-				5879826F292EC9870085B254 /* GRDB in Frameworks */,
 				58F2EB1E292FB954004A9BDE /* Sparkle in Frameworks */,
 				6C147C4529A329350089B630 /* OrderedCollections in Frameworks */,
 				5879828A292ED15F0085B254 /* SwiftTerm in Frameworks */,
@@ -2366,7 +2364,6 @@
 			name = CodeEdit;
 			packageProductDependencies = (
 				2816F593280CF50500DD548B /* CodeEditSymbols */,
-				5879826E292EC9870085B254 /* GRDB */,
 				58798289292ED15F0085B254 /* SwiftTerm */,
 				58F2EB16292FB74D004A9BDE /* CodeEditTextView */,
 				58F2EB19292FB91C004A9BDE /* Preferences */,
@@ -2458,7 +2455,6 @@
 			packageReferences = (
 				2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */,
 				287136B1292A407E00E9F5F4 /* XCRemoteSwiftPackageReference "SwiftLintPlugin" */,
-				5879826D292EC9870085B254 /* XCRemoteSwiftPackageReference "GRDB.swift" */,
 				58798288292ED15F0085B254 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
 				58F2EB15292FB74D004A9BDE /* XCRemoteSwiftPackageReference "CodeEditTextView" */,
 				58F2EB18292FB91C004A9BDE /* XCRemoteSwiftPackageReference "Preferences" */,
@@ -3788,14 +3784,6 @@
 				version = 1.9.0;
 			};
 		};
-		5879826D292EC9870085B254 /* XCRemoteSwiftPackageReference "GRDB.swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/groue/GRDB.swift.git";
-			requirement = {
-				kind = exactVersion;
-				version = 5.22.2;
-			};
-		};
 		58798288292ED15F0085B254 /* XCRemoteSwiftPackageReference "SwiftTerm" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/migueldeicaza/SwiftTerm.git";
@@ -3809,7 +3797,7 @@
 			repositoryURL = "https://github.com/CodeEditApp/CodeEditTextView.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.5.0;
+				version = 0.5.1;
 			};
 		};
 		58F2EB18292FB91C004A9BDE /* XCRemoteSwiftPackageReference "Preferences" */ = {
@@ -3853,11 +3841,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 583E529A29361BAB001AB554 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
 			productName = SnapshotTesting;
-		};
-		5879826E292EC9870085B254 /* GRDB */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5879826D292EC9870085B254 /* XCRemoteSwiftPackageReference "GRDB.swift" */;
-			productName = GRDB;
 		};
 		58798289292ED15F0085B254 /* SwiftTerm */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
       "state" : {
-        "revision" : "02595fb02841568b9befcbfcdaf9be88280c49aa",
-        "version" : "0.1.11"
+        "revision" : "08cb9dc04e70d1e7b9610580794ed4da774c2b84",
+        "version" : "0.1.13"
       }
     },
     {
@@ -23,17 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "4ff2df56b94c822e834353ce9f74836f700bff1c",
-        "version" : "0.5.0"
-      }
-    },
-    {
-      "identity" : "grdb.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/groue/GRDB.swift.git",
-      "state" : {
-        "revision" : "15c06e037430c8a2dc570f9199dd7bf8caa21195",
-        "version" : "5.22.2"
+        "revision" : "36a5f790153d9feae0221ba40e0b9da2a1211232",
+        "version" : "0.5.1"
       }
     },
     {

--- a/CodeEdit.xcodeproj/xcshareddata/xcschemes/CodeEdit.xcscheme
+++ b/CodeEdit.xcodeproj/xcshareddata/xcschemes/CodeEdit.xcscheme
@@ -29,70 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CodeFileTests"
-               BuildableName = "CodeFileTests"
-               BlueprintName = "CodeFileTests"
-               ReferencedContainer = "container:CodeEditModules">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "WorkspaceClientTests"
-               BuildableName = "WorkspaceClientTests"
-               BlueprintName = "WorkspaceClientTests"
-               ReferencedContainer = "container:CodeEditModules">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "GitClientTests"
-               BuildableName = "GitClientTests"
-               BlueprintName = "GitClientTests"
-               ReferencedContainer = "container:CodeEditModules">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "StatusBarTests"
-               BuildableName = "StatusBarTests"
-               BlueprintName = "StatusBarTests"
-               ReferencedContainer = "container:CodeEditModules">
-            </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "StatusBarUnitTests/testStatusBarCollapsedDark()">
-               </Test>
-               <Test
-                  Identifier = "StatusBarUnitTests/testStatusBarCollapsedLight()">
-               </Test>
-               <Test
-                  Identifier = "StatusBarUnitTests/testStatusBarExpandedDark()">
-               </Test>
-               <Test
-                  Identifier = "StatusBarUnitTests/testStatusBarExpandedLight()">
-               </Test>
-            </SkippedTests>
-         </TestableReference>
-         <TestableReference
-            skipped = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CodeEditUtilsTests"
-               BuildableName = "CodeEditUtilsTests"
-               BlueprintName = "CodeEditUtilsTests"
-               ReferencedContainer = "container:CodeEditModules">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
@@ -102,6 +38,9 @@
                ReferencedContainer = "container:CodeEdit.xcodeproj">
             </BuildableReference>
             <SkippedTests>
+               <Test
+                  Identifier = "CodeEditUIUnitTests">
+               </Test>
                <Test
                   Identifier = "CodeEditUIUnitTests/testBranchPickerDark()">
                </Test>
@@ -149,6 +88,9 @@
                </Test>
                <Test
                   Identifier = "DocumentsUnitTests/testSplitViewControllerStopSnappedWhenWidthIsHigherAppropriateRange()">
+               </Test>
+               <Test
+                  Identifier = "WelcomeModuleUnitTests">
                </Test>
                <Test
                   Identifier = "WelcomeModuleUnitTests/testRecentJSFileDarkSnapshot()">


### PR DESCRIPTION
- updates `CodeEditTextView` with support for `Dart` language grammar.
- removes `GRDB` dependency as it is no longer used anywhere.
- removes _missing_ test bundles from the CodeEdit target