### PR TITLE
Add holding priority view modifier

### DIFF
--- a/CodeEdit/Features/SplitView/SplitViewItem.swift
+++ b/CodeEdit/Features/SplitView/SplitViewItem.swift
@@ -25,6 +25,7 @@ class SplitViewItem: ObservableObject {
         self.collapsed = child[SplitViewItemCollapsedViewTraitKey.self]
         self.item.canCollapse = child[SplitViewItemCanCollapseViewTraitKey.self]
         self.item.isCollapsed = self.collapsed.wrappedValue
+        self.item.holdingPriority = child[SplitViewHoldingPriorityTraitKey.self]
         self.observers = createObservers()
     }
 
@@ -44,6 +45,7 @@ class SplitViewItem: ObservableObject {
         DispatchQueue.main.async {
             self.observers = []
             self.item.animator().isCollapsed = child[SplitViewItemCollapsedViewTraitKey.self].wrappedValue
+            self.item.holdingPriority = child[SplitViewHoldingPriorityTraitKey.self]
             self.observers = self.createObservers()
         }
     }

--- a/CodeEdit/Features/SplitView/SplitViewModifiers.swift
+++ b/CodeEdit/Features/SplitView/SplitViewModifiers.swift
@@ -19,6 +19,10 @@ struct SplitViewItemCanCollapseViewTraitKey: _ViewTraitKey {
     static var defaultValue: Bool = false
 }
 
+struct SplitViewHoldingPriorityTraitKey: _ViewTraitKey {
+    static var defaultValue: NSLayoutConstraint.Priority = .defaultLow
+}
+
 extension View {
     func collapsed(_ value: Binding<Bool>) -> some View {
         self
@@ -33,5 +37,10 @@ extension View {
     func collapsable() -> some View {
         self
             ._trait(SplitViewItemCanCollapseViewTraitKey.self, true)
+    }
+
+    func holdingPriority(_ priority: NSLayoutConstraint.Priority) -> some View {
+        self
+            ._trait(SplitViewHoldingPriorityTraitKey.self, priority)
     }
 }

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -44,6 +44,7 @@ struct WorkspaceView: View {
 
                         EditorView(tabgroup: tabManager.tabGroups, focus: $focusedEditor)
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .holdingPriority(.init(10))
                             .safeAreaInset(edge: .bottom, spacing: 0) {
                                 StatusBarView(proxy: proxy, collapsed: $terminalCollapsed)
                             }
@@ -51,6 +52,7 @@ struct WorkspaceView: View {
                         StatusBarDrawer()
                             .collapsable()
                             .collapsed($terminalCollapsed)
+                            .holdingPriority(.init(20))
                             .frame(minHeight: 200, maxHeight: 400)
 
                     }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This PR adds a holdingPriority view modifier, to specify the NSSplitViewItem.holdingPriority property in SwiftUI:

```swift
func holdingPriority(_ priority: NSLayoutConstraint)) -> some View
```

It is applied in WorkspaceView, to prevent the terminal from resizing when resizing the window.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
