### PR TITLE
bugfix: renaming a file uses the wrong background color

### DIFF
--- a/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/OutlineTableViewCell.swift
@@ -144,11 +144,11 @@ extension OutlineTableViewCell: NSTextFieldDelegate {
     func controlTextDidChange(_ obj: Notification) {
         print("Contents changed to \(label?.stringValue ?? "idk")")
         print("File validity: \(validateFileName(for: label?.stringValue ?? ""))")
-        label.backgroundColor = validateFileName(for: label?.stringValue ?? "") ? .none : errorRed
+        label.backgroundColor = validateFileName(for: label?.stringValue ?? "") ? .textBackgroundColor : errorRed
     }
     func controlTextDidEndEditing(_ obj: Notification) {
         print("File validity: \(validateFileName(for: label?.stringValue ?? ""))")
-        label.backgroundColor = validateFileName(for: label?.stringValue ?? "") ? .none : errorRed
+        label.backgroundColor = validateFileName(for: label?.stringValue ?? "") ? .textBackgroundColor : errorRed
         if validateFileName(for: label?.stringValue ?? "") {
             let destinationURL = fileItem.url
                 .deletingLastPathComponent()


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->
change the bg color from none to [textBackgroundColor](https://developer.apple.com/documentation/appkit/nscolor/1535446-textbackgroundcolor)
### Description

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues
* #1228 

### Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested


### Screenshots

https://user-images.githubusercontent.com/53724307/233899709-38e0162b-e712-4bd2-aa98-fe1886f45e99.mov 


https://user-images.githubusercontent.com/53724307/233899733-16ed96b3-5e5d-4986-a9d6-ec8084b28995.mov







