### PR TITLE
Fix a bug with the image preview bounds

### DIFF
--- a/CodeEdit/Features/Documents/Views/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Features/Documents/Views/WorkspaceCodeFileView.swift
@@ -51,7 +51,10 @@ struct WorkspaceCodeFileView: View {
                         OtherFileView(otherFile)
                     } else {
                         OtherFileView(otherFile)
-                            .frame(width: proxy.size.width, height: proxy.size.height)
+                            .frame(
+                                width: proxy.size.width * (proxy.size.width / image.size.width),
+                                height: proxy.size.height
+                            )
                             .position(x: proxy.frame(in: .local).midX, y: proxy.frame(in: .local).midY)
                     }
                 }

--- a/CodeEdit/Features/Documents/Views/WorkspaceCodeFileView.swift
+++ b/CodeEdit/Features/Documents/Views/WorkspaceCodeFileView.swift
@@ -51,7 +51,7 @@ struct WorkspaceCodeFileView: View {
                         OtherFileView(otherFile)
                     } else {
                         OtherFileView(otherFile)
-                            .frame(width: image.size.width, height: image.size.height)
+                            .frame(width: proxy.size.width, height: proxy.size.height)
                             .position(x: proxy.frame(in: .local).midX, y: proxy.frame(in: .local).midY)
                     }
                 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

this `PR` fixes a bug where the image preview bounds were the size of the image itself.

### Related Issues

* closes #1076

### Checklist
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://user-images.githubusercontent.com/128280019/232110855-cc20f852-60f4-48da-af9d-2e74ce8f341c.mov

https://user-images.githubusercontent.com/128280019/232112141-5e980b4f-807e-4fa9-b76a-7366f7fc4643.mov