### PR TITLE
Add terminal zoom in/out (building on top of #1191)

### DIFF
--- a/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
+++ b/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
@@ -31,7 +31,7 @@ struct TerminalEmulatorView: NSViewRepresentable {
 
     private var font: NSFont {
         if !prefs.preferences.terminal.font.customFont {
-            return systemFont
+            return systemFont.withSize(CGFloat(prefs.preferences.terminal.font.size))
         }
         return NSFont(
             name: prefs.preferences.terminal.font.name,

--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -32,7 +32,7 @@ struct ViewCommands: Commands {
             .keyboardShortcut("p", modifiers: [.shift, .command])
 
             Button("Zoom in") {
-                if !(CodeEditDocumentController.shared.documents.count > 1) {
+                if CodeEditDocumentController.shared.documents.count > 1 {
                     prefs.preferences.textEditing.font.size += 1
                 }
                 prefs.preferences.terminal.font.size += 1
@@ -40,7 +40,7 @@ struct ViewCommands: Commands {
             .keyboardShortcut("+")
 
             Button("Zoom out") {
-                if !(CodeEditDocumentController.shared.documents.count > 1) {
+                if CodeEditDocumentController.shared.documents.count > 1 {
                     if !(prefs.preferences.textEditing.font.size <= 1) {
                         prefs.preferences.textEditing.font.size -= 1
                     }

--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ViewCommands: Commands {
+    let documentController: CodeEditDocumentController = CodeEditDocumentController()
+    let statusBarViewModel: StatusBarViewModel = StatusBarViewModel()
     private var prefs: AppPreferencesModel = .shared
     @State var windowController: CodeEditWindowController?
 
@@ -27,14 +29,18 @@ struct ViewCommands: Commands {
             .keyboardShortcut("p", modifiers: [.shift, .command])
 
             Button("Zoom in") {
-                prefs.preferences.textEditing.font.size += 1
+                if !(CodeEditDocumentController.shared.documents.count > 1) {
+                    prefs.preferences.textEditing.font.size += 1
+                }
                 prefs.preferences.terminal.font.size += 1
             }
             .keyboardShortcut("+")
 
             Button("Zoom out") {
-                if !(prefs.preferences.textEditing.font.size <= 1) {
-                    prefs.preferences.textEditing.font.size -= 1
+                if !(CodeEditDocumentController.shared.documents.count > 1) {
+                    if !(prefs.preferences.textEditing.font.size <= 1) {
+                        prefs.preferences.textEditing.font.size -= 1
+                    }
                 }
                 if !(prefs.preferences.terminal.font.size <= 1) {
                     prefs.preferences.terminal.font.size -= 1

--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -28,12 +28,16 @@ struct ViewCommands: Commands {
 
             Button("Zoom in") {
                 prefs.preferences.textEditing.font.size += 1
+                prefs.preferences.terminal.font.size += 1
             }
             .keyboardShortcut("+")
 
             Button("Zoom out") {
                 if !(prefs.preferences.textEditing.font.size <= 1) {
                     prefs.preferences.textEditing.font.size -= 1
+                }
+                if !(prefs.preferences.terminal.font.size <= 1) {
+                    prefs.preferences.terminal.font.size -= 1
                 }
             }
             .keyboardShortcut("-")

--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -8,10 +8,13 @@
 import SwiftUI
 
 struct ViewCommands: Commands {
-    let documentController: CodeEditDocumentController = CodeEditDocumentController()
-    let statusBarViewModel: StatusBarViewModel = StatusBarViewModel()
+    @ObservedObject
     private var prefs: AppPreferencesModel = .shared
+
     @State var windowController: CodeEditWindowController?
+
+    private let documentController: CodeEditDocumentController = CodeEditDocumentController()
+    private let statusBarViewModel: StatusBarViewModel = StatusBarViewModel()
 
     var navigatorCollapsed: Bool {
         windowController?.navigatorCollapsed ?? false

--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -31,7 +31,7 @@ struct ViewCommands: Commands {
             }
             .keyboardShortcut("p", modifiers: [.shift, .command])
 
-            Button("Zoom in") {
+            Button("Increase font size") {
                 if CodeEditDocumentController.shared.documents.count > 1 {
                     prefs.preferences.textEditing.font.size += 1
                 }
@@ -39,7 +39,7 @@ struct ViewCommands: Commands {
             }
             .keyboardShortcut("+")
 
-            Button("Zoom out") {
+            Button("Decrease font size") {
                 if CodeEditDocumentController.shared.documents.count > 1 {
                     if !(prefs.preferences.textEditing.font.size <= 1) {
                         prefs.preferences.textEditing.font.size -= 1


### PR DESCRIPTION
### Description

this `PR` further builds on #1191 by adding the text-zoom feature to the terminal (to mimic xcode) and puts a small fix in `TerminalEmulatorView.swift` (that is related to text-zoom). I'm offline for tonight, but maintainers have edit access

### Related Issues

* further improves #1122

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://user-images.githubusercontent.com/128280019/228368135-306ad0d0-170e-42bc-a9e8-7bbde00fca0c.mov


