### PR TITLE
Improve textfield behavior in Project Navigator

### DIFF
--- a/CodeEdit/Features/NavigatorSidebar/OutlineView/StandardTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorSidebar/OutlineView/StandardTableViewCell.swift
@@ -187,12 +187,18 @@ class StandardTableViewCell: NSTableCellView {
     }
 
     class SpecialSelectTextField: NSTextField {
-//        override func becomeFirstResponder() -> Bool {
-            // TODO: Set text range
-            // this is the code to get the text range, however I cannot find a way to select it :(
-//            NSRange(location: 0, length: stringValue.distance(from: stringValue.startIndex,
-//                to: stringValue.lastIndex(of: ".") ?? stringValue.endIndex))
-//            return true
-//        }
+        override func becomeFirstResponder() -> Bool {
+            let range = NSRange(
+                location: 0,
+                length: stringValue.distance(
+                    from: stringValue.startIndex,
+                    to: stringValue.lastIndex(of: ".") ?? stringValue.endIndex
+                )
+            )
+            selectText(nil)
+            let editor = currentEditor()
+            editor?.selectedRange = range
+            return true
+        }
     }
 }

--- a/CodeEdit/Features/NavigatorSidebar/OutlineView/StandardTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorSidebar/OutlineView/StandardTableViewCell.swift
@@ -195,10 +195,22 @@ class StandardTableViewCell: NSTableCellView {
                     to: stringValue.lastIndex(of: ".") ?? stringValue.endIndex
                 )
             )
-            selectText(nil)
+            selectText(self)
             let editor = currentEditor()
             editor?.selectedRange = range
             return true
+        }
+
+        override func textDidBeginEditing(_ notification: Notification) {
+            super.textDidBeginEditing(notification)
+            wantsLayer = true
+            layer?.backgroundColor = NSColor.textBackgroundColor.cgColor
+        }
+
+        override func textDidEndEditing(_ notification: Notification) {
+            super.textDidEndEditing(notification)
+            wantsLayer = false
+            layer?.backgroundColor = nil
         }
     }
 }


### PR DESCRIPTION
### Description

This PR includes the enhancement of textfield behavior in Project Navigator as follows.
1. Select filename excluding file extension when focusing textfield
2. Fix background layer of textfield turning into blue

### Related Issues

https://github.com/CodeEditApp/CodeEdit/issues/1290


### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/67727096/e1757ff5-0b1c-4cd8-b941-94fb97bba53b



