### PR TITLE
Quicklook Previews in Open Quickly overlay

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		6CFF967C29BEBD5200182D6F /* WindowCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFF967B29BEBD5200182D6F /* WindowCommands.swift */; };
 		850C631029D6B01D00E1444C /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850C630F29D6B01D00E1444C /* SettingsView.swift */; };
 		850C631229D6B03400E1444C /* SettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850C631129D6B03400E1444C /* SettingsPage.swift */; };
+		85CD0C5F2A10CC3200E531FD /* URL+isImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CD0C5E2A10CC3200E531FD /* URL+isImage.swift */; };
 		B6041F4D29D7A4E9000F3454 /* SettingsPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6041F4C29D7A4E9000F3454 /* SettingsPageView.swift */; };
 		B6041F5229D7D6D6000F3454 /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6041F5129D7D6D6000F3454 /* SettingsWindow.swift */; };
 		B60BE8BD297A167600841125 /* AcknowledgementRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60BE8BC297A167600841125 /* AcknowledgementRowView.swift */; };
@@ -712,6 +713,7 @@
 		6CFF967B29BEBD5200182D6F /* WindowCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCommands.swift; sourceTree = "<group>"; };
 		850C630F29D6B01D00E1444C /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		850C631129D6B03400E1444C /* SettingsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPage.swift; sourceTree = "<group>"; };
+		85CD0C5E2A10CC3200E531FD /* URL+isImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+isImage.swift"; sourceTree = "<group>"; };
 		B6041F4C29D7A4E9000F3454 /* SettingsPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageView.swift; sourceTree = "<group>"; };
 		B6041F5129D7D6D6000F3454 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		B60BE8BC297A167600841125 /* AcknowledgementRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementRowView.swift; sourceTree = "<group>"; };
@@ -1869,6 +1871,7 @@
 		58D01C87293167DC00C5B6B4 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				85CD0C5D2A10CC2500E531FD /* URL */,
 				6C82D6C429C0129E00495C54 /* NSApplication */,
 				588847672992AAB800996D95 /* Array */,
 				6CBD1BC42978DE3E006639D5 /* Text */,
@@ -2045,6 +2048,14 @@
 				6CBD1BC52978DE53006639D5 /* Font+Caption3.swift */,
 			);
 			path = Text;
