### PR TITLE
Add Missing Text View Settings

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -247,7 +247,6 @@
 		58F2EB0B292FB2B0004A9BDE /* AccountsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F2EADD292FB2B0004A9BDE /* AccountsSettings.swift */; };
 		58F2EB0D292FB2B0004A9BDE /* ThemeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F2EAE0292FB2B0004A9BDE /* ThemeSettings.swift */; };
 		58F2EB0E292FB2B0004A9BDE /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F2EAE1292FB2B0004A9BDE /* SoftwareUpdater.swift */; };
-		58F2EB17292FB74D004A9BDE /* CodeEditTextView in Frameworks */ = {isa = PBXBuildFile; productRef = 58F2EB16292FB74D004A9BDE /* CodeEditTextView */; };
 		58F2EB1E292FB954004A9BDE /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 58F2EB1D292FB954004A9BDE /* Sparkle */; };
 		58FD7608291EA1CB0051D6E4 /* CommandPaletteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD7605291EA1CB0051D6E4 /* CommandPaletteViewModel.swift */; };
 		58FD7609291EA1CB0051D6E4 /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD7607291EA1CB0051D6E4 /* CommandPaletteView.swift */; };
@@ -296,6 +295,7 @@
 		6CABB1A129C5593800340467 /* OverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CABB1A029C5593800340467 /* OverlayView.swift */; };
 		6CB9144B29BEC7F100BC47F2 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6CBD1BC62978DE53006639D5 /* Font+Caption3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBD1BC52978DE53006639D5 /* Font+Caption3.swift */; };
+		6CC81CEC2A16BB8F00487975 /* CodeEditTextView in Frameworks */ = {isa = PBXBuildFile; productRef = 6CC81CEB2A16BB8F00487975 /* CodeEditTextView */; };
 		6CC9E4B229B5669900C97388 /* Environment+ActiveTabGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC9E4B129B5669900C97388 /* Environment+ActiveTabGroup.swift */; };
 		6CD03B6A29FC773F001BD1D0 /* SettingsInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD03B6929FC773F001BD1D0 /* SettingsInjector.swift */; };
 		6CDA84AD284C1BA000C1CC3A /* TabBarContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */; };
@@ -792,8 +792,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				58F2EB17292FB74D004A9BDE /* CodeEditTextView in Frameworks */,
 				58F2EB1E292FB954004A9BDE /* Sparkle in Frameworks */,
+				6CC81CEC2A16BB8F00487975 /* CodeEditTextView in Frameworks */,
 				6C147C4529A329350089B630 /* OrderedCollections in Frameworks */,
 				5879828A292ED15F0085B254 /* SwiftTerm in Frameworks */,
 				6CDEFC9629E22C2700B7C684 /* Introspect in Frameworks */,
@@ -1779,7 +1779,6 @@
 			isa = PBXGroup;
 			children = (
 				588847652992A35800996D95 /* Models */,
-				588847662992A36100996D95 /* Views */,
 			);
 			path = CEWorkspace;
 			sourceTree = "<group>";
@@ -1793,13 +1792,6 @@
 				58710158298EB80000951BA4 /* CEWorkspaceFileManager.swift */,
 			);
 			path = Models;
