### PR TITLE
fix(AccountsSettingsDetailsView): Fix Delete Account button (#1245)

### DIFF
--- a/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsDetailsView.swift
+++ b/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsDetailsView.swift
@@ -12,7 +12,7 @@ struct AccountsSettingsDetailsView: View {
 
     @Binding var account: SourceControlAccount
 
-    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    @Environment(\.dismiss) private var dismiss
 
     @State var cloneUsing: Bool = false
     @State var deleteConfirmationIsPresented: Bool = false
@@ -64,6 +64,7 @@ struct AccountsSettingsDetailsView: View {
                             Button("OK") {
                                 // Handle the account delete
                                 handleAccountDelete()
+                                dismiss()
                             }
                             Button("Cancel") {
                                 // Handle the cancel, dismiss the alert
@@ -86,6 +87,5 @@ struct AccountsSettingsDetailsView: View {
         // Delete account by finding the position of the account and remove by position
         // We can abort if it is `nil` because account should exist
         settings.accounts.sourceControlAccounts.gitAccounts.remove(at: gitAccounts.firstIndex(of: account)!)
-        self.presentationMode.wrappedValue.dismiss()
     }
 }

--- a/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsDetailsView.swift
+++ b/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsDetailsView.swift
@@ -61,6 +61,7 @@ struct AccountsSettingsDetailsView: View {
                         ) {
                             Button("OK") {
                                 // Handle the account delete
+                                handleAccountDelete()
                             }
                             Button("Cancel") {
                                 // Handle the cancel, dismiss the alert
@@ -76,5 +77,12 @@ struct AccountsSettingsDetailsView: View {
                 }
             }
         }
+    }
+
+    private func handleAccountDelete() {
+        let gitAccounts = settings.accounts.sourceControlAccounts.gitAccounts
+        // Delete account by finding the position of the account and remove by position
+        // We can abort if it is `nil` because account should exist
+        settings.accounts.sourceControlAccounts.gitAccounts.remove(at: gitAccounts.firstIndex(of: account)!)
     }
 }

--- a/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsDetailsView.swift
+++ b/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsDetailsView.swift
@@ -55,14 +55,21 @@ struct AccountsSettingsDetailsView: View {
                         Button("Delete Account...") {
                             deleteConfirmationIsPresented.toggle()
                         }
-                        .alert(isPresented: $deleteConfirmationIsPresented) {
-                            Alert(
-                                title: Text("Are you sure you want to delete the account “\(account.description)”?"),
-                                message: Text("Deleting this account will remove it from CodeEdit."),
-                                primaryButton: .default(Text("OK")),
-                                secondaryButton: .default(Text("Cancel"))
-                            )
+                        .alert(
+                            Text("Are you sure you want to delete the account “\(account.description)”?"),
+                            isPresented: $deleteConfirmationIsPresented
+                        ) {
+                            Button("OK") {
+                                // Handle the account delete
+                            }
+                            Button("Cancel") {
+                                // Handle the cancel, dismiss the alert
+                                deleteConfirmationIsPresented.toggle()
+                            }
+                        } message: {
+                            Text("Deleting this account will remove it from CodeEdit.")
                         }
+
                         Spacer()
                     }
                     .padding(.top, 10)

--- a/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsDetailsView.swift
+++ b/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsDetailsView.swift
@@ -12,6 +12,8 @@ struct AccountsSettingsDetailsView: View {
 
     @Binding var account: SourceControlAccount
 
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+
     @State var cloneUsing: Bool = false
     @State var deleteConfirmationIsPresented: Bool = false
 
@@ -84,5 +86,6 @@ struct AccountsSettingsDetailsView: View {
         // Delete account by finding the position of the account and remove by position
         // We can abort if it is `nil` because account should exist
         settings.accounts.sourceControlAccounts.gitAccounts.remove(at: gitAccounts.firstIndex(of: account)!)
+        self.presentationMode.wrappedValue.dismiss()
     }
 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

- The `Alert` Structure is deprecated (https://developer.apple.com/documentation/swiftui/alert), replace it with a a [View](https://developer.apple.com/documentation/swiftui/view) modifier `alert(_:isPresented:actions:message:)`.
- Handle the account delete action properly.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #1245 

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] The issues this PR addresses are related to each other
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

https://user-images.githubusercontent.com/72877496/235045192-c4d9e14f-b4da-4828-8dd3-b3b8d795c8f3.mov



