### PR TITLE
Fix: #1035 finding in project bug

### DIFF
--- a/CodeEdit/Features/Documents/WorkspaceDocument+Search.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument+Search.swift
@@ -17,9 +17,6 @@ extension WorkspaceDocument {
         ]
         @Published var searchResult: [SearchResultModel] = []
         @Published var searchResultCount: Int = 0
-        /// A unique ID for the current search results. Used to "re-search" with the same
-        /// search text but refresh results and UI.
-        @Published var searchId: UUID?
 
         var ignoreCase: Bool = true
 
@@ -40,13 +37,12 @@ extension WorkspaceDocument {
             guard let text else {
                 searchResult = []
                 searchResultCount = 0
-                searchId = nil
                 return
             }
 
             let textToCompare = ignoreCase ? text.lowercased() : text
             self.searchResult = []
-            self.searchId = UUID()
+            self.searchResultCount = 0
             guard let url = self.workspace.fileURL else { return }
             let enumerator = FileManager.default.enumerator(
                 at: url,
@@ -109,7 +105,7 @@ extension WorkspaceDocument {
                                 lineMatches: matches
                             )
                         }
-                        searchResultCount += 1
+                        searchResultCount += matches.count
                     }
                 }
 

--- a/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
+++ b/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
@@ -12,7 +12,6 @@ final class FindNavigatorListViewController: NSViewController {
     public var workspace: WorkspaceDocument
     public var selectedItem: Any?
 
-    private var searchId: UUID?
     private var searchItems: [SearchResultModel] = []
     private var scrollView: NSScrollView!
     private var outlineView: NSOutlineView!
@@ -64,15 +63,10 @@ final class FindNavigatorListViewController: NSViewController {
 
     /// Updates the view with new search results and updates the UI.
     /// - Parameter searchItems: The search items to set.
-    /// - Parameter searchText: The search text, used to preserve result deletions across view updates.
-    public func updateNewSearchResults(_ searchItems: [SearchResultModel], searchId: UUID?) {
-        if searchId != self.searchId {
-            self.searchItems = searchItems
-            outlineView.reloadData()
-            outlineView.expandItem(nil, expandChildren: true)
-
-            self.searchId = searchId
-        }
+    public func updateNewSearchResults(_ searchItems: [SearchResultModel]) {
+        self.searchItems = searchItems
+        outlineView.reloadData()
+        outlineView.expandItem(nil, expandChildren: true)
 
         if let selectedItem {
             selectSearchResult(selectedItem)

--- a/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorResultList.swift
+++ b/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorResultList/FindNavigatorResultList.swift
@@ -27,8 +27,7 @@ struct FindNavigatorResultList: NSViewControllerRepresentable {
 
     func updateNSViewController(_ nsViewController: FindNavigatorListViewController, context: Context) {
         nsViewController.updateNewSearchResults(
-            workspace.searchState?.searchResult ?? [],
-            searchId: workspace.searchState?.searchId
+            workspace.searchState?.searchResult ?? []
         )
         if nsViewController.rowHeight != projectNavigatorSize.rowHeight {
             nsViewController.rowHeight = projectNavigatorSize.rowHeight
@@ -48,12 +47,9 @@ struct FindNavigatorResultList: NSViewControllerRepresentable {
             self.controller = controller
             super.init()
             self.listener = state?
-                .searchResult
-                .publisher
-                .receive(on: RunLoop.main)
-                .collect()
+                .$searchResult
                 .sink(receiveValue: { [weak self] searchResults in
-                    self?.controller?.updateNewSearchResults(searchResults, searchId: state?.searchId)
+                    self?.controller?.updateNewSearchResults(searchResults)
                 })
         }
 

--- a/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorView.swift
+++ b/CodeEdit/Features/NavigatorSidebar/FindNavigator/FindNavigatorView.swift
@@ -26,13 +26,11 @@ struct FindNavigatorView: View {
 
     @State var currentFilter: String = ""
 
-    private var foundFilesCount: Int {
-        state.searchResult.count
-    }
+    @State
+    private var foundFilesCount: Int = 0
 
-    private var foundResultsCount: Int {
-        state.searchResult.count
-    }
+    @State
+    private var searchResultCount: Int = 0
 
     var body: some View {
         VStack {
@@ -82,7 +80,7 @@ struct FindNavigatorView: View {
             .padding(.vertical, 5)
             Divider()
             HStack(alignment: .center) {
-                Text("\(state.searchResultCount) results in \(foundFilesCount) files")
+                Text("\(self.searchResultCount) results in \(self.foundFilesCount) files")
                     .font(.system(size: 10))
             }
             Divider()
@@ -90,6 +88,10 @@ struct FindNavigatorView: View {
         }
         .onSubmit {
             state.search(searchText)
+        }
+        .onReceive(state.objectWillChange) { _ in
+            self.searchResultCount = state.searchResultCount
+            self.foundFilesCount = state.searchResult.count
         }
     }
 }


### PR DESCRIPTION

<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
This PR fix #1035:
- Fix the issue of not displaying any results after a search.
- Fix the display issue with the count of search results.

By the way, In this PR, I removed the `searchId` that was previously used to refresh the UI when performing a search with the same text. I think when a search is triggered, the `searchResults` will update, causing the UI to refresh.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues
* #1235 
<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

### Checklist

<!--- Add things that are not yet implemented above -->

- [ ] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [ ] The issues this PR addresses are related to each other
- [ ] My changes generate no new warnings
- [ ] My code builds and runs on my machine
- [ ] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
<img width="1365" alt="截屏2023-05-15 00 40 26" src="https://github.com/CodeEditApp/CodeEdit/assets/22616933/57e91ce3-f241-4172-89c3-aa1cc3b73653">

https://github.com/CodeEditApp/CodeEdit/assets/22616933/6cb77b68-e496-44e5-b6a2-5491d3db6377