-			sourceTree = "<group>";
-		};
-		588847662992A36100996D95 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Views;
 			sourceTree = "<group>";
 		};
 		588847672992AAB800996D95 /* Array */ = {
@@ -2367,11 +2359,11 @@
 			packageProductDependencies = (
 				2816F593280CF50500DD548B /* CodeEditSymbols */,
 				58798289292ED15F0085B254 /* SwiftTerm */,
-				58F2EB16292FB74D004A9BDE /* CodeEditTextView */,
 				58F2EB1D292FB954004A9BDE /* Sparkle */,
 				6C147C4429A329350089B630 /* OrderedCollections */,
 				6C81916A29B41DD300B75C92 /* DequeModule */,
 				6CDEFC9529E22C2700B7C684 /* Introspect */,
+				6CC81CEB2A16BB8F00487975 /* CodeEditTextView */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -2458,11 +2450,11 @@
 				2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */,
 				287136B1292A407E00E9F5F4 /* XCRemoteSwiftPackageReference "SwiftLintPlugin" */,
 				58798288292ED15F0085B254 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
-				58F2EB15292FB74D004A9BDE /* XCRemoteSwiftPackageReference "CodeEditTextView" */,
 				58F2EB1C292FB954004A9BDE /* XCRemoteSwiftPackageReference "Sparkle" */,
 				583E529A29361BAB001AB554 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 				6C147C4329A329350089B630 /* XCRemoteSwiftPackageReference "swift-collections" */,
 				6CDEFC9429E22C2700B7C684 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
+				6CC81CEA2A16BB8F00487975 /* XCRemoteSwiftPackageReference "CodeEditTextView" */,
 			);
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
 			projectDirPath = "";
@@ -3804,14 +3796,6 @@
 				version = 1.2.0;
 			};
 		};
-		58F2EB15292FB74D004A9BDE /* XCRemoteSwiftPackageReference "CodeEditTextView" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CodeEditApp/CodeEditTextView.git";
-			requirement = {
-				kind = exactVersion;
-				version = 0.6.2;
-			};
-		};
 		58F2EB1C292FB954004A9BDE /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle.git";
@@ -3826,6 +3810,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.0.0;
+			};
+		};
+		6CC81CEA2A16BB8F00487975 /* XCRemoteSwiftPackageReference "CodeEditTextView" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CodeEditApp/CodeEditTextView";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.6.2;
 			};
 		};
 		6CDEFC9429E22C2700B7C684 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {
@@ -3859,11 +3851,6 @@
 			package = 58798288292ED15F0085B254 /* XCRemoteSwiftPackageReference "SwiftTerm" */;
 			productName = SwiftTerm;
 		};
-		58F2EB16292FB74D004A9BDE /* CodeEditTextView */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 58F2EB15292FB74D004A9BDE /* XCRemoteSwiftPackageReference "CodeEditTextView" */;
-			productName = CodeEditTextView;
-		};
 		58F2EB1D292FB954004A9BDE /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 58F2EB1C292FB954004A9BDE /* XCRemoteSwiftPackageReference "Sparkle" */;
