### PR TITLE
Fixed inspector toolbar background color and inspector maxWidth

### DIFF
--- a/CodeEdit/Features/InspectorSidebar/InspectorSidebarToolbarTop.swift
+++ b/CodeEdit/Features/InspectorSidebar/InspectorSidebarToolbarTop.swift
@@ -51,7 +51,7 @@ struct InspectorSidebarToolbarTop: View {
             .animation(.default, value: icons)
             Divider()
         }
-        .frame(height: TabBarView.height)
+        .frame(height: TabBarView.height + 1)
     }
 
     func makeInspectorIcon(systemImage: String, title: String, id: Int) -> some View {

--- a/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
+++ b/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
@@ -54,7 +54,7 @@ struct InspectorSidebarView: View {
         )
         .safeAreaInset(edge: .top, spacing: 0) {
             InspectorSidebarToolbarTop(selection: $selection)
-                .background(.ultraThinMaterial)
+                .background(EffectView(.windowBackground))
         }
     }
 }

--- a/CodeEdit/Features/InspectorSidebar/Views/FileInspectorView.swift
+++ b/CodeEdit/Features/InspectorSidebar/Views/FileInspectorView.swift
@@ -71,7 +71,6 @@ struct FileInspectorView: View {
             }
         }
         .controlSize(.small)
-        .frame(maxWidth: 250)
         .padding(.horizontal, 8)
         .padding(.vertical, 1)
     }


### PR DESCRIPTION
### Description

Fixed the inspector toolbar background color.

The file inspector also had a maxWidth which was unnecessary and prevented it from growing with the sidebar width so I removed it.

### Related Issues

- #924

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

#### Inspector toolbar background color

Before
<img width="396" alt="image" src="https://user-images.githubusercontent.com/806104/229173111-f581bba7-d803-4034-8835-d5f1e4e4ebfc.png">

Notice the background color is too saturated compared to the content below and the separators do not line up with the main content area.

After
<img width="395" alt="image" src="https://user-images.githubusercontent.com/806104/229173189-57ab4e4b-da5f-4d04-8276-1ed48b705448.png">

#### Inspector content max width

Before

https://user-images.githubusercontent.com/806104/229173469-4712ace0-1a94-46ca-a479-3dafba7e241d.mov

After

https://user-images.githubusercontent.com/806104/229173564-c9f57201-12ce-4a95-b6c0-af9300bcc3de.mov
