### PR TITLE
Add setting for letter spacing

### DIFF
--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -18,6 +18,7 @@ struct CodeFileView: View {
 
     @AppSettings(\.textEditing.defaultTabWidth) var defaultTabWidth
     @AppSettings(\.textEditing.lineHeightMultiple) var lineHeightMultiple
+    @AppSettings(\.textEditing.letterSpacing) var letterSpacing
     @AppSettings(\.textEditing.wrapLinesToEditorWidth) var wrapLinesToEditorWidth
     @AppSettings(\.textEditing.font) var settingsFont
     @AppSettings(\.theme.useThemeBackground) var useThemeBackground
@@ -85,7 +86,8 @@ struct CodeFileView: View {
             cursorPosition: $codeFile.cursorPosition,
             useThemeBackground: useThemeBackground,
             contentInsets: edgeInsets.nsEdgeInsets,
-            isEditable: isEditable
+            isEditable: isEditable,
+            letterSpacing: letterSpacing
         )
         .id(codeFile.fileURL)
         .background {

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
@@ -31,7 +31,7 @@ extension SettingsData {
         var lineHeightMultiple: Double = 1.45
 
         /// A multiplier for setting the letter spacing, `1` being no spacing and
-        /// `2` is a character of spacing between letters, defaults to `1`.
+        /// `2` is one character of spacing between letters, defaults to `1`.
         var letterSpacing: Double = 1.0
 
         /// Default initializer

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
@@ -30,6 +30,10 @@ extension SettingsData {
         /// A multiplier for setting the line height. Defaults to `1.45`
         var lineHeightMultiple: Double = 1.45
 
+        /// A multiplier for setting the letter spacing, `1` being no spacing and
+        /// `2` is a character of spacing between letters, defaults to `1`.
+        var letterSpacing: Double = 1.0
+
         /// Default initializer
         init() {
             self.populateCommands()
@@ -56,6 +60,10 @@ extension SettingsData {
                 Double.self,
                 forKey: .lineHeightMultiple
             ) ?? 1.45
+            self.letterSpacing = try container.decodeIfPresent(
+                Double.self,
+                forKey: .letterSpacing
+            ) ?? 1
 
             self.populateCommands()
         }

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -96,7 +96,7 @@ private extension TextEditingSettingsView {
         Stepper(
             "Letter Spacing",
             value: $textEditing.letterSpacing,
-            in: 1.0...2.0,
+            in: 0.5...2.0,
             step: 0.05,
             format: .number
         )

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -21,6 +21,7 @@ struct TextEditingSettingsView: View {
                 fontSelector
                 fontSizeSelector
                 lineHeight
+                letterSpacing
             }
             Section {
                 autocompleteBraces
@@ -89,5 +90,15 @@ private extension TextEditingSettingsView {
             Text("spaces")
                 .foregroundColor(.secondary)
         }
+    }
+
+    private var letterSpacing: some View {
+        Stepper(
+            "Letter Spacing",
+            value: $textEditing.letterSpacing,
+            in: 1.0...2.0,
+            step: 0.05,
+            format: .number
+        )
     }
 }


### PR DESCRIPTION
### Description

Adds a setting in `TextEditingSettings` and `CodeFileView.swift` for letter spacing

### Related Issues

* close #1099
* https://github.com/CodeEditApp/CodeEditTextView/issues/153

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
- [x] Setting for letter spacing

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/128280019/40033ff3-7b0e-4acb-af8c-8770fcbbcedb