### PR TITLE
Implement keyboard shortcuts

### DIFF
--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -49,11 +49,9 @@ struct FileCommands: Commands {
             .keyboardShortcut("w", modifiers: [.shift, .command])
 
             Button("Close Workspace") {
-                NSDocumentController.shared.closeAllDocuments(
-                    withDelegate: nil,
-                    didCloseAllSelector: nil,
-                    contextInfo: nil
-                )
+                if NSApp.keyWindow?.windowController.document != nil {
+                    NSApp.keyWindow?.close()
+                }
             }
             .keyboardShortcut("w", modifiers: [.control, .option, .command])
 

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -49,7 +49,7 @@ struct FileCommands: Commands {
             .keyboardShortcut("w", modifiers: [.shift, .command])
 
             Button("Close Workspace") {
-                if NSApp.keyWindow?.windowController.document != nil {
+                if NSApp.keyWindow?.windowController?.document != nil {
                     NSApp.keyWindow?.close()
                 }
             }

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -49,7 +49,7 @@ struct FileCommands: Commands {
             .keyboardShortcut("w", modifiers: [.shift, .command])
 
             Button("Close Workspace") {
-                NSDocumentController().closeAllDocuments(
+                NSDocumentController.shared.closeAllDocuments(
                     withDelegate: nil,
                     didCloseAllSelector: nil,
                     contextInfo: nil

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -44,13 +44,15 @@ struct FileCommands: Commands {
             .keyboardShortcut("w", modifiers: [.control, .shift, .command])
 
             Button("Close Window") {
-                NSApp.keyWindow?.close()
+                CodeEditDocumentController.shared.saveAllDocuments(nil)
+                NSApp.keyWindow?.windowController?.close()
             }
             .keyboardShortcut("w", modifiers: [.shift, .command])
 
             Button("Close Workspace") {
                 if NSApp.keyWindow?.windowController?.document != nil {
-                    NSApp.keyWindow?.close()
+                    CodeEditDocumentController.shared.saveAllDocuments(nil)
+                    NSApp.keyWindow?.windowController?.close()
                 }
             }
             .keyboardShortcut("w", modifiers: [.control, .option, .command])

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -44,12 +44,16 @@ struct FileCommands: Commands {
             .keyboardShortcut("w", modifiers: [.control, .shift, .command])
 
             Button("Close Window") {
-
+                NSApp.keyWindow?.close()
             }
             .keyboardShortcut("w", modifiers: [.shift, .command])
 
             Button("Close Workspace") {
-
+                NSDocumentController().closeAllDocuments(
+                    withDelegate: nil,
+                    didCloseAllSelector: nil,
+                    contextInfo: nil
+                )
             }
             .keyboardShortcut("w", modifiers: [.control, .option, .command])
 


### PR DESCRIPTION
### Description

this `PR` adds support for more xcode-like keybindings and enabling them, and also tweaking a few to be more like xcode

### Related Issues

* closes #1097 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
- [x] Window closes if no tabs are open when pressing ⌘W
- [ ] ~~Close editor~~
- [x] Close Workspace
- [x] Close Window
- [ ] ~~Navigate tab commands~~

### Screenshots

coming soon
