### PR TITLE
Refactor Tab Bar to abstract styles away from logic

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		B66A4E5329C91831004573B4 /* CodeEditCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66A4E5229C91831004573B4 /* CodeEditCommands.swift */; };
 		B66A4E5629C918A0004573B4 /* SceneID.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66A4E5529C918A0004573B4 /* SceneID.swift */; };
 		B685DE7929CC9CCD002860C8 /* StatusBarIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = B685DE7829CC9CCD002860C8 /* StatusBarIcon.swift */; };
+		B6A15A7329D5E3FD006CDFC5 /* TabBarTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A15A7229D5E3FD006CDFC5 /* TabBarTabs.swift */; };
 		B6C6A42A297716A500A3D28F /* TabBarItemCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C6A429297716A500A3D28F /* TabBarItemCloseButton.swift */; };
 		B6C6A42E29771A8D00A3D28F /* TabBarItemButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C6A42D29771A8D00A3D28F /* TabBarItemButtonStyle.swift */; };
 		B6C6A43029771F7100A3D28F /* TabBarItemBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C6A42F29771F7100A3D28F /* TabBarItemBackground.swift */; };
@@ -744,6 +745,7 @@
 		B66A4E5229C91831004573B4 /* CodeEditCommands.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeEditCommands.swift; sourceTree = "<group>"; };
 		B66A4E5529C918A0004573B4 /* SceneID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneID.swift; sourceTree = "<group>"; };
 		B685DE7829CC9CCD002860C8 /* StatusBarIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarIcon.swift; sourceTree = "<group>"; };
+		B6A15A7229D5E3FD006CDFC5 /* TabBarTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarTabs.swift; sourceTree = "<group>"; };
 		B6C6A429297716A500A3D28F /* TabBarItemCloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItemCloseButton.swift; sourceTree = "<group>"; };
 		B6C6A42D29771A8D00A3D28F /* TabBarItemButtonStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarItemButtonStyle.swift; sourceTree = "<group>"; };
 		B6C6A42F29771F7100A3D28F /* TabBarItemBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItemBackground.swift; sourceTree = "<group>"; };
@@ -1792,6 +1794,7 @@
 			isa = PBXGroup;
 			children = (
 				287776E827E34BC700D46668 /* TabBarView.swift */,
+				B6A15A7229D5E3FD006CDFC5 /* TabBarTabs.swift */,
 				287776EE27E3515300D46668 /* TabBarItemView.swift */,
 				B6C6A429297716A500A3D28F /* TabBarItemCloseButton.swift */,
 				6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */,
@@ -2779,6 +2782,7 @@
 				587B9E7E29301D8F00AC7927 /* GitHubGistRouter.swift in Sources */,
 				6CAAF69229BCC71C00A1F48A /* (null) in Sources */,
 				581BFB682926431000D251EC /* WelcomeView.swift in Sources */,
+				B6A15A7329D5E3FD006CDFC5 /* TabBarTabs.swift in Sources */,
 				6CFF967829BEBCF600182D6F /* MainCommands.swift in Sources */,
 				587B9E7129301D8F00AC7927 /* GitURLSession.swift in Sources */,
 				5882252C292C280D00E83CDE /* StatusBarDrawer.swift in Sources */,

