### PR TITLE
Allow themes to optionally tint windows

### DIFF
--- a/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarView.swift
+++ b/CodeEdit/Features/NavigatorSidebar/NavigatorSidebarView.swift
@@ -11,8 +11,17 @@ struct NavigatorSidebarView: View {
     @ObservedObject
     private var workspace: WorkspaceDocument
 
+    @AppSettings(\.general.useSidebarVibrancyEffect) var useSidebarVibrancyEffect: Bool
+    @AppSettings(\.theme.allowThemeWindowTinting) var allowThemeWindowTinting: Bool
+
+    @State
+    private var selectedTheme = ThemeModel.shared.selectedTheme ?? ThemeModel.shared.themes.first!
+
     @State
     private var selection: Int = 0
+
+    @StateObject
+    private var themeModel: ThemeModel = .shared
 
     init(workspace: WorkspaceDocument) {
         self.workspace = workspace
@@ -46,5 +55,19 @@ struct NavigatorSidebarView: View {
             }
         }
         .environmentObject(workspace)
+        .background(
+            allowThemeWindowTinting
+            ? Color(nsColor: selectedTheme.editor.background.nsColor).opacity(0.5).ignoresSafeArea()
+            : nil
+        )
+        .background(
+            !useSidebarVibrancyEffect
+            ? EffectView(.windowBackground, blendingMode: .withinWindow).ignoresSafeArea()
+            : nil
+        )
+        .onChange(of: themeModel.selectedTheme) { newValue in
+            guard let theme = newValue else { return }
+            self.selectedTheme = theme
+        }
     }
 }

--- a/CodeEdit/Features/Settings/Pages/GeneralSettings/GeneralSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/GeneralSettings/GeneralSettingsView.swift
@@ -39,6 +39,7 @@ struct GeneralSettingsView: View {
                 tabBarStyle
                 navigatorTabBarPosition
                 inspectorTabBarPosition
+                useSidebarVibrancyEffectToggle
             }
             Section {
                 showIssues
@@ -166,6 +167,10 @@ private extension GeneralSettingsView {
                 .tag(SettingsData.SidebarTabBarPosition.side)
         }
         .pickerStyle(.radioGroup)
+    }
+
+    var useSidebarVibrancyEffectToggle: some View {
+        Toggle("Use vibrancy effect in navigator sidebar", isOn: $settings.useSidebarVibrancyEffect)
     }
 
     var reopenBehavior: some View {

--- a/CodeEdit/Features/Settings/Pages/GeneralSettings/Models/GeneralSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/GeneralSettings/Models/GeneralSettings.swift
@@ -42,6 +42,9 @@ extension SettingsData {
         /// The position for the inspector sidebar tab bar
         var inspectorTabBarPosition: SidebarTabBarPosition = .top
 
+        /// Enables or disables vibrancy effect in navigator sidebar
+        var useSidebarVibrancyEffect: Bool = true
+
         /// The reopen behavior of the app
         var reopenBehavior: ReopenBehavior = .welcome
 
@@ -110,6 +113,10 @@ extension SettingsData {
                 SidebarTabBarPosition.self,
                 forKey: .inspectorTabBarPosition
             ) ?? .top
+            self.useSidebarVibrancyEffect = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .useSidebarVibrancyEffect
+            ) ?? true
             self.reopenBehavior = try container.decodeIfPresent(
                 ReopenBehavior.self,
                 forKey: .reopenBehavior

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeSettings.swift
@@ -44,6 +44,9 @@ extension SettingsData {
         /// Use the system background that matches the appearance setting
         var useThemeBackground: Bool = true
 
+        /// Use the system background that matches the appearance setting
+        var allowThemeWindowTinting: Bool = false
+
         /// Automatically change theme based on system appearance
         var matchAppearance: Bool = true
 
@@ -88,6 +91,7 @@ extension SettingsData {
             ) ?? selectedLightTheme
             self.selectedTheme = try container.decodeIfPresent(String.self, forKey: .selectedTheme)
             self.useThemeBackground = try container.decodeIfPresent(Bool.self, forKey: .useThemeBackground) ?? true
+            self.allowThemeWindowTinting = try container.decodeIfPresent(Bool.self, forKey: .allowThemeWindowTinting) ?? false
             self.matchAppearance = try container.decodeIfPresent(
                 Bool.self, forKey: .matchAppearance
             ) ?? true

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsView.swift
@@ -63,6 +63,9 @@ struct ThemeSettingsView: View {
                     alwaysUseDarkTerminalAppearance
                 }
                 useThemeBackground
+                if settings.useThemeBackground {
+                    allowThemeWindowTintingToggle
+                }
             }
             Section {
                 VStack(spacing: 0) {
@@ -104,7 +107,11 @@ struct ThemeSettingsView: View {
 
 private extension ThemeSettingsView {
     private var useThemeBackground: some View {
-        Toggle("Use theme background ", isOn: $settings.useThemeBackground)
+        Toggle("Use theme background", isOn: $settings.useThemeBackground)
+    }
+
+    private var allowThemeWindowTintingToggle: some View {
+        Toggle("Allow theme to tint window", isOn: $settings.allowThemeWindowTinting)
     }
 
     private var alwaysUseDarkTerminalAppearance: some View {


### PR DESCRIPTION
### Description

Allow users to customize the UI by letting themes tint windows and disable the sidebar vibrancy effect if they so choose.

Adds the following settings: 
- use vibrancy effect in navigator sidebar
- allow theme to tint window. 

### Related Issues

n/a

### Checklist

- [x] Add setting "Use vibrancy effect in navigator sidebar"
- [x] Add setting "Allow theme to tint window"
- [ ] Add conditional backgrounds to navigator sidebar
- [ ] Add conditional backgrounds to toolbar
- [ ] Add conditional backgrounds to tab bar
- [ ] Add conditional backgrounds to path bar
- [ ] Add conditional backgrounds to status bar
- [ ] Add conditional backgrounds to debug area
- [ ] Add conditional backgrounds to inspector sidebar
- [ ] Modify outline view selection highlight when vibrancy is disabled or theme tinting is enabled
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Coming soon
