### PR TITLE
Fix Settings color picker

### DIFF
--- a/CodeEdit/Features/Settings/Views/SettingsColorPicker.swift
+++ b/CodeEdit/Features/Settings/Views/SettingsColorPicker.swift
@@ -8,19 +8,29 @@
 import SwiftUI
 
 struct SettingsColorPicker: View {
+
+    /// Color modified elsewhere in user theme
     @Binding var color: Color
+
+    /// Component private color to display
+    /// UI changes
+    @State private var selectedColor: Color
 
     private let label: String
 
     init(_ label: String, color: Binding<Color>) {
         self._color = color
         self.label = label
+        self._selectedColor = State(initialValue: color.wrappedValue)
     }
 
     var body: some View {
         LabeledContent(label) {
-            ColorPicker(selection: $color, supportsOpacity: false) { }
+            ColorPicker(selection: $selectedColor, supportsOpacity: false) { }
                 .labelsHidden()
+        }
+        .onChange(of: selectedColor) { newValue in
+            color = newValue
         }
     }
 }

--- a/CodeEdit/Utils/Extensions/Color/Color+HEX.swift
+++ b/CodeEdit/Utils/Extensions/Color/Color+HEX.swift
@@ -31,6 +31,7 @@ extension Color {
         self.init(.sRGB, red: Double(red) / 255, green: Double(green) / 255, blue: Double(blue) / 255, opacity: alpha)
     }
 
+    /// Returns an Int representing the `Color` in hex format (e.g.: 0x112233)
     var hex: Int {
         guard let components = cgColor?.components, components.count >= 3 else { return 0 }
 

--- a/CodeEdit/Utils/Extensions/Color/Color+HEX.swift
+++ b/CodeEdit/Utils/Extensions/Color/Color+HEX.swift
@@ -31,18 +31,21 @@ extension Color {
         self.init(.sRGB, red: Double(red) / 255, green: Double(green) / 255, blue: Double(blue) / 255, opacity: alpha)
     }
 
+    var hex: Int {
+        guard let components = cgColor?.components, components.count >= 3 else { return 0 }
+
+        let red = lround((Double(components[0]) * 255.0)) << 16
+        let green = lround((Double(components[1]) * 255.0)) << 8
+        let blue = lround((Double(components[2]) * 255.0))
+
+        return red | green | blue
+    }
+
     /// Returns a HEX String representing the `Color` (e.g.: #112233)
     var hexString: String {
-        if let color = self.cgColor {
-            let components = color.components ?? []
-            let red = UInt8(components[0] * 255)
-            let green = UInt8(components[1] * 255)
-            let blue = UInt8(components[2] * 255)
+        let color = self.hex
 
-            return String(format: "#%02X%02X%02X", red, green, blue)
-        }
-
-        return "#000000" /// Return black color hex string as default
+        return "#" + String(format: "%06x", color)
     }
 
     /// The alpha (opacity) component of the Color (0.0 - 1.0)

--- a/CodeEdit/Utils/Extensions/Color/Color+HEX.swift
+++ b/CodeEdit/Utils/Extensions/Color/Color+HEX.swift
@@ -31,22 +31,18 @@ extension Color {
         self.init(.sRGB, red: Double(red) / 255, green: Double(green) / 255, blue: Double(blue) / 255, opacity: alpha)
     }
 
-    /// Returns an Int representing the `Color` in hex format (e.g.: 0x112233)
-    var hex: Int {
-        guard let components = cgColor?.components, components.count >= 3 else { return 0 }
-
-        let red = lround((Double(components[0]) * 255.0)) << 16
-        let green = lround((Double(components[1]) * 255.0)) << 8
-        let blue = lround((Double(components[2]) * 255.0))
-
-        return red | green | blue
-    }
-
     /// Returns a HEX String representing the `Color` (e.g.: #112233)
     var hexString: String {
-        let color = self.hex
+        if let color = self.cgColor {
+            let components = color.components ?? []
+            let red = UInt8(components[0] * 255)
+            let green = UInt8(components[1] * 255)
+            let blue = UInt8(components[2] * 255)
 
-        return "#" + String(format: "%06x", color)
+            return String(format: "#%02X%02X%02X", red, green, blue)
+        }
+
+        return "#000000" /// Return black color hex string as default
     }
 
     /// The alpha (opacity) component of the Color (0.0 - 1.0)


### PR DESCRIPTION
Add local state and onChange to SettingsColorPicker, to handle theme changes separately. Simplify Color extension on hexString


### Description

I changed the SettingsColorPicker.swift and Color+HEX.swift. The SettingsColorPicker now has local state handling the color of the picker, and any change to this triggers a theme update via the passed binding. Prior implementation caused undefined behavior and sporadic color picker changes.

Changes to Color+HEX extension were only simplifications of existing code.

### Related Issues

* closes #1262 

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] The issues this PR addresses are related to each other
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots

<img width="459" alt="Settings color picker" src="https://github.com/CodeEditApp/CodeEdit/assets/96535657/9436240f-9f37-446b-ab49-1692bc581f8a">

https://github.com/CodeEditApp/CodeEdit/assets/96535657/46f463ab-957d-47f5-bb6f-143124db041f


