### PR TITLE
refactor: Remove unused if case in ViewCommands

### DIFF
--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -31,19 +31,11 @@ struct ViewCommands: Commands {
             .keyboardShortcut("p", modifiers: [.shift, .command])
 
             Button("Increase font size") {
-                if CodeEditDocumentController.shared.documents.count > 1 {
-                    font.size += 1
-                }
                 font.size += 1
             }
             .keyboardShortcut("+")
 
             Button("Decrease font size") {
-                if CodeEditDocumentController.shared.documents.count > 1 {
-                    if !(font.size <= 1) {
-                        font.size -= 1
-                    }
-                }
                 if !(font.size <= 1) {
                     font.size -= 1
                 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

There's a `if CodeEditDocumentController.shared.documents.count > 1` when executing command for changing font size, as discussed in the Discord channel, we are not sure what it does and it could be removed, so I removed in this PR.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] The issues this PR addresses are related to each other
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

N/A

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