--- a/CodeEdit/Features/AppPreferences/Model/General/GeneralPreferences.swift
+++ b/CodeEdit/Features/AppPreferences/Model/General/GeneralPreferences.swift
@@ -34,7 +34,7 @@ extension AppPreferences {
         var fileIconStyle: FileIconStyle = .color
 
         /// Choose between native-styled tab bar and Xcode-liked tab bar.
-        var tabBarStyle: TabBarStyle = .xcode
+        var tabBarStyle: TabBarView.TabBarStyle = .xcode
 
         /// The reopen behavior of the app
         var reopenBehavior: ReopenBehavior = .welcome
@@ -93,7 +93,7 @@ extension AppPreferences {
                 forKey: .fileIconStyle
             ) ?? .color
             self.tabBarStyle = try container.decodeIfPresent(
-                TabBarStyle.self,
+                TabBarView.TabBarStyle.self,
                 forKey: .tabBarStyle
             ) ?? .xcode
             self.reopenBehavior = try container.decodeIfPresent(
@@ -200,14 +200,6 @@ extension AppPreferences {
     enum FileIconStyle: String, Codable {
         case color
         case monochrome
-    }
-
-    /// The style for tab bar
-    /// - **native**: Native-styled tab bar (like Finder)
-    /// - **xcode**: Xcode-liked tab bar
-    enum TabBarStyle: String, Codable {
-        case native
-        case xcode
     }
 
     /// The reopen behavior of the app

--- a/CodeEdit/Features/AppPreferences/Sections/GeneralPreferences/GeneralPreferencesView.swift
+++ b/CodeEdit/Features/AppPreferences/Sections/GeneralPreferences/GeneralPreferencesView.swift
@@ -142,9 +142,9 @@ private extension GeneralPreferencesView {
         PreferencesSection("Tab Bar Style") {
             Picker("Tab Bar Style:", selection: $prefs.preferences.general.tabBarStyle) {
                 Text("Xcode")
-                    .tag(AppPreferences.TabBarStyle.xcode)
+                    .tag(TabBarView.TabBarStyle.xcode)
                 Text("Native")
-                    .tag(AppPreferences.TabBarStyle.native)
+                    .tag(TabBarView.TabBarStyle.native)
             }
             .pickerStyle(.radioGroup)
         }

--- a/CodeEdit/Features/SplitView/EditorView.swift
+++ b/CodeEdit/Features/SplitView/EditorView.swift
@@ -27,7 +27,7 @@ struct EditorView: View {
         VStack {
             switch tabgroup {
             case .one(let detailTabGroup):
-                WorkspaceTabGroupView(tabgroup: detailTabGroup, focus: $focus)
+                WorkspaceTabGroupView(tabGroup: detailTabGroup, focus: $focus)
                     .transformEnvironment(\.edgeInsets) { insets in
                         switch isAtEdge {
                         case .all:

--- a/CodeEdit/Features/Tabs/TabGroup/WorkspaceTabGroupView.swift
+++ b/CodeEdit/Features/Tabs/TabGroup/WorkspaceTabGroupView.swift
@@ -9,7 +9,10 @@ import SwiftUI
 
 struct WorkspaceTabGroupView: View {
     @ObservedObject
-    var tabgroup: TabGroupData
+    var tabGroup: TabGroupData
+
+    @StateObject
+    private var prefs: AppPreferencesModel = .shared
 
     @FocusState.Binding
     var focus: TabGroupData?
@@ -19,7 +22,7 @@ struct WorkspaceTabGroupView: View {
 
     var body: some View {
         VStack {
-            if let selected = tabgroup.selected {
+            if let selected = tabGroup.selected {
                 WorkspaceCodeFileView(file: selected)
                     .transformEnvironment(\.edgeInsets) { insets in
                         insets.top += TabBarView.height + PathBarView.height + 1 + 1
@@ -37,7 +40,7 @@ struct WorkspaceTabGroupView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    tabManager.activeTabGroup = tabgroup
+                    tabManager.activeTabGroup = tabGroup
                 }
             }
         }
@@ -46,25 +49,25 @@ struct WorkspaceTabGroupView: View {
         .safeAreaInset(edge: .top, spacing: 0) {
             VStack(spacing: 0) {
                 TabBarView()
-                    .id("TabBarView" + tabgroup.id.uuidString)
-                    .environmentObject(tabgroup)
-
+                    .id("TabBarView" + tabGroup.id.uuidString)
+                    .environmentObject(tabGroup)
+                    .tabBarStyle(prefs.preferences.general.tabBarStyle)
                 Divider()
-                if let file = tabgroup.selected {
-                    PathBarView(file: file) { [weak tabgroup] newFile in
-                        if let index = tabgroup?.tabs.firstIndex(of: file) {
-                            tabgroup?.openTab(item: newFile, at: index)
+                if let file = tabGroup.selected {
+                    PathBarView(file: file) { [weak tabGroup] newFile in
+                        if let index = tabGroup?.tabs.firstIndex(of: file) {
+                            tabGroup?.openTab(item: newFile, at: index)
                         }
                     }
                     Divider()
                 }
             }
-            .environment(\.isActiveTabGroup, tabgroup == tabManager.activeTabGroup)
+            .environment(\.isActiveTabGroup, tabGroup == tabManager.activeTabGroup)
             .background(EffectView(.titlebar, blendingMode: .withinWindow, emphasized: false))
         }
-        .focused($focus, equals: tabgroup)
+        .focused($focus, equals: tabGroup)
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("CodeEditor.didBeginEditing"))) { _ in
-            tabgroup.temporaryTab = nil
+            tabGroup.temporaryTab = nil
         }
     }
 }

--- a/CodeEdit/Features/Tabs/Views/TabBarItemCloseButton.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarItemCloseButton.swift
@@ -19,6 +19,9 @@ struct TabBarItemCloseButton: View {
     @Environment(\.colorScheme)
     var colorScheme
 
+    @Environment(\.tabBarStyle)
+    private var tabBarStyle: TabBarView.TabBarStyle
+
     @StateObject
     private var prefs: AppPreferencesModel = .shared
 
@@ -32,7 +35,7 @@ struct TabBarItemCloseButton: View {
 
     var body: some View {
         HStack {
-            if prefs.preferences.general.tabBarStyle == .xcode {
+            if tabBarStyle == .xcode {
                 Image(systemName: "xmark")
                     .font(.system(size: 11.5, weight: .regular, design: .rounded))
                     .foregroundColor(
@@ -52,7 +55,7 @@ struct TabBarItemCloseButton: View {
             ? Color(nsColor: .white)
                 .opacity(isPressingClose ? 0.10 : isHoveringClose ? 0.05 : 0)
             : (
-                prefs.preferences.general.tabBarStyle == .xcode
+                tabBarStyle == .xcode
                 ? Color(nsColor: isActive ? .controlAccentColor : .black)
                     .opacity(
                         isPressingClose

--- a/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
@@ -23,6 +23,9 @@ struct TabBarItemView: View {
     @Environment(\.isFullscreen)
     private var isFullscreen
 
+    @Environment(\.tabBarStyle)
+    private var tabBarStyle: TabBarView.TabBarStyle
+
     @EnvironmentObject
     private var tabManager: TabManager
 
@@ -112,7 +115,7 @@ struct TabBarItemView: View {
     func closeAction() {
         isAppeared = false
         withAnimation(
-            .easeOut(duration: prefs.preferences.general.tabBarStyle == .native ? 0.15 : 0.20)
+            .easeOut(duration: tabBarStyle == .native ? 0.15 : 0.20)
         ) {
             tabgroup.closeTab(item: item)
         }
@@ -140,9 +143,9 @@ struct TabBarItemView: View {
             TabDivider()
                 .opacity(
                     (isActive || inHoldingState)
-                    && prefs.preferences.general.tabBarStyle == .xcode ? 0.0 : 1.0
+                    && tabBarStyle == .xcode ? 0.0 : 1.0
                 )
-                .padding(.top, isActive && prefs.preferences.general.tabBarStyle == .native ? 1.22 : 0)
+                .padding(.top, isActive && tabBarStyle == .native ? 1.22 : 0)
             // Tab content (icon and text).
             HStack(alignment: .center, spacing: 5) {
                 Image(systemName: item.systemImage)
@@ -165,11 +168,11 @@ struct TabBarItemView: View {
             }
             .frame(
                 // To horizontally max-out the given width area ONLY in native tab bar style.
-                maxWidth: prefs.preferences.general.tabBarStyle == .native ? .infinity : nil,
+                maxWidth: tabBarStyle == .native ? .infinity : nil,
                 // To max-out the parent (tab bar) area.
                 maxHeight: .infinity
             )
-            .padding(.horizontal, prefs.preferences.general.tabBarStyle == .native ? 28 : 23)
+            .padding(.horizontal, tabBarStyle == .native ? 28 : 23)
             .overlay {
                 ZStack {
                     if isActive {
@@ -218,31 +221,31 @@ struct TabBarItemView: View {
                 ? 1.0
                 : (
                     isActive
-                    ? (prefs.preferences.general.tabBarStyle == .xcode ? 0.6 : 0.35)
-                    : (prefs.preferences.general.tabBarStyle == .xcode ? 0.4 : 0.55)
+                    ? (tabBarStyle == .xcode ? 0.6 : 0.35)
+                    : (tabBarStyle == .xcode ? 0.4 : 0.55)
                 )
             )
             TabDivider()
                 .opacity(
                     (isActive || inHoldingState)
-                    && prefs.preferences.general.tabBarStyle == .xcode ? 0.0 : 1.0
+                    && tabBarStyle == .xcode ? 0.0 : 1.0
                 )
-                .padding(.top, isActive && prefs.preferences.general.tabBarStyle == .native ? 1.22 : 0)
+                .padding(.top, isActive && tabBarStyle == .native ? 1.22 : 0)
         }
         .overlay(alignment: .top) {
             // Only show NativeTabShadow when `tabBarStyle` is native and this tab is not active.
             TabBarTopDivider()
-                .opacity(prefs.preferences.general.tabBarStyle == .native && !isActive ? 1 : 0)
+                .opacity(tabBarStyle == .native && !isActive ? 1 : 0)
         }
         .foregroundColor(
             isActive && isActiveTabGroup
             ? (
-                prefs.preferences.general.tabBarStyle == .xcode && colorScheme != .dark
+                tabBarStyle == .xcode && colorScheme != .dark
                 ? Color(nsColor: .controlAccentColor)
                 : .primary
             )
             : (
-                prefs.preferences.general.tabBarStyle == .xcode
+                tabBarStyle == .xcode
                 ? .primary
                 : .secondary
             )
@@ -267,7 +270,7 @@ struct TabBarItemView: View {
                 content
             }
             .background {
-                if prefs.preferences.general.tabBarStyle == .xcode {
+                if tabBarStyle == .xcode {
                     TabBarItemBackground(isActive: isActive, isPressing: isPressing, isDragging: isDragging)
                         .animation(.easeInOut(duration: 0.08), value: isHovering)
                 } else {
@@ -306,29 +309,29 @@ struct TabBarItemView: View {
         )
         .padding(
             // This padding is to avoid background color overlapping with top divider.
-            .top, prefs.preferences.general.tabBarStyle == .xcode ? 1 : 0
+            .top, tabBarStyle == .xcode ? 1 : 0
         )
 //        .offset(
-//            x: isAppeared || prefs.preferences.general.tabBarStyle == .native ? 0 : -14,
+//            x: isAppeared || tabBarStyle == .native ? 0 : -14,
 //            y: 0
 //        )
 //        .opacity(isAppeared && onDragTabId != item.id ? 1.0 : 0.0)
         .zIndex(
             isActive
-            ? (prefs.preferences.general.tabBarStyle == .native ? -1 : 2)
+            ? (tabBarStyle == .native ? -1 : 2)
             : (isDragging ? 3 : (isPressing ? 1 : 0))
         )
         .frame(
             width: (
                 // Constrain the width of tab bar item for native tab style only.
-                prefs.preferences.general.tabBarStyle == .native
+                tabBarStyle == .native
                 ? max(expectedWidth.isFinite ? expectedWidth : 0, 0)
                 : nil
             )
         )
         .onAppear {
             withAnimation(
-                .easeOut(duration: prefs.preferences.general.tabBarStyle == .native ? 0.15 : 0.20)
+                .easeOut(duration: tabBarStyle == .native ? 0.15 : 0.20)
             ) {
 //                isAppeared = true
             }

--- a/CodeEdit/Features/Tabs/Views/TabBarTabs.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarTabs.swift
@@ -1,0 +1,456 @@
+//
+//  TabBarTabs.swift
+//  CodeEdit
+//
+//  Created by Austin Condiff on 3/30/23.
+//
+
+import SwiftUI
+
+// Disable the rule because the tabs view is fairly complicated.
+// It has the gesture implementation and its animations.
+// I am now also disabling `file_length` rule because the dragging algorithm (with UX) is complex.
+// swiftlint:disable file_length type_body_length
+// - TODO: TabBarItemView drop-outside event handler.
+struct TabBarTabs: View {
+    typealias TabID = WorkspaceClient.FileItem.ID
+
+    @StateObject
+    private var prefs: AppPreferencesModel = .shared
+
+    @EnvironmentObject
+    private var tabGroup: TabGroupData
+
+    /// The tab id of current dragging tab.
+    ///
+    /// It will be `nil` when there is no tab dragged currently.
+    @State
+    private var draggingTabId: TabID?
+
+    @State
+    private var onDragTabId: TabID?
+
+    /// The start location of dragging.
+    ///
+    /// When there is no tab being dragged, it will be `nil`.
+    /// - TODO: Check if I can use `value.startLocation` trustfully.
+    @State
+    private var draggingStartLocation: CGFloat?
+
+    /// The last location of dragging.
+    ///
+    /// This is used to determine the dragging direction.
+    /// - TODO: Check if I can use `value.translation` instead.
+    @State
+    private var draggingLastLocation: CGFloat?
+
+    /// Current opened tabs.
+    ///
+    /// This is a copy of `workspace.selectionState.openedTabs`.
+    /// I am making a copy of it because using state will hugely improve the dragging performance.
+    /// Updating ObservedObject too often will generate lags.
+    @State
+    private var openedTabs: [TabID] = []
+
+    /// A map of tab width.
+    ///
+    /// All width are measured dynamically (so it can also fit the Xcode tab bar style).
+    /// This is used to be added on the offset of current dragging tab in order to make a smooth
+    /// dragging experience.
+    @State
+    private var tabWidth: [TabID: CGFloat] = [:]
+
+    /// A map of tab location (CGRect).
+    ///
+    /// All locations are measured dynamically.
+    /// This is used to compute when we should swap two tabs based on current cursor location.
+    @State
+    private var tabLocations: [TabID: CGRect] = [:]
+
+    /// A map of tab offsets.
+    ///
+    /// This is used to determine the tab offset of every tab (by their tab id) while dragging.
+    @State
+    private var tabOffsets: [TabID: CGFloat] = [:]
+
+    /// The expected tab width in native tab bar style.
+    ///
+    /// This is computed by the total width of tab bar. It is updated automatically.
+    @State
+    private var expectedTabWidth: CGFloat = 0
+
+    /// This state is used to detect if the mouse is hovering over tabs.
+    /// If it is true, then we do not update the expected tab width immediately.
+    @State
+    private var isHoveringOverTabs: Bool = false
+
+    /// This state is used to detect if the dragging type should be changed from DragGesture to OnDrag.
+    /// It is basically switched when vertical displacement is exceeding the threshold.
+    @State
+    private var shouldOnDrag: Bool = false
+
+    /// Is current `onDrag` over tabs?
+    ///
+    /// When it is true, then the `onDrag` is over the tabs, then we leave the space for dragged tab.
+    /// When it is false, then the dragging cursor is outside the tab bar, then we should shrink the space.
+    ///
+    /// - TODO: The change of this state is overall incorrect. Should move it into workspace state.
+    @State
+    private var isOnDragOverTabs: Bool = false
+
+    /// The last location of `onDrag`.
+    ///
+    /// It can be used on reordering algorithm of `onDrag` (detecting when should we switch two tabs).
+    @State
+    private var onDragLastLocation: CGPoint?
+
+    @State
+    private var closeButtonGestureActive: Bool = false
+
+    /// Update the expected tab width when corresponding UI state is updated.
+    ///
+    /// This function will be called when the number of tabs or the parent size is changed.
+    private func updateExpectedTabWidth(proxy: GeometryProxy) {
+        expectedTabWidth = max(
+            // Equally divided size of a native tab.
+            (proxy.size.width + 1) / CGFloat(tabGroup.tabs.count) + 1,
+            // Min size of a native tab.
+            CGFloat(140)
+        )
+    }
+
+    // Disable the rule because this function is implementing the drag gesture and its animations.
+    // It is fairly complicated, so ignore the function body length limitation for now.
+    // swiftlint:disable function_body_length cyclomatic_complexity
+    private func makeTabDragGesture(id: TabID) -> some Gesture {
+        return DragGesture(minimumDistance: 2, coordinateSpace: .global)
+            .onChanged({ value in
+                if closeButtonGestureActive {
+                    return
+                }
+
+                if draggingTabId != id {
+                    shouldOnDrag = false
+                    draggingTabId = id
+                    draggingStartLocation = value.startLocation.x
+                    draggingLastLocation = value.location.x
+                }
+                // TODO: Enable this code snippet when re-enabling dragging-out behavior.
+                // I disabled (1 == 0) this behavior for now as dragging-out behavior isn't allowed.
+                if 1 == 0 && abs(value.location.y - value.startLocation.y) > TabBarView.height {
+                    shouldOnDrag = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
+                        shouldOnDrag = false
+                        draggingStartLocation = nil
+                        draggingLastLocation = nil
+                        draggingTabId = nil
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            // Clean the tab offsets.
+                            tabOffsets = [:]
+                        }
+                    })
+                    return
+                }
+                // Get the current cursor location.
+                let currentLocation = value.location.x
+                guard let startLocation = draggingStartLocation,
+                      let currentIndex = openedTabs.firstIndex(of: id),
+                      let currentTabWidth = tabWidth[id],
+                      let lastLocation = draggingLastLocation
+                else { return }
+                let dragDifference = currentLocation - lastLocation
+                let previousIndex = currentIndex > 0 ? currentIndex - 1 : nil
+                let nextIndex = currentIndex < openedTabs.count - 1 ? currentIndex + 1 : nil
+                tabOffsets[id] = currentLocation - startLocation
+                // Interacting with the previous tab.
+                if previousIndex != nil && dragDifference < 0 {
+                    // Wrap `previousTabIndex` because it may be `nil`.
+                    guard let previousTabIndex = previousIndex,
+                          let previousTabLocation = tabLocations[openedTabs[previousTabIndex]],
+                          let previousTabWidth = tabWidth[openedTabs[previousTabIndex]]
+                    else { return }
+                    if currentLocation < max(
+                        previousTabLocation.maxX - previousTabWidth * 0.1,
+                        previousTabLocation.minX + currentTabWidth * 0.9
+                    ) {
+                        let changing = previousTabWidth - 1 // One offset for overlapping divider.
+                        draggingStartLocation! -= changing
+                        withAnimation {
+                            tabOffsets[id]! += changing
+                            openedTabs.move(
+                                fromOffsets: IndexSet(integer: previousTabIndex),
+                                toOffset: currentIndex + 1
+                            )
+                        }
+                        return
+                    }
+                }
+                // Interacting with the next tab.
+                if nextIndex != nil && dragDifference > 0 {
+                    // Wrap `previousTabIndex` because it may be `nil`.
+                    guard let nextTabIndex = nextIndex,
+                          let nextTabLocation = tabLocations[openedTabs[nextTabIndex]],
+                          let nextTabWidth = tabWidth[openedTabs[nextTabIndex]]
+                    else { return }
+                    if currentLocation > min(
+                        nextTabLocation.minX + nextTabWidth * 0.1,
+                        nextTabLocation.maxX - currentTabWidth * 0.9
+                    ) {
+                        let changing = nextTabWidth - 1 // One offset for overlapping divider.
+                        draggingStartLocation! += changing
+                        withAnimation {
+                            tabOffsets[id]! -= changing
+                            openedTabs.move(
+                                fromOffsets: IndexSet(integer: nextTabIndex),
+                                toOffset: currentIndex
+                            )
+                        }
+                        return
+                    }
+                }
+                // Only update the last dragging location when there is enough offset.
+                if draggingLastLocation == nil || abs(value.location.x - draggingLastLocation!) >= 10 {
+                    draggingLastLocation = value.location.x
+                }
+            })
+            .onEnded({ _ in
+                shouldOnDrag = false
+                draggingStartLocation = nil
+                draggingLastLocation = nil
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    tabOffsets = [:]
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    draggingTabId = nil
+                }
+                // Sync the workspace's `openedTabs` 150ms after animation is finished.
+                // In order to avoid the lag due to the update of workspace state.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.40) {
+                    if draggingStartLocation == nil {
+                        tabGroup.tabs = .init(openedTabs.compactMap { id in
+                            tabGroup.tabs.first { $0.id == id }
+                        })
+                        // workspace.reorderedTabs(openedTabs: openedTabs)
+                        // TODO: Fix save state
+                    }
+                }
+            })
+    }
+    // swiftlint:enable function_body_length cyclomatic_complexity
+
+    private func makeTabItemGeometryReader(id: TabID) -> some View {
+        GeometryReader { tabItemGeoReader in
+            Rectangle()
+                .foregroundColor(.clear)
+                .onAppear {
+                    tabWidth[id] = tabItemGeoReader.size.width
+                    tabLocations[id] = tabItemGeoReader
+                        .frame(in: .global)
+                }
+                .onChange(
+                    of: tabItemGeoReader.frame(in: .global),
+                    perform: { tabCGRect in
+                        tabLocations[id] = tabCGRect
+                    }
+                )
+                .onChange(
+                    of: tabItemGeoReader.size.width,
+                    perform: { newWidth in
+                        tabWidth[id] = newWidth
+                    }
+                )
+        }
+    }
+
+    /// Conditionally updates the `expectedTabWidth`.
+    /// Called when the tab count changes or the temporary tab changes.
+    /// - Parameter geometryProxy: The geometry proxy to calculate the new width using.
+    private func updateForTabCountChange(geometryProxy: GeometryProxy) {
+        openedTabs = tabGroup.tabs.map(\.id)
+
+        // Only update the expected width when user is not hovering over tabs.
+        // This should give users a better experience on closing multiple tabs continuously.
+        if !isHoveringOverTabs {
+            withAnimation(.easeOut(duration: 0.15)) {
+                updateExpectedTabWidth(proxy: geometryProxy)
+            }
+        }
+    }
+
+    var body: some View {
+        GeometryReader { geometryProxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                ScrollViewReader { scrollReader in
+                    HStack(
+                        alignment: .center,
+                        spacing: -1 // Negative spacing for overlapping the divider.
+                    ) {
+                        ForEach(Array(openedTabs.enumerated()), id: \.element) { index, id in
+                            if let item = tabGroup.tabs.first(where: { $0.id == id }) {
+                                TabBarItemView(
+                                    expectedWidth: expectedTabWidth,
+                                    item: item,
+                                    index: index,
+                                    draggingTabId: draggingTabId,
+                                    onDragTabId: onDragTabId,
+                                    closeButtonGestureActive: $closeButtonGestureActive
+                                )
+                                .transition(
+                                    .asymmetric(
+                                        insertion: .offset(x: -14).combined(with: .opacity),
+                                        removal: .opacity
+                                    )
+                                )
+                                .frame(height: TabBarView.height)
+                                .background(makeTabItemGeometryReader(id: id))
+                                .offset(x: tabOffsets[id] ?? 0, y: 0)
+                                .simultaneousGesture(
+                                    makeTabDragGesture(id: id),
+                                    including: shouldOnDrag ? .subviews : .all
+                                )
+                                // TODO: Detect the onDrag outside of tab bar.
+                                // Detect the drop action of each tab.
+                                .onDrop(
+                                    of: [.utf8PlainText], // TODO: Make a unique type for it.
+                                    delegate: TabBarItemOnDropDelegate(
+                                        currentTabId: id,
+                                        openedTabs: $openedTabs,
+                                        onDragTabId: $onDragTabId,
+                                        onDragLastLocation: $onDragLastLocation,
+                                        isOnDragOverTabs: $isOnDragOverTabs,
+                                        tabWidth: $tabWidth
+                                    )
+                                )
+                            }
+                        }
+                    }
+                    // This padding is to hide dividers at two ends under the accessory view divider.
+                    .padding(.horizontal, prefs.preferences.general.tabBarStyle == .native ? -1 : 0)
+                    .onAppear {
+                        openedTabs = tabGroup.tabs.map(\.id)
+                        // On view appeared, compute the initial expected width for tabs.
+                        updateExpectedTabWidth(proxy: geometryProxy)
+                        // On first tab appeared, jump to the corresponding position.
+                        scrollReader.scrollTo(tabGroup.selected)
+                    }
+                    .onChange(of: tabGroup.tabs) { [tabs = tabGroup.tabs] newValue in
+                        if tabs.count == newValue.count {
+                            updateForTabCountChange(geometryProxy: geometryProxy)
+                        } else {
+                            withAnimation(
+                                .easeOut(duration: prefs.preferences.general.tabBarStyle == .native ? 0.15 : 0.20)
+                            ) {
+                                updateForTabCountChange(geometryProxy: geometryProxy)
+                            }
+                        }
+                        Task {
+                            try? await Task.sleep(for: .milliseconds(300))
+                            withAnimation {
+                                scrollReader.scrollTo(tabGroup.selected?.id)
+                            }
+                        }
+                    }
+                    // When selected tab is changed, scroll to it if possible.
+                    .onChange(of: tabGroup.selected) { newValue in
+                        withAnimation {
+                            scrollReader.scrollTo(newValue?.id)
+                        }
+                    }
+
+                    // When window size changes, re-compute the expected tab width.
+                    .onChange(of: geometryProxy.size.width) { _ in
+                        updateExpectedTabWidth(proxy: geometryProxy)
+                        withAnimation {
+                            scrollReader.scrollTo(tabGroup.selected?.id)
+                        }
+                    }
+                    // When user is not hovering anymore, re-compute the expected tab width immediately.
+                    .onHover { isHovering in
+                        isHoveringOverTabs = isHovering
+                        if !isHovering {
+                            withAnimation(.easeOut(duration: 0.15)) {
+                                updateExpectedTabWidth(proxy: geometryProxy)
+                            }
+                        }
+                    }
+                    .frame(height: TabBarView.height)
+                }
+
+                // To fill up the parent space of tab bar.
+                .frame(maxWidth: .infinity)
+                .background {
+                    if prefs.preferences.general.tabBarStyle == .native {
+                        TabBarNativeInactiveBackground()
+                    }
+                }
+            }
+            .background {
+                if prefs.preferences.general.tabBarStyle == .native {
+                    TabBarAccessoryNativeBackground(dividerAt: .none)
+                }
+            }
+        }
+    }
+
+    private struct TabBarItemOnDropDelegate: DropDelegate {
+        private let currentTabId: TabID
+        @Binding
+        private var openedTabs: [TabID]
+        @Binding
+        private var onDragTabId: TabID?
+        @Binding
+        private var onDragLastLocation: CGPoint?
+        @Binding
+        private var isOnDragOverTabs: Bool
+        @Binding
+        private var tabWidth: [TabID: CGFloat]
+
+        public init(
+            currentTabId: TabID,
+            openedTabs: Binding<[TabID]>,
+            onDragTabId: Binding<TabID?>,
+            onDragLastLocation: Binding<CGPoint?>,
+            isOnDragOverTabs: Binding<Bool>,
+            tabWidth: Binding<[TabID: CGFloat]>
+        ) {
+            self.currentTabId = currentTabId
+            self._openedTabs = openedTabs
+            self._onDragTabId = onDragTabId
+            self._onDragLastLocation = onDragLastLocation
+            self._isOnDragOverTabs = isOnDragOverTabs
+            self._tabWidth = tabWidth
+        }
+
+        func dropEntered(info: DropInfo) {
+            isOnDragOverTabs = true
+            guard let onDragTabId,
+                  currentTabId != onDragTabId,
+                  let from = openedTabs.firstIndex(of: onDragTabId),
+                  let toIndex = openedTabs.firstIndex(of: currentTabId)
+            else { return }
+            if openedTabs[toIndex] != onDragTabId {
+                withAnimation {
+                    openedTabs.move(
+                        fromOffsets: IndexSet(integer: from),
+                        toOffset: toIndex > from ? toIndex + 1 : toIndex
+                    )
+                }
+            }
+        }
+
+        func dropExited(info: DropInfo) {
+            // Do nothing.
+        }
+
+        func dropUpdated(info: DropInfo) -> DropProposal? {
+            return DropProposal(operation: .move)
+        }
+
+        func performDrop(info: DropInfo) -> Bool {
+            isOnDragOverTabs = false
+            onDragTabId = nil
+            onDragLastLocation = nil
+            return true
+        }
+    }
+}

--- a/CodeEdit/Features/Tabs/Views/TabBarTabs.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarTabs.swift
@@ -18,6 +18,9 @@ struct TabBarTabs: View {
     @StateObject
     private var prefs: AppPreferencesModel = .shared
 
+    @Environment(\.tabBarStyle)
+    private var tabBarStyle: TabBarView.TabBarStyle
+
     @EnvironmentObject
     private var tabGroup: TabGroupData
 
@@ -324,8 +327,11 @@ struct TabBarTabs: View {
                             }
                         }
                     }
+
+                    // TODO: Replace the code below with:
+                    // tabBarStyle.dividerStyle ???
                     // This padding is to hide dividers at two ends under the accessory view divider.
-                    .padding(.horizontal, prefs.preferences.general.tabBarStyle == .native ? -1 : 0)
+                    .padding(.horizontal, tabBarStyle == .native ? -1 : 0)
                     .onAppear {
                         openedTabs = tabGroup.tabs.map(\.id)
                         // On view appeared, compute the initial expected width for tabs.
@@ -337,8 +343,10 @@ struct TabBarTabs: View {
                         if tabs.count == newValue.count {
                             updateForTabCountChange(geometryProxy: geometryProxy)
                         } else {
+                            // TODO: Replace the code below with:
+                            // tabBarStyle.tabEnterAnimationLength
                             withAnimation(
-                                .easeOut(duration: prefs.preferences.general.tabBarStyle == .native ? 0.15 : 0.20)
+                                .easeOut(duration: tabBarStyle == .native ? 0.15 : 0.20)
                             ) {
                                 updateForTabCountChange(geometryProxy: geometryProxy)
                             }
@@ -379,13 +387,17 @@ struct TabBarTabs: View {
                 // To fill up the parent space of tab bar.
                 .frame(maxWidth: .infinity)
                 .background {
-                    if prefs.preferences.general.tabBarStyle == .native {
+                    // TODO: Replace the code below with:
+                    // tabBarStyle.tabBarInactiveBackground ???
+                    if tabBarStyle == .native {
                         TabBarNativeInactiveBackground()
                     }
                 }
             }
             .background {
-                if prefs.preferences.general.tabBarStyle == .native {
+                // TODO: Replace the code below with:
+                // tabBarStyle.tabBarBackground
+                if tabBarStyle == .native {
                     TabBarAccessoryNativeBackground(dividerAt: .none)
                 }
             }

--- a/CodeEdit/Features/Tabs/Views/TabBarView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarView.swift
@@ -7,11 +7,6 @@
 
 import SwiftUI
 
-// Disable the rule because the tab bar view is fairly complicated.
-// It has the gesture implementation and its animations.
-// I am now also disabling `file_length` rule because the dragging algorithm (with UX) is complex.
-// swiftlint:disable file_length type_body_length
-// - TODO: TabBarItemView drop-outside event handler.
 struct TabBarView: View {
 
     @Environment(\.modifierKeys) var modifierKeys
@@ -36,7 +31,7 @@ struct TabBarView: View {
     private var tabManager: TabManager
 
     @EnvironmentObject
-    private var tabgroup: TabGroupData
+    private var tabGroup: TabGroupData
 
     @Environment(\.splitEditor) var splitEditor
 
@@ -44,379 +39,12 @@ struct TabBarView: View {
     @StateObject
     private var prefs: AppPreferencesModel = .shared
 
-    /// The tab id of current dragging tab.
-    ///
-    /// It will be `nil` when there is no tab dragged currently.
-    @State
-    private var draggingTabId: TabID?
-
-    @State
-    private var onDragTabId: TabID?
-
-    /// The start location of dragging.
-    ///
-    /// When there is no tab being dragged, it will be `nil`.
-    /// - TODO: Check if I can use `value.startLocation` trustfully.
-    @State
-    private var draggingStartLocation: CGFloat?
-
-    /// The last location of dragging.
-    ///
-    /// This is used to determine the dragging direction.
-    /// - TODO: Check if I can use `value.translation` instead.
-    @State
-    private var draggingLastLocation: CGFloat?
-
-    /// Current opened tabs.
-    ///
-    /// This is a copy of `workspace.selectionState.openedTabs`.
-    /// I am making a copy of it because using state will hugely improve the dragging performance.
-    /// Updating ObservedObject too often will generate lags.
-    @State
-    private var openedTabs: [TabID] = []
-
-    /// A map of tab width.
-    ///
-    /// All width are measured dynamically (so it can also fit the Xcode tab bar style).
-    /// This is used to be added on the offset of current dragging tab in order to make a smooth
-    /// dragging experience.
-    @State
-    private var tabWidth: [TabID: CGFloat] = [:]
-
-    /// A map of tab location (CGRect).
-    ///
-    /// All locations are measured dynamically.
-    /// This is used to compute when we should swap two tabs based on current cursor location.
-    @State
-    private var tabLocations: [TabID: CGRect] = [:]
-
-    /// A map of tab offsets.
-    ///
-    /// This is used to determine the tab offset of every tab (by their tab id) while dragging.
-    @State
-    private var tabOffsets: [TabID: CGFloat] = [:]
-
-    /// The expected tab width in native tab bar style.
-    ///
-    /// This is computed by the total width of tab bar. It is updated automatically.
-    @State
-    private var expectedTabWidth: CGFloat = 0
-
-    /// This state is used to detect if the mouse is hovering over tabs.
-    /// If it is true, then we do not update the expected tab width immediately.
-    @State
-    private var isHoveringOverTabs: Bool = false
-
-    /// This state is used to detect if the dragging type should be changed from DragGesture to OnDrag.
-    /// It is basically switched when vertical displacement is exceeding the threshold.
-    @State
-    private var shouldOnDrag: Bool = false
-
-    /// Is current `onDrag` over tabs?
-    ///
-    /// When it is true, then the `onDrag` is over the tabs, then we leave the space for dragged tab.
-    /// When it is false, then the dragging cursor is outside the tab bar, then we should shrink the space.
-    ///
-    /// - TODO: The change of this state is overall incorrect. Should move it into workspace state.
-    @State
-    private var isOnDragOverTabs: Bool = false
-
-    /// The last location of `onDrag`.
-    ///
-    /// It can be used on reordering algorithm of `onDrag` (detecting when should we switch two tabs).
-    @State
-    private var onDragLastLocation: CGPoint?
-
-    @State
-    private var closeButtonGestureActive: Bool = false
-
-    /// Update the expected tab width when corresponding UI state is updated.
-    ///
-    /// This function will be called when the number of tabs or the parent size is changed.
-    private func updateExpectedTabWidth(proxy: GeometryProxy) {
-        expectedTabWidth = max(
-            // Equally divided size of a native tab.
-            (proxy.size.width + 1) / CGFloat(tabgroup.tabs.count) + 1,
-            // Min size of a native tab.
-            CGFloat(140)
-        )
-    }
-
-    // Disable the rule because this function is implementing the drag gesture and its animations.
-    // It is fairly complicated, so ignore the function body length limitation for now.
-    // swiftlint:disable function_body_length cyclomatic_complexity
-    private func makeTabDragGesture(id: TabID) -> some Gesture {
-        return DragGesture(minimumDistance: 2, coordinateSpace: .global)
-            .onChanged({ value in
-                if closeButtonGestureActive {
-                    return
-                }
-
-                if draggingTabId != id {
-                    shouldOnDrag = false
-                    draggingTabId = id
-                    draggingStartLocation = value.startLocation.x
-                    draggingLastLocation = value.location.x
-                }
-                // TODO: Enable this code snippet when re-enabling dragging-out behavior.
-                // I disabled (1 == 0) this behavior for now as dragging-out behavior isn't allowed.
-                if 1 == 0 && abs(value.location.y - value.startLocation.y) > TabBarView.height {
-                    shouldOnDrag = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
-                        shouldOnDrag = false
-                        draggingStartLocation = nil
-                        draggingLastLocation = nil
-                        draggingTabId = nil
-                        withAnimation(.easeInOut(duration: 0.25)) {
-                            // Clean the tab offsets.
-                            tabOffsets = [:]
-                        }
-                    })
-                    return
-                }
-                // Get the current cursor location.
-                let currentLocation = value.location.x
-                guard let startLocation = draggingStartLocation,
-                      let currentIndex = openedTabs.firstIndex(of: id),
-                      let currentTabWidth = tabWidth[id],
-                      let lastLocation = draggingLastLocation
-                else { return }
-                let dragDifference = currentLocation - lastLocation
-                let previousIndex = currentIndex > 0 ? currentIndex - 1 : nil
-                let nextIndex = currentIndex < openedTabs.count - 1 ? currentIndex + 1 : nil
-                tabOffsets[id] = currentLocation - startLocation
-                // Interacting with the previous tab.
-                if previousIndex != nil && dragDifference < 0 {
-                    // Wrap `previousTabIndex` because it may be `nil`.
-                    guard let previousTabIndex = previousIndex,
-                          let previousTabLocation = tabLocations[openedTabs[previousTabIndex]],
-                          let previousTabWidth = tabWidth[openedTabs[previousTabIndex]]
-                    else { return }
-                    if currentLocation < max(
-                        previousTabLocation.maxX - previousTabWidth * 0.1,
-                        previousTabLocation.minX + currentTabWidth * 0.9
-                    ) {
-                        let changing = previousTabWidth - 1 // One offset for overlapping divider.
-                        draggingStartLocation! -= changing
-                        withAnimation {
-                            tabOffsets[id]! += changing
-                            openedTabs.move(
-                                fromOffsets: IndexSet(integer: previousTabIndex),
-                                toOffset: currentIndex + 1
-                            )
-                        }
-                        return
-                    }
-                }
-                // Interacting with the next tab.
-                if nextIndex != nil && dragDifference > 0 {
-                    // Wrap `previousTabIndex` because it may be `nil`.
-                    guard let nextTabIndex = nextIndex,
-                          let nextTabLocation = tabLocations[openedTabs[nextTabIndex]],
-                          let nextTabWidth = tabWidth[openedTabs[nextTabIndex]]
-                    else { return }
-                    if currentLocation > min(
-                        nextTabLocation.minX + nextTabWidth * 0.1,
-                        nextTabLocation.maxX - currentTabWidth * 0.9
-                    ) {
-                        let changing = nextTabWidth - 1 // One offset for overlapping divider.
-                        draggingStartLocation! += changing
-                        withAnimation {
-                            tabOffsets[id]! -= changing
-                            openedTabs.move(
-                                fromOffsets: IndexSet(integer: nextTabIndex),
-                                toOffset: currentIndex
-                            )
-                        }
-                        return
-                    }
-                }
-                // Only update the last dragging location when there is enough offset.
-                if draggingLastLocation == nil || abs(value.location.x - draggingLastLocation!) >= 10 {
-                    draggingLastLocation = value.location.x
-                }
-            })
-            .onEnded({ _ in
-                shouldOnDrag = false
-                draggingStartLocation = nil
-                draggingLastLocation = nil
-                withAnimation(.easeInOut(duration: 0.25)) {
-                    tabOffsets = [:]
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-                    draggingTabId = nil
-                }
-                // Sync the workspace's `openedTabs` 150ms after animation is finished.
-                // In order to avoid the lag due to the update of workspace state.
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.40) {
-                    if draggingStartLocation == nil {
-                        tabgroup.tabs = .init(openedTabs.compactMap { id in
-                            tabgroup.tabs.first { $0.id == id }
-                        })
-                        // workspace.reorderedTabs(openedTabs: openedTabs)
-                        // TODO: Fix save state
-                    }
-                }
-            })
-    }
-    // swiftlint:enable function_body_length cyclomatic_complexity
-
-    private func makeTabItemGeometryReader(id: TabID) -> some View {
-        GeometryReader { tabItemGeoReader in
-            Rectangle()
-                .foregroundColor(.clear)
-                .onAppear {
-                    tabWidth[id] = tabItemGeoReader.size.width
-                    tabLocations[id] = tabItemGeoReader
-                        .frame(in: .global)
-                }
-                .onChange(
-                    of: tabItemGeoReader.frame(in: .global),
-                    perform: { tabCGRect in
-                        tabLocations[id] = tabCGRect
-                    }
-                )
-                .onChange(
-                    of: tabItemGeoReader.size.width,
-                    perform: { newWidth in
-                        tabWidth[id] = newWidth
-                    }
-                )
-        }
-    }
-
-    /// Conditionally updates the `expectedTabWidth`.
-    /// Called when the tab count changes or the temporary tab changes.
-    /// - Parameter geometryProxy: The geometry proxy to calculate the new width using.
-    private func updateForTabCountChange(geometryProxy: GeometryProxy) {
-        openedTabs = tabgroup.tabs.map(\.id)
-
-        // Only update the expected width when user is not hovering over tabs.
-        // This should give users a better experience on closing multiple tabs continuously.
-        if !isHoveringOverTabs {
-            withAnimation(.easeOut(duration: 0.15)) {
-                updateExpectedTabWidth(proxy: geometryProxy)
-            }
-        }
-    }
-
     var body: some View {
         HStack(alignment: .center, spacing: 0) {
             // Tab bar navigation control.
             leadingAccessories
             // Tab bar items.
-            GeometryReader { geometryProxy in
-                ScrollView(.horizontal, showsIndicators: false) {
-                    ScrollViewReader { scrollReader in
-                        HStack(
-                            alignment: .center,
-                            spacing: -1 // Negative spacing for overlapping the divider.
-                        ) {
-                            ForEach(Array(openedTabs.enumerated()), id: \.element) { index, id in
-                                if let item = tabgroup.tabs.first(where: { $0.id == id }) {
-                                    TabBarItemView(
-                                        expectedWidth: expectedTabWidth,
-                                        item: item,
-                                        index: index,
-                                        draggingTabId: draggingTabId,
-                                        onDragTabId: onDragTabId,
-                                        closeButtonGestureActive: $closeButtonGestureActive
-                                    )
-                                    .transition(
-                                        .asymmetric(
-                                            insertion: .offset(x: -14).combined(with: .opacity),
-                                            removal: .opacity
-                                        )
-                                    )
-                                    .frame(height: TabBarView.height)
-                                    .background(makeTabItemGeometryReader(id: id))
-                                    .offset(x: tabOffsets[id] ?? 0, y: 0)
-                                    .simultaneousGesture(
-                                        makeTabDragGesture(id: id),
-                                        including: shouldOnDrag ? .subviews : .all
-                                    )
-                                    // TODO: Detect the onDrag outside of tab bar.
-                                    // Detect the drop action of each tab.
-                                    .onDrop(
-                                        of: [.utf8PlainText], // TODO: Make a unique type for it.
-                                        delegate: TabBarItemOnDropDelegate(
-                                            currentTabId: id,
-                                            openedTabs: $openedTabs,
-                                            onDragTabId: $onDragTabId,
-                                            onDragLastLocation: $onDragLastLocation,
-                                            isOnDragOverTabs: $isOnDragOverTabs,
-                                            tabWidth: $tabWidth
-                                        )
-                                    )
-                                }
-                            }
-                        }
-                        // This padding is to hide dividers at two ends under the accessory view divider.
-                        .padding(.horizontal, prefs.preferences.general.tabBarStyle == .native ? -1 : 0)
-                        .onAppear {
-                            openedTabs = tabgroup.tabs.map(\.id)
-                            // On view appeared, compute the initial expected width for tabs.
-                            updateExpectedTabWidth(proxy: geometryProxy)
-                            // On first tab appeared, jump to the corresponding position.
-                            scrollReader.scrollTo(tabgroup.selected)
-                        }
-                        .onChange(of: tabgroup.tabs) { [tabs = tabgroup.tabs] newValue in
-                            if tabs.count == newValue.count {
-                                updateForTabCountChange(geometryProxy: geometryProxy)
-                            } else {
-                                withAnimation(
-                                    .easeOut(duration: prefs.preferences.general.tabBarStyle == .native ? 0.15 : 0.20)
-                                ) {
-                                    updateForTabCountChange(geometryProxy: geometryProxy)
-                                }
-                            }
-                            Task {
-                                try? await Task.sleep(for: .milliseconds(300))
-                                withAnimation {
-                                    scrollReader.scrollTo(tabgroup.selected?.id)
-                                }
-                            }
-                        }
-                        // When selected tab is changed, scroll to it if possible.
-                        .onChange(of: tabgroup.selected) { newValue in
-                            withAnimation {
-                                scrollReader.scrollTo(newValue?.id)
-                            }
-                        }
-
-                        // When window size changes, re-compute the expected tab width.
-                        .onChange(of: geometryProxy.size.width) { _ in
-                            updateExpectedTabWidth(proxy: geometryProxy)
-                            withAnimation {
-                                scrollReader.scrollTo(tabgroup.selected?.id)
-                            }
-                        }
-                        // When user is not hovering anymore, re-compute the expected tab width immediately.
-                        .onHover { isHovering in
-                            isHoveringOverTabs = isHovering
-                            if !isHovering {
-                                withAnimation(.easeOut(duration: 0.15)) {
-                                    updateExpectedTabWidth(proxy: geometryProxy)
-                                }
-                            }
-                        }
-                        .frame(height: TabBarView.height)
-                    }
-
-                    // To fill up the parent space of tab bar.
-                    .frame(maxWidth: .infinity)
-                    .background {
-                        if prefs.preferences.general.tabBarStyle == .native {
-                            TabBarNativeInactiveBackground()
-                        }
-                    }
-                }
-                .background {
-                    if prefs.preferences.general.tabBarStyle == .native {
-                        TabBarAccessoryNativeBackground(dividerAt: .none)
-                    }
-                }
-            }
+            TabBarTabs()
             // Tab bar tools (e.g. split view).
             trailingAccessories
         }
@@ -442,13 +70,13 @@ struct TabBarView: View {
 
     private var leadingAccessories: some View {
         HStack(spacing: 2) {
-            if tabManager.tabGroups.findSomeTabGroup(except: tabgroup) != nil {
+            if tabManager.tabGroups.findSomeTabGroup(except: tabGroup) != nil {
                 TabBarAccessoryIcon(
                     icon: .init(systemName: "multiply"),
-                    action: { [weak tabgroup] in
-                        tabgroup?.close()
-                        if tabManager.activeTabGroup == tabgroup {
-                            tabManager.activeTabGroupHistory.removeAll { $0() == nil || $0() == tabgroup }
+                    action: { [weak tabGroup] in
+                        tabGroup?.close()
+                        if tabManager.activeTabGroup == tabGroup {
+                            tabManager.activeTabGroupHistory.removeAll { $0() == nil || $0() == tabGroup }
                             tabManager.activeTabGroup = tabManager.activeTabGroupHistory.removeFirst()()!
                         }
                         tabManager.flatten()
@@ -464,12 +92,12 @@ struct TabBarView: View {
             Group {
                 Menu {
                     ForEach(
-                        Array(tabgroup.history.dropFirst(tabgroup.historyOffset+1).enumerated()),
+                        Array(tabGroup.history.dropFirst(tabGroup.historyOffset+1).enumerated()),
                         id: \.offset
                     ) { index, tab in
                         Button {
-                            tabManager.activeTabGroup = tabgroup
-                            tabgroup.historyOffset += index + 1
+                            tabManager.activeTabGroup = tabGroup
+                            tabGroup.historyOffset += index + 1
                         } label: {
                             HStack {
                                 tab.icon
@@ -481,24 +109,24 @@ struct TabBarView: View {
                     Image(systemName: "chevron.left")
                         .controlSize(.regular)
                         .opacity(
-                            tabgroup.historyOffset == tabgroup.history.count-1 || tabgroup.history.isEmpty
+                            tabGroup.historyOffset == tabGroup.history.count-1 || tabGroup.history.isEmpty
                             ? 0.5 : 1.0
                         )
                 } primaryAction: {
-                    tabManager.activeTabGroup = tabgroup
-                    tabgroup.historyOffset += 1
+                    tabManager.activeTabGroup = tabGroup
+                    tabGroup.historyOffset += 1
                 }
-                .disabled(tabgroup.historyOffset == tabgroup.history.count-1 || tabgroup.history.isEmpty)
+                .disabled(tabGroup.historyOffset == tabGroup.history.count-1 || tabGroup.history.isEmpty)
                 .help("Navigate back")
 
                 Menu {
                     ForEach(
-                        Array(tabgroup.history.prefix(tabgroup.historyOffset).reversed().enumerated()),
+                        Array(tabGroup.history.prefix(tabGroup.historyOffset).reversed().enumerated()),
                         id: \.offset
                     ) { index, tab in
                         Button {
-                            tabManager.activeTabGroup = tabgroup
-                            tabgroup.historyOffset -= index + 1
+                            tabManager.activeTabGroup = tabGroup
+                            tabGroup.historyOffset -= index + 1
                         } label: {
                             HStack {
                                 tab.icon
@@ -509,12 +137,12 @@ struct TabBarView: View {
                 } label: {
                     Image(systemName: "chevron.right")
                         .controlSize(.regular)
-                        .opacity(tabgroup.historyOffset == 0 ? 0.5 : 1.0)
+                        .opacity(tabGroup.historyOffset == 0 ? 0.5 : 1.0)
                 } primaryAction: {
-                    tabManager.activeTabGroup = tabgroup
-                    tabgroup.historyOffset -= 1
+                    tabManager.activeTabGroup = tabGroup
+                    tabGroup.historyOffset -= 1
                 }
-                .disabled(tabgroup.historyOffset == 0)
+                .disabled(tabGroup.historyOffset == 0)
                 .help("Navigate forward")
             }
             .controlSize(.small)
@@ -565,7 +193,7 @@ struct TabBarView: View {
 
     var splitviewButton: some View {
         Group {
-            switch (tabgroup.parent?.axis, modifierKeys.contains(.option)) {
+            switch (tabGroup.parent?.axis, modifierKeys.contains(.option)) {
             case (.horizontal, true), (.vertical, false):
                 TabBarAccessoryIcon(icon: Image(systemName: "square.split.1x2")) {
                     split(edge: .bottom)
@@ -587,76 +215,15 @@ struct TabBarView: View {
     }
 
     func split(edge: Edge) {
-        let newTabgroup: TabGroupData
-        if let tab = tabgroup.selected {
-            newTabgroup = .init(files: [tab])
+        let newTabGroup: TabGroupData
+        if let tab = tabGroup.selected {
+            newTabGroup = .init(files: [tab])
         } else {
-            newTabgroup = .init()
+            newTabGroup = .init()
         }
-        splitEditor(edge, newTabgroup)
-        tabManager.activeTabGroup = newTabgroup
+        splitEditor(edge, newTabGroup)
+        tabManager.activeTabGroup = newTabGroup
     }
 
-    private struct TabBarItemOnDropDelegate: DropDelegate {
-        private let currentTabId: TabID
-        @Binding
-        private var openedTabs: [TabID]
-        @Binding
-        private var onDragTabId: TabID?
-        @Binding
-        private var onDragLastLocation: CGPoint?
-        @Binding
-        private var isOnDragOverTabs: Bool
-        @Binding
-        private var tabWidth: [TabID: CGFloat]
-
-        public init(
-            currentTabId: TabID,
-            openedTabs: Binding<[TabID]>,
-            onDragTabId: Binding<TabID?>,
-            onDragLastLocation: Binding<CGPoint?>,
-            isOnDragOverTabs: Binding<Bool>,
-            tabWidth: Binding<[TabID: CGFloat]>
-        ) {
-            self.currentTabId = currentTabId
-            self._openedTabs = openedTabs
-            self._onDragTabId = onDragTabId
-            self._onDragLastLocation = onDragLastLocation
-            self._isOnDragOverTabs = isOnDragOverTabs
-            self._tabWidth = tabWidth
-        }
-
-        func dropEntered(info: DropInfo) {
-            isOnDragOverTabs = true
-            guard let onDragTabId,
-                  currentTabId != onDragTabId,
-                  let from = openedTabs.firstIndex(of: onDragTabId),
-                  let toIndex = openedTabs.firstIndex(of: currentTabId)
-            else { return }
-            if openedTabs[toIndex] != onDragTabId {
-                withAnimation {
-                    openedTabs.move(
-                        fromOffsets: IndexSet(integer: from),
-                        toOffset: toIndex > from ? toIndex + 1 : toIndex
-                    )
-                }
-            }
-        }
-
-        func dropExited(info: DropInfo) {
-            // Do nothing.
-        }
-
-        func dropUpdated(info: DropInfo) -> DropProposal? {
-            return DropProposal(operation: .move)
-        }
-
-        func performDrop(info: DropInfo) -> Bool {
-            isOnDragOverTabs = false
-            onDragTabId = nil
-            onDragLastLocation = nil
-            return true
-        }
-    }
 }
 // swiftlint:enable type_body_length

--- a/CodeEdit/Features/Tabs/Views/TabBarView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarView.swift
@@ -9,14 +9,6 @@ import SwiftUI
 
 struct TabBarView: View {
 
-    /// The style for tab bar
-    /// - **native**: Native-styled tab bar (like Finder)
-    /// - **xcode**: Xcode-liked tab bar
-    enum TabBarStyle: String, Codable {
-        case native
-        case xcode
-    }
-
     @Environment(\.modifierKeys) var modifierKeys
 
     typealias TabID = WorkspaceClient.FileItem.ID
@@ -249,41 +241,51 @@ struct TabBarView: View {
     }
 
 }
-// swiftlint:enable type_body_length
-
-//struct TabBarStyleModifier: ViewModifier {
-//    let style: TabBarView.TabBarStyle
-//
-//    func body(content: Content) -> some View {
-//        content
-//            .environment(style)
-//            .overlay {
-//                Text(style == .native
-//                     ? "Native-style tabs"
-//                     : "Xcode-style tabs")
-//            }
-//    }
-//}
-//
-//extension View {
-//    func tabBarStyle(_ style: TabBarView.TabBarStyle) -> some View {
-//        self.modifier(TabBarStyleModifier(style: style))
-//    }
-//}
 
 struct TabBarStyleEnvironmentKey: EnvironmentKey {
-    static var defaultValue: TabBarView.TabBarStyle = .xcode
+    static var defaultValue: some TabBarStyle = .xcode
 }
 
 extension EnvironmentValues {
-    var tabBarStyle: TabBarStyleEnvironmentKey.Value {
+    var tabBarStyle: some TabBarStyle {
         get { self[TabBarStyleEnvironmentKey.self] }
         set { self[TabBarStyleEnvironmentKey.self] = newValue }
     }
 }
 
 extension View {
-  func tabBarStyle(_ style: TabBarView.TabBarStyle) -> some View {
+  func tabBarStyle(_ style: some TabBarStyle) -> some View {
     self.environment(\.tabBarStyle, style)
   }
 }
+
+protocol TabBarStyle {
+    associatedtype BackgroundView: View
+
+    var foregroundColor: Color { get }
+    var background: BackgroundView { get }
+}
+
+struct XcodeTabBarStyle: TabBarStyle {
+    var foregroundColor: Color = .red
+    var background: some View {
+        Text("Xcode Tab Bar Style")
+    }
+}
+
+extension TabBarStyle where Self == XcodeTabBarStyle {
+    static var xcode: Self { XcodeTabBarStyle() }
+}
+
+struct NativeTabBarStyle: TabBarStyle {
+    var foregroundColor: Color = .blue
+    var background: some View {
+        Text("Native Tab Bar Style")
+    }
+}
+
+extension TabBarStyle where Self == NativeTabBarStyle {
+    static var native: Self { NativeTabBarStyle() }
+}
+
+// swiftlint:enable type_body_length

--- a/CodeEdit/Features/Tabs/Views/TabBarView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarView.swift
@@ -9,6 +9,14 @@ import SwiftUI
 
 struct TabBarView: View {
 
+    /// The style for tab bar
+    /// - **native**: Native-styled tab bar (like Finder)
+    /// - **xcode**: Xcode-liked tab bar
+    enum TabBarStyle: String, Codable {
+        case native
+        case xcode
+    }
+
     @Environment(\.modifierKeys) var modifierKeys
 
     typealias TabID = WorkspaceClient.FileItem.ID
@@ -33,6 +41,9 @@ struct TabBarView: View {
     @EnvironmentObject
     private var tabGroup: TabGroupData
 
+    @Environment(\.tabBarStyle)
+    private var tabBarStyle: TabBarStyle
+
     @Environment(\.splitEditor) var splitEditor
 
     /// The app preference.
@@ -50,13 +61,19 @@ struct TabBarView: View {
         }
         .frame(height: TabBarView.height)
         .overlay(alignment: .top) {
+            // TODO: Replace the code below with:
+            // tabBarStyle.showTopDivider
+
             // When tab bar style is `xcode`, we put the top divider as an overlay.
-            if prefs.preferences.general.tabBarStyle == .xcode {
+            if tabBarStyle == .xcode {
                 TabBarTopDivider()
             }
         }
         .background {
-            if prefs.preferences.general.tabBarStyle == .native {
+            // TODO: Replace the code below with:
+            // tabBarStyle.tabBarBackground
+
+            if tabBarStyle == .native {
                 TabBarNativeMaterial()
                     .edgesIgnoringSafeArea(.top)
             } else {
@@ -157,7 +174,10 @@ struct TabBarView: View {
         .opacity(activeState != .inactive ? 1.0 : 0.5)
         .frame(maxHeight: .infinity) // Fill out vertical spaces.
         .background {
-            if prefs.preferences.general.tabBarStyle == .native {
+            // TODO: Replace the code below with:
+            // tabBarStyle.tabBarBackground
+
+            if tabBarStyle == .native {
                 TabBarAccessoryNativeBackground(dividerAt: .trailing)
             }
         }
@@ -185,7 +205,10 @@ struct TabBarView: View {
         .opacity(activeState != .inactive ? 1.0 : 0.5)
         .frame(maxHeight: .infinity) // Fill out vertical spaces.
         .background {
-            if prefs.preferences.general.tabBarStyle == .native {
+            // TODO: Replace the code below with:
+            // tabBarStyle.tabBarBackground
+
+            if tabBarStyle == .native {
                 TabBarAccessoryNativeBackground(dividerAt: .leading)
             }
         }
@@ -227,3 +250,40 @@ struct TabBarView: View {
 
 }
 // swiftlint:enable type_body_length
+
+//struct TabBarStyleModifier: ViewModifier {
+//    let style: TabBarView.TabBarStyle
+//
+//    func body(content: Content) -> some View {
+//        content
+//            .environment(style)
+//            .overlay {
+//                Text(style == .native
+//                     ? "Native-style tabs"
+//                     : "Xcode-style tabs")
+//            }
+//    }
+//}
+//
+//extension View {
+//    func tabBarStyle(_ style: TabBarView.TabBarStyle) -> some View {
+//        self.modifier(TabBarStyleModifier(style: style))
+//    }
+//}
+
+struct TabBarStyleEnvironmentKey: EnvironmentKey {
+    static var defaultValue: TabBarView.TabBarStyle = .xcode
+}
+
+extension EnvironmentValues {
+    var tabBarStyle: TabBarStyleEnvironmentKey.Value {
+        get { self[TabBarStyleEnvironmentKey.self] }
+        set { self[TabBarStyleEnvironmentKey.self] = newValue }
+    }
+}
+
+extension View {
+  func tabBarStyle(_ style: TabBarView.TabBarStyle) -> some View {
+    self.environment(\.tabBarStyle, style)
+  }
+}

--- a/CodeEdit/Features/Tabs/Views/TabBarView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarView.swift
@@ -9,6 +9,14 @@ import SwiftUI
 
 struct TabBarView: View {
 
+    /// The style for tab bar
+    /// - **native**: Native-styled tab bar (like Finder)
+    /// - **xcode**: Xcode-liked tab bar
+    enum TabBarStyle: String, Codable {
+        case native
+        case xcode
+    }
+
     @Environment(\.modifierKeys) var modifierKeys
 
     typealias TabID = WorkspaceClient.FileItem.ID
@@ -243,49 +251,20 @@ struct TabBarView: View {
 }
 
 struct TabBarStyleEnvironmentKey: EnvironmentKey {
-    static var defaultValue: some TabBarStyle = .xcode
+    static var defaultValue: TabBarView.TabBarStyle = .xcode
 }
 
 extension EnvironmentValues {
-    var tabBarStyle: some TabBarStyle {
+    var tabBarStyle: TabBarStyleEnvironmentKey.Value {
         get { self[TabBarStyleEnvironmentKey.self] }
         set { self[TabBarStyleEnvironmentKey.self] = newValue }
     }
 }
 
 extension View {
-  func tabBarStyle(_ style: some TabBarStyle) -> some View {
+  func tabBarStyle(_ style: TabBarView.TabBarStyle) -> some View {
     self.environment(\.tabBarStyle, style)
   }
-}
-
-protocol TabBarStyle {
-    associatedtype BackgroundView: View
-
-    var foregroundColor: Color { get }
-    var background: BackgroundView { get }
-}
-
-struct XcodeTabBarStyle: TabBarStyle {
-    var foregroundColor: Color = .red
-    var background: some View {
-        Text("Xcode Tab Bar Style")
-    }
-}
-
-extension TabBarStyle where Self == XcodeTabBarStyle {
-    static var xcode: Self { XcodeTabBarStyle() }
-}
-
-struct NativeTabBarStyle: TabBarStyle {
-    var foregroundColor: Color = .blue
-    var background: some View {
-        Text("Native Tab Bar Style")
-    }
-}
-
-extension TabBarStyle where Self == NativeTabBarStyle {
-    static var native: Self { NativeTabBarStyle() }
 }
 
 // swiftlint:enable type_body_length


### PR DESCRIPTION
### Description

This PR attempts to refactor the tab bar to abstract styles away from logic allowing us to easily create and swap out tab styles. It also reorganizes and splits up files so that they aren't so long and easier to read/maintain.

### Related Issues

* closes #1207

### Checklist

- [x] Remove tabs from TabBarView and added them to a new file called TabBarTabs.
- [ ] Remove leading accessories from TabBarView and added them to a new file called TabBarLeadingAccessories.
- [ ] Remove trailing accessories from TabBarView and added them to a new file called TabBarTrailingAccessories.
- [ ] Separate tab bar styles from logic
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [ ] My changes generate no new warnings
- [ ] My code builds and runs on my machine
- [ ] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots

No visual changes should occur due to this PR.