@@ -3878,6 +3865,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6C147C4329A329350089B630 /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = DequeModule;
+		};
+		6CC81CEB2A16BB8F00487975 /* CodeEditTextView */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CC81CEA2A16BB8F00487975 /* XCRemoteSwiftPackageReference "CodeEditTextView" */;
+			productName = CodeEditTextView;
 		};
 		6CDEFC9529E22C2700B7C684 /* Introspect */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -21,7 +21,7 @@
     {
       "identity" : "codeedittextview",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
+      "location" : "https://github.com/CodeEditApp/CodeEditTextView",
       "state" : {
         "revision" : "045bd359ef9c4addf2a5bf51e22ba660d69c5d10",
         "version" : "0.6.2"
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/STTextView.git",
       "state" : {
-        "revision" : "77a37aed80277467990c2c8d224ed951899446f0",
-        "version" : "0.6.0"
+        "revision" : "2d592df0a5712e4b94ed24079a75e01afc775210",
+        "version" : "0.6.4"
       }
     },
     {

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView",
       "state" : {
-        "revision" : "045bd359ef9c4addf2a5bf51e22ba660d69c5d10",
-        "version" : "0.6.2"
+        "revision" : "1dfd0b535e4d80fd8037298a30020bbfd7b5fb9c",
+        "version" : "0.6.3"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/STTextView.git",
       "state" : {
-        "revision" : "2d592df0a5712e4b94ed24079a75e01afc775210",
-        "version" : "0.6.4"
+        "revision" : "6c6243ae790247368aea258e4fb3642523759bec",
+        "version" : "0.5.3"
       }
     },
     {

--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -39,12 +39,6 @@ struct CodeFileView: View {
     init(codeFile: CodeFileDocument, isEditable: Bool = true) {
         self.codeFile = codeFile
         self.isEditable = isEditable
-        switch Settings[\.textEditing].indentOption.indentType {
-        case .tab:
-            self.indentOption = .tab
-        case .spaces:
-            self.indentOption = .spaces(count: Settings[\.textEditing].indentOption.spaceCount)
-        }
 
         codeFile
             .$content
@@ -76,27 +70,34 @@ struct CodeFileView: View {
         return Settings[\.textEditing].font.current()
     }()
 
-   @State
-   private var bracketPairHighlight: BracketPairHighlight? = {
-       let theme = ThemeModel.shared.selectedTheme ?? ThemeModel.shared.themes.first!
-       let color = Settings[\.textEditing].bracketHighlight.useCustomColor
-                   ? Settings[\.textEditing].bracketHighlight.color.nsColor
-                   : theme.editor.text.nsColor.withAlphaComponent(0.8)
-       switch Settings[\.textEditing].bracketHighlight.highlightType {
-       case .disabled:
-           return nil
-       case .flash:
-           return .flash
-       case .bordered:
-           return .bordered(color: color)
-       case .underline:
-           return .underline(color: color)
-       }
-   }()
+    @State
+    private var bracketPairHighlight: BracketPairHighlight? = {
+        let theme = ThemeModel.shared.selectedTheme ?? ThemeModel.shared.themes.first!
+        let color = Settings[\.textEditing].bracketHighlight.useCustomColor
+        ? Settings[\.textEditing].bracketHighlight.color.nsColor
+        : theme.editor.text.nsColor.withAlphaComponent(0.8)
+        switch Settings[\.textEditing].bracketHighlight.highlightType {
+        case .disabled:
+            return nil
+        case .flash:
+            return .flash
+        case .bordered:
+            return .bordered(color: color)
+        case .underline:
+            return .underline(color: color)
+        }
+    }()
 
     // Tab is a placeholder value, is overriden immediately in `init`.
     @State
-    private var indentOption: IndentOption = .tab
+    private var indentOption: IndentOption = {
+        switch Settings[\.textEditing].indentOption.indentType {
+        case .tab:
+            return .tab
+        case .spaces:
+            return .spaces(count: Settings[\.textEditing].indentOption.spaceCount)
+        }
+    }()
 
     @Environment(\.edgeInsets)
     private var edgeInsets
@@ -131,8 +132,8 @@ struct CodeFileView: View {
         }
         .colorScheme(
             selectedTheme.appearance == .dark
-                ? .dark
-                : .light
+            ? .dark
+            : .light
         )
         // minHeight zero fixes a bug where the app would freeze if the contents of the file are empty.
         .frame(minHeight: .zero, maxHeight: .infinity)
@@ -143,16 +144,16 @@ struct CodeFileView: View {
         .onChange(of: colorScheme) { newValue in
             if matchAppearance {
                 themeModel.selectedTheme = newValue == .dark
-                    ? themeModel.selectedDarkTheme
+                ? themeModel.selectedDarkTheme
                 : themeModel.selectedLightTheme
             }
         }
         .onChange(of: settingsFont) { _ in
             font = Settings.shared.preferences.textEditing.font.current()
         }
-       .onChange(of: bracketHighlight) { _ in
-           bracketPairHighlight = getBracketPairHighlight()
-       }
+        .onChange(of: bracketHighlight) { _ in
+            bracketPairHighlight = getBracketPairHighlight()
+        }
         .onChange(of: settingsIndentOption) { option in
             switch option.indentType {
             case .tab:
@@ -170,20 +171,20 @@ struct CodeFileView: View {
         return .detectLanguageFrom(url: url)
     }
 
-   private func getBracketPairHighlight() -> BracketPairHighlight? {
-       let theme = ThemeModel.shared.selectedTheme ?? ThemeModel.shared.themes.first!
-       let color = Settings[\.textEditing].bracketHighlight.useCustomColor
-                   ? Settings[\.textEditing].bracketHighlight.color.nsColor
-                   : theme.editor.text.nsColor.withAlphaComponent(0.8)
-       switch Settings[\.textEditing].bracketHighlight.highlightType {
-       case .disabled:
-           return nil
-       case .flash:
-           return .flash
-       case .bordered:
-           return .bordered(color: color)
-       case .underline:
-           return .underline(color: color)
-       }
-   }
+    private func getBracketPairHighlight() -> BracketPairHighlight? {
+        let theme = ThemeModel.shared.selectedTheme ?? ThemeModel.shared.themes.first!
+        let color = Settings[\.textEditing].bracketHighlight.useCustomColor
+        ? Settings[\.textEditing].bracketHighlight.color.nsColor
+        : theme.editor.text.nsColor.withAlphaComponent(0.8)
+        switch Settings[\.textEditing].bracketHighlight.highlightType {
+        case .disabled:
+            return nil
+        case .flash:
+            return .flash
+        case .bordered:
+            return .bordered(color: color)
+        case .underline:
+            return .underline(color: color)
+        }
+    }
 }

--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -19,13 +19,12 @@ struct CodeFileView: View {
     @AppSettings(\.textEditing.defaultTabWidth) var defaultTabWidth
     @AppSettings(\.textEditing.indentOption) var settingsIndentOption
     @AppSettings(\.textEditing.lineHeightMultiple) var lineHeightMultiple
-    @AppSettings(\.textEditing.letterSpacing) var letterSpacing
     @AppSettings(\.textEditing.wrapLinesToEditorWidth) var wrapLinesToEditorWidth
     @AppSettings(\.textEditing.font) var settingsFont
     @AppSettings(\.theme.useThemeBackground) var useThemeBackground
     @AppSettings(\.theme.matchAppearance) var matchAppearance
     @AppSettings(\.textEditing.letterSpacing) var letterSpacing
-   @AppSettings(\.textEditing.bracketHighlight) var bracketHighlight
+    @AppSettings(\.textEditing.bracketHighlight) var bracketHighlight
 
     @Environment(\.colorScheme)
     private var colorScheme

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
@@ -12,8 +12,12 @@ extension SettingsData {
 
     /// The global settings for text editing
     struct TextEditingSettings: Codable, Hashable {
-        /// An integer indicating how many spaces a `tab` will generate
+        /// An integer indicating how many spaces a `tab` will appear as visually.
         var defaultTabWidth: Int = 4
+
+        /// The behavior of a `tab` keypress. If `.tab`, will insert a tab character. If `.spaces` will insert
+        /// `.spaceCount` spaces instead.
+        var indentOption: IndentOption = IndentOption(indentType: .spaces, spaceCount: 4)
 
         /// The font to use in editor.
         var font: EditorFont = .init()
@@ -34,6 +38,9 @@ extension SettingsData {
         /// `2` is one character of spacing between letters, defaults to `1`.
         var letterSpacing: Double = 1.0
 
+        /// The behavior of bracket pair highlights.
+        var bracketHighlight: BracketPairHighlight = BracketPairHighlight()
+
         /// Default initializer
         init() {
             self.populateCommands()
@@ -43,6 +50,10 @@ extension SettingsData {
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.defaultTabWidth = try container.decodeIfPresent(Int.self, forKey: .defaultTabWidth) ?? 4
+            self.indentOption = try container.decodeIfPresent(
+                IndentOption.self,
+                forKey: .indentOption
+            ) ?? IndentOption(indentType: .spaces, spaceCount: 4)
             self.font = try container.decodeIfPresent(EditorFont.self, forKey: .font) ?? .init()
             self.enableTypeOverCompletion = try container.decodeIfPresent(
                 Bool.self,
@@ -64,6 +75,10 @@ extension SettingsData {
                 Double.self,
                 forKey: .letterSpacing
             ) ?? 1
+            self.bracketHighlight = try container.decodeIfPresent(
+                BracketPairHighlight.self,
+                forKey: .bracketHighlight
+            ) ?? BracketPairHighlight()
 
             self.populateCommands()
         }
@@ -98,6 +113,33 @@ extension SettingsData {
                     Settings[\.textEditing].wrapLinesToEditorWidth.toggle()
                 }
             )
+        }
+
+        struct IndentOption: Codable, Hashable {
+            var indentType: IndentType
+            // Kept even when `indentType` is `.tab` to retain the user's
+            // settings when changing `indentType`.
+            var spaceCount: Int = 4
+
+            enum IndentType: String, Codable {
+                case tab
+                case spaces
+            }
+        }
+
+        struct BracketPairHighlight: Codable, Hashable {
+            /// The type of highlight to use
+            var highlightType: HighlightType = .flash
+            var useCustomColor: Bool = false
+            /// The color to use for the highlight.
+            var color: Theme.Attributes = Theme.Attributes(color: "FFFFFF")
+
+            enum HighlightType: String, Codable {
+                case disabled
+                case bordered
+                case flash
+                case underline
+            }
         }
     }
 

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -94,16 +94,20 @@ private extension TextEditingSettingsView {
                     .tag(SettingsData.TextEditingSettings.IndentOption.IndentType.spaces)
             }
             if textEditing.indentOption.indentType == .spaces {
-                Stepper(
-                    "Indent Width",
-                    value: Binding<Double>(
-                        get: { Double(textEditing.indentOption.spaceCount) },
-                        set: { textEditing.indentOption.spaceCount = Int($0) }
-                    ),
-                    in: 0...10,
-                    step: 1,
-                    format: .number
-                )
+                HStack {
+                    Stepper(
+                        "Indent Width",
+                        value: Binding<Double>(
+                            get: { Double(textEditing.indentOption.spaceCount) },
+                            set: { textEditing.indentOption.spaceCount = Int($0) }
+                        ),
+                        in: 0...10,
+                        step: 1,
+                        format: .number
+                    )
+                    Text("spaces")
+                        .foregroundColor(.secondary)
+                }
                 .help("The number of spaces to insert when the tab key is pressed.")
             }
         }

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -14,6 +14,7 @@ struct TextEditingSettingsView: View {
     var body: some View {
         SettingsForm {
             Section {
+                indentOption
                 defaultTabWidth
                 wrapLinesToEditorWidth
             }
@@ -43,6 +44,7 @@ private extension TextEditingSettingsView {
             }
     }
 
+    @ViewBuilder
     private var fontSizeSelector: some View {
         Stepper(
             "Font Size",
@@ -53,6 +55,7 @@ private extension TextEditingSettingsView {
         )
     }
 
+    @ViewBuilder
     private var autocompleteBraces: some View {
         Toggle(isOn: $textEditing.autocompleteBraces) {
             Text("Autocomplete braces")
@@ -60,14 +63,17 @@ private extension TextEditingSettingsView {
         }
     }
 
+    @ViewBuilder
     private var enableTypeOverCompletion: some View {
         Toggle("Enable type-over completion", isOn: $textEditing.enableTypeOverCompletion)
     }
 
+    @ViewBuilder
     private var wrapLinesToEditorWidth: some View {
         Toggle("Wrap lines to editor width", isOn: $textEditing.wrapLinesToEditorWidth)
     }
 
+    @ViewBuilder
     private var lineHeight: some View {
         Stepper(
             "Line Height",
@@ -78,10 +84,36 @@ private extension TextEditingSettingsView {
         )
     }
 
+    @ViewBuilder
+    private var indentOption: some View {
+        Group {
+            Picker("Prefer Indent Using", selection: $textEditing.indentOption.indentType) {
+                Text("Tabs")
+                    .tag(SettingsData.TextEditingSettings.IndentOption.IndentType.tab)
+                Text("Spaces")
+                    .tag(SettingsData.TextEditingSettings.IndentOption.IndentType.spaces)
+            }
+            if textEditing.indentOption.indentType == .spaces {
+                Stepper(
+                    "Indent Width",
+                    value: Binding<Double>(
+                        get: { Double(textEditing.indentOption.spaceCount) },
+                        set: { textEditing.indentOption.spaceCount = Int($0) }
+                    ),
+                    in: 0...10,
+                    step: 1,
+                    format: .number
+                )
+                .help("The number of spaces to insert when the tab key is pressed.")
+            }
+        }
+    }
+
+    @ViewBuilder
     private var defaultTabWidth: some View {
         HStack(alignment: .top) {
             Stepper(
-                "Default Tab Width",
+                "Tab Width",
                 value: Binding<Double>(
                     get: { Double(textEditing.defaultTabWidth) },
                     set: { textEditing.defaultTabWidth = Int($0) }
@@ -93,8 +125,10 @@ private extension TextEditingSettingsView {
             Text("spaces")
                 .foregroundColor(.secondary)
         }
+        .help("The visual width of tabs.")
     }
 
+    @ViewBuilder
     private var letterSpacing: some View {
         Stepper(
             "Letter Spacing",
@@ -104,7 +138,8 @@ private extension TextEditingSettingsView {
             format: .number
         )
     }
-    
+
+    @ViewBuilder
     private var bracketPairHighlight: some View {
         Group {
             Picker(

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -27,6 +27,9 @@ struct TextEditingSettingsView: View {
                 autocompleteBraces
                 enableTypeOverCompletion
             }
+            Section {
+                bracketPairHighlight
+            }
         }
     }
 }
@@ -100,5 +103,33 @@ private extension TextEditingSettingsView {
             step: 0.05,
             format: .number
         )
+    }
+    
+    private var bracketPairHighlight: some View {
+        Group {
+            Picker(
+                "Braket Pair Highlight",
+                selection: $textEditing.bracketHighlight.highlightType
+            ) {
+                Text("Disabled").tag(SettingsData.TextEditingSettings.BracketPairHighlight.HighlightType.disabled)
+                Divider()
+                Text("Bordered").tag(SettingsData.TextEditingSettings.BracketPairHighlight.HighlightType.bordered)
+                Text("Flash").tag(SettingsData.TextEditingSettings.BracketPairHighlight.HighlightType.flash)
+                Text("Underline").tag(SettingsData.TextEditingSettings.BracketPairHighlight.HighlightType.underline)
+            }
+            if [.bordered, .underline].contains(textEditing.bracketHighlight.highlightType) {
+                Toggle("Use Custom Color", isOn: $textEditing.bracketHighlight.useCustomColor)
+                SettingsColorPicker(
+                    "Braket Pair Highlight Color",
+                    color: $textEditing.bracketHighlight.color.swiftColor
+                )
+                .foregroundColor(
+                    textEditing.bracketHighlight.useCustomColor
+                        ? Color(NSColor.labelColor)
+                        : Color(NSColor.secondaryLabelColor)
+                )
+                .disabled(!textEditing.bracketHighlight.useCustomColor)
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This implements a few settings for parameters available in CodeEditTextView that haven't been made available yet in CodeEdit:
- Indent Options, whether to space or tab on a tab key press
- Bracket Highlights, when the user's cursor is next to a bracket highlight the opposite pair or both brackets.

### Related Issues

* N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Bracket Pair Highlighting:

https://github.com/CodeEditApp/CodeEdit/assets/35942988/d2b53b53-24b1-49c2-9029-83a2ea1166d3

Indent Options:

https://github.com/CodeEditApp/CodeEdit/assets/35942988/19afd52a-6019-4035-aba2-243d15241ebe
