### PR TITLE
Add pixel to top of first line

### DIFF
--- a/CodeEdit/Features/SplitView/Environment+ContentInsets.swift
+++ b/CodeEdit/Features/SplitView/Environment+ContentInsets.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct EdgeInsetsEnvironmentKey: EnvironmentKey {
-    static var defaultValue: EdgeInsets = .init()
+    static var defaultValue: EdgeInsets = EdgeInsets(top: 1, leading: 0, bottom: 0, trailing: 0)
 }
 
 extension EnvironmentValues {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This PR adds a single pixel to the top of the first line so there is a space between the highlight color and the divider of the path bar.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #1227

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->
Before
<img width="220" alt="Screenshot 2023-04-12 at 12 04 41 AM" src="https://user-images.githubusercontent.com/71157264/231346697-2dfbc84b-9e5f-4361-b34a-d3e3c79c7e2c.png">

After
<img width="206" alt="Screenshot 2023-04-12 at 12 03 40 AM" src="https://user-images.githubusercontent.com/71157264/231346716-b616a330-769f-45e9-9d57-d1aedbc7b694.png">



<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