+			sourceTree = "<group>";
+		};
+		85CD0C5D2A10CC2500E531FD /* URL */ = {
+			isa = PBXGroup;
+			children = (
+				85CD0C5E2A10CC3200E531FD /* URL+isImage.swift */,
+			);
+			path = URL;
 			sourceTree = "<group>";
 		};
 		B61DA9DD29D929BF00BF4A43 /* Pages */ = {
@@ -2617,6 +2628,7 @@
 				587B9E6929301D8F00AC7927 /* GitLabEvent.swift in Sources */,
 				587B9E5E29301D8F00AC7927 /* GitLabCommitRouter.swift in Sources */,
 				58F2EB0D292FB2B0004A9BDE /* ThemeSettings.swift in Sources */,
+				85CD0C5F2A10CC3200E531FD /* URL+isImage.swift in Sources */,
 				587B9D9F29300ABD00AC7927 /* SegmentedControl.swift in Sources */,
 				6C7256D729A3D7D000C2D3E0 /* SplitViewControllerView.swift in Sources */,
 				B6EA1FE529DA33DB001BF195 /* ThemeModel.swift in Sources */,

--- a/CodeEdit/Features/QuickOpen/Views/QuickOpenPreviewView.swift
+++ b/CodeEdit/Features/QuickOpen/Views/QuickOpenPreviewView.swift
@@ -28,10 +28,12 @@ struct QuickOpenPreviewView: View {
     }
 
     var body: some View {
-        if document.fileURL?.isImage() != nil {
-            OtherFileView(document)
-        } else {
-            CodeFileView(codeFile: document, isEditable: false)
+        if document.fileURL != nil {
+            if document.fileURL!.isImage() {
+                OtherFileView(document)
+            } else {
+                CodeFileView(codeFile: document, isEditable: false)
+            }
         }
     }
 }

--- a/CodeEdit/Features/QuickOpen/Views/QuickOpenPreviewView.swift
+++ b/CodeEdit/Features/QuickOpen/Views/QuickOpenPreviewView.swift
@@ -30,7 +30,28 @@ struct QuickOpenPreviewView: View {
     var body: some View {
         if document.fileURL != nil {
             if document.fileURL!.isImage() {
-                OtherFileView(document)
+                if let url = document.fileURL,
+                   let image = NSImage(contentsOf: url) {
+                    GeometryReader { proxy in
+                        if image.size.width > proxy.size.width || image.size.height > proxy.size.height {
+                            OtherFileView(document)
+                        } else {
+                            // FIXME: The following code causes a bug where the image size doesn't change when zooming.
+                            // The proper version found in WorkspaceCodeFile.swift line 59 to 60.
+                            // Cannot use that code as the image obscures the open quickly overlay.
+                            // There might be a solution for this in QuickOpenView.swift or OverlayView.swift
+
+                            OtherFileView(document)
+                                .frame(
+                                    width: image.size.width,
+                                    height: image.size.height
+                                )
+                                .position(x: proxy.frame(in: .local).midX, y: proxy.frame(in: .local).midY)
+                        }
+                    }
+                } else {
+                    OtherFileView(document)
+                }
             } else {
                 CodeFileView(codeFile: document, isEditable: false)
             }

--- a/CodeEdit/Features/QuickOpen/Views/QuickOpenPreviewView.swift
+++ b/CodeEdit/Features/QuickOpen/Views/QuickOpenPreviewView.swift
@@ -28,10 +28,9 @@ struct QuickOpenPreviewView: View {
     }
 
     var body: some View {
-        if document.fileURL != nil {
-            if document.fileURL!.isImage() {
-                if let url = document.fileURL,
-                   let image = NSImage(contentsOf: url) {
+        if let url = document.fileURL {
+            if url.isImage() {
+                if let image = NSImage(contentsOf: url) {
                     GeometryReader { proxy in
                         if image.size.width > proxy.size.width || image.size.height > proxy.size.height {
                             OtherFileView(document)

--- a/CodeEdit/Features/QuickOpen/Views/QuickOpenPreviewView.swift
+++ b/CodeEdit/Features/QuickOpen/Views/QuickOpenPreviewView.swift
@@ -28,6 +28,10 @@ struct QuickOpenPreviewView: View {
     }
 
     var body: some View {
-        CodeFileView(codeFile: document, isEditable: false)
+        if document.fileURL?.isImage() != nil {
+            OtherFileView(document)
+        } else {
+            CodeFileView(codeFile: document, isEditable: false)
+        }
     }
 }

--- a/CodeEdit/Utils/Extensions/URL/URL+isImage.swift
+++ b/CodeEdit/Utils/Extensions/URL/URL+isImage.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension URL {
     func isImage() -> Bool {
-        let ext: String = self.pathExtension
+        let ext: String = self.pathExtension.lowercased()
 
         // A list of supported file types by QLPreviewItem
         // Some of the image file types (in UTType) are not supported by QLPreviewItem

--- a/CodeEdit/Utils/Extensions/URL/URL+isImage.swift
+++ b/CodeEdit/Utils/Extensions/URL/URL+isImage.swift
@@ -9,19 +9,19 @@ import Foundation
 
 extension URL {
     func isImage() -> Bool {
-        let ext = self.pathExtension
+        let ext: String = self.pathExtension
 
         // A list of supported file types by QLPreviewItem
         // Some of the image file types (in UTType) are not supported by QLPreviewItem
         let quickLookImageFileTypes: [String] = [
-            ".png",
-            ".jpg",
-            ".jpeg",
-            ".bmp",
-            ".pdf",
-            ".heic",
-            ".webp",
-            ".tiff"
+            "png",
+            "jpg",
+            "jpeg",
+            "bmp",
+            "pdf",
+            "heic",
+            "webp",
+            "tiff"
         ]
 
         if quickLookImageFileTypes.contains(ext) {

--- a/CodeEdit/Utils/Extensions/URL/URL+isImage.swift
+++ b/CodeEdit/Utils/Extensions/URL/URL+isImage.swift
@@ -1,0 +1,33 @@
+//
+//  URL+isImage.swift
+//  CodeEdit
+//
+//  Created by Raymond Vleeshouwer on 14/05/23.
+//
+
+import Foundation
+
+extension URL {
+    func isImage() -> Bool {
+        let ext = self.pathExtension
+
+        // A list of supported file types by QLPreviewItem
+        // Some of the image file types (in UTType) are not supported by QLPreviewItem
+        let quickLookImageFileTypes: [String] = [
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".bmp",
+            ".pdf",
+            ".heic",
+            ".webp",
+            ".tiff"
+        ]
+
+        if quickLookImageFileTypes.contains(ext) {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/CodeEdit/Utils/Extensions/URL/URL+isImage.swift
+++ b/CodeEdit/Utils/Extensions/URL/URL+isImage.swift
@@ -21,7 +21,12 @@ extension URL {
             "pdf",
             "heic",
             "webp",
-            "tiff"
+            "tiff",
+            "gif",
+            "tga",
+            "avif",
+            "psd",
+            "svg"
         ]
 
         if quickLookImageFileTypes.contains(ext) {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

this PR adds support for Quicklook Previews in the Open Quickly Overlay using `OtherFileView`. In addition, this PR extends `URL` to check whether or not the file is supported by `OtherFileView`.

### Related Issues

* close #1181

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/CodeEditApp/CodeEdit/assets/128280019/47854503-f378-4dca-b60f-644ce590b78c

