### PR TITLE
fix: Fix issues when adding/displaying GitHub/GitLab accounts

### DIFF
--- a/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsSigninView.swift
+++ b/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsSigninView.swift
@@ -197,11 +197,11 @@ struct AccountsSettingsSigninView: View {
         } else {
             settings.accounts.sourceControlAccounts.gitAccounts.append(
                 SourceControlAccount(
-                    id: "\(server)_\(username.lowercased())",
+                    id: "\(providerLink)_\(username.lowercased())",
                     name: username,
                     description: provider.name,
                     provider: provider,
-                    serverURL: server,
+                    serverURL: providerLink,
                     urlProtocol: true,
                     sshKey: "",
                     isTokenValid: true

--- a/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsSigninView.swift
+++ b/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsSigninView.swift
@@ -159,7 +159,7 @@ struct AccountsSettingsSigninView: View {
 
         switch provider {
         case .github, .githubEnterprise:
-            let config = GitHubTokenConfiguration(personalAccessToken, url: configURL)
+            let config = GitHubTokenConfiguration(personalAccessToken, url: configURL ?? GitURL.githubBaseURL)
             GitHubAccount(config).me { response in
                 switch response {
                 case .success:
@@ -169,7 +169,7 @@ struct AccountsSettingsSigninView: View {
                 }
             }
         case .gitlab, .gitlabSelfHosted:
-            let config = GitLabTokenConfiguration(personalAccessToken, url: configURL)
+            let config = GitLabTokenConfiguration(personalAccessToken, url: configURL ?? GitURL.gitlabBaseURL)
             GitLabAccount(config).me { response in
                 switch response {
                 case .success:


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

- When the user is adding a new account from GitHub or GitLab, the `configURL` parameter for initialize `GitHubTokenConfiguration` is `nil`, which will generate error. Added a `?? GitURL.githubBaseURL` to fix this issue.
- Use `providerLink` as a part of account ID and `serverURL` instead of `server`.
	- This fixes the problem that the same accounts from GitHub/GitLab can be added multiple times.
	- This fixes the problem that the provider icon for GitHub/GitLab accounts cannot be displayed correctly.
	- This should not influence the GitHub enterprise or GitLab self-hosted accounts because in that case, `providerLink` is `server`.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] The issues this PR addresses are related to each other
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
	- I don't have GitHub enterprise / GitLab self-hosted accounts, so these are not tested.
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

<img width="827" alt="image" src="https://user-images.githubusercontent.com/72877496/234934804-4e4f1fa5-5c45-44b0-be8e-887e12d1819d.png">
