### PR TITLE
Sync file selection state between tab group and outline view

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -361,3 +361,17 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, TabBar
     }
 
 }
+
+extension Array where Element == CEWorkspaceFile {
+    func find(by tabID: TabBarItemID) -> CEWorkspaceFile? {
+        guard let item = first(where: { $0.tabID == tabID }) else {
+            for element in self {
+                if let item = element.children?.find(by: tabID) {
+                    return item
+                }
+            }
+            return nil
+        }
+        return item
+    }
+}

--- a/CodeEdit/Features/NavigatorSidebar/OutlineView/StandardTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorSidebar/OutlineView/StandardTableViewCell.swift
@@ -187,12 +187,18 @@ class StandardTableViewCell: NSTableCellView {
     }
 
     class SpecialSelectTextField: NSTextField {
-//        override func becomeFirstResponder() -> Bool {
-            // TODO: Set text range
-            // this is the code to get the text range, however I cannot find a way to select it :(
-//            NSRange(location: 0, length: stringValue.distance(from: stringValue.startIndex,
-//                to: stringValue.lastIndex(of: ".") ?? stringValue.endIndex))
-//            return true
-//        }
+        override func becomeFirstResponder() -> Bool {
+            let range = NSRange(
+                location: 0,
+                length: stringValue.distance(
+                    from: stringValue.startIndex,
+                    to: stringValue.lastIndex(of: ".") ?? stringValue.endIndex
+                )
+            )
+            selectText(nil)
+            let editor = currentEditor()
+            editor?.selectedRange = range
+            return true
+        }
     }
 }

--- a/CodeEdit/Features/NavigatorSidebar/OutlineView/StandardTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorSidebar/OutlineView/StandardTableViewCell.swift
@@ -195,10 +195,22 @@ class StandardTableViewCell: NSTableCellView {
                     to: stringValue.lastIndex(of: ".") ?? stringValue.endIndex
                 )
             )
-            selectText(nil)
+            selectText(self)
             let editor = currentEditor()
             editor?.selectedRange = range
             return true
+        }
+
+        override func textDidBeginEditing(_ notification: Notification) {
+            super.textDidBeginEditing(notification)
+            wantsLayer = true
+            layer?.backgroundColor = NSColor.textBackgroundColor.cgColor
+        }
+
+        override func textDidEndEditing(_ notification: Notification) {
+            super.textDidEndEditing(notification)
+            wantsLayer = false
+            layer?.backgroundColor = nil
         }
     }
 }

--- a/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
+++ b/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
@@ -17,10 +17,6 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
     @StateObject
     var prefs: Settings = .shared
 
-    // This is mainly just used to trigger a view update.
-    @Binding
-    var selection: CEWorkspaceFile?
-
     typealias NSViewControllerType = ProjectNavigatorViewController
 
     func makeNSViewController(context: Context) -> ProjectNavigatorViewController {
@@ -42,7 +38,8 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
         nsViewController.fileExtensionsVisibility = prefs.preferences.general.fileExtensionsVisibility
         nsViewController.shownFileExtensions = prefs.preferences.general.shownFileExtensions
         nsViewController.hiddenFileExtensions = prefs.preferences.general.hiddenFileExtensions
-        nsViewController.updateSelection()
+        /// if the window becomes active from background, it will restores the selection to outline view.
+        nsViewController.updateSelection(itemID: workspace.tabManager.activeTabGroup.selected?.id)
         return
     }
 
@@ -55,21 +52,28 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
             self.workspace = workspace
             super.init()
 
-            listener = workspace.listenerModel.$highlightedFileItem
+            workspace.listenerModel.$highlightedFileItem
                 .sink(receiveValue: { [weak self] fileItem in
-                guard let fileItem else {
-                    return
+                    guard let fileItem else {
+                        return
+                    }
+                    self?.controller?.reveal(fileItem)
+                })
+                .store(in: &cancellables)
+            workspace.tabManager.tabBarItemIdSubject
+                .sink { [weak self] itemID in
+                    self?.controller?.updateSelection(itemID: itemID)
                 }
-                self?.controller?.reveal(fileItem)
-            })
+                .store(in: &cancellables)
         }
 
-        var listener: AnyCancellable?
+        var cancellables: Set<AnyCancellable> = []
         var workspace: WorkspaceDocument
         var controller: ProjectNavigatorViewController?
 
         deinit {
-            listener?.cancel()
+            cancellables.forEach { $0.cancel() }
+            cancellables.removeAll()
         }
     }
 }

--- a/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
+++ b/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
@@ -89,8 +89,9 @@ final class ProjectNavigatorViewController: NSViewController {
     /// Updates the selection of the ``outlineView`` whenever it changes.
     ///
     /// Most importantly when the `id` changes from an external view.
-    func updateSelection() {
-        guard let itemID = workspace?.tabManager.activeTabGroup.selected?.id else {
+    /// - Parameter itemID: The id of the file or folder.
+    func updateSelection(itemID: String?) {
+        guard let itemID else {
             outlineView.deselectRow(outlineView.selectedRow)
             return
         }
@@ -310,11 +311,7 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
                reveal(fileItem)
            }
         }
-
-        guard let item = collection.first(where: { $0.tabID == id }) else {
-            for item in collection {
-                select(by: id, from: item.children ?? [])
-            }
+        guard let item = collection.find(by: id) else {
             return
         }
         let row = outlineView.row(forItem: item)

--- a/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/ProjectNavigatorView.swift
+++ b/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/ProjectNavigatorView.swift
@@ -15,14 +15,10 @@ import SwiftUI
 /// When selecting a file it will open in the editor.
 ///
 struct ProjectNavigatorView: View {
-
-    @EnvironmentObject var tabManager: TabManager
-
     var body: some View {
-        ProjectNavigatorOutlineView(selection: $tabManager.activeTabGroup.selected)
+        ProjectNavigatorOutlineView()
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 ProjectNavigatorToolbarBottom()
             }
     }
-
 }

--- a/CodeEdit/Features/Tabs/Models/TabManager.swift
+++ b/CodeEdit/Features/Tabs/Models/TabManager.swift
@@ -5,9 +5,10 @@
 //  Created by Wouter Hennen on 03/03/2023.
 //
 
+import Combine
 import Foundation
-import OrderedCollections
 import DequeModule
+import OrderedCollections
 
 class TabManager: ObservableObject {
     /// Collection of all the tabgroups.
@@ -19,6 +20,7 @@ class TabManager: ObservableObject {
     var activeTabGroup: TabGroupData {
         didSet {
             activeTabGroupHistory.prepend { [weak oldValue] in oldValue }
+            switchToActiveTabGroup()
         }
     }
 
@@ -27,11 +29,16 @@ class TabManager: ObservableObject {
 
     var fileDocuments: [CEWorkspaceFile: CodeFileDocument] = [:]
 
+    /// notify listeners whenever tab selection changes on the active tab group.
+    var tabBarItemIdSubject = PassthroughSubject<String?, Never>()
+    var cancellable: AnyCancellable?
+
     init() {
         let tab = TabGroupData()
         self.activeTabGroup = tab
         self.activeTabGroupHistory.prepend { [weak tab] in tab }
         self.tabGroups = .horizontal(.init(.horizontal, tabgroups: [.one(tab)]))
+        switchToActiveTabGroup()
     }
 
     /// Flattens the splitviews.
@@ -48,5 +55,15 @@ class TabManager: ObservableObject {
     func openTab(item: CEWorkspaceFile, in tabgroup: TabGroupData? = nil) {
         let tabgroup = tabgroup ?? activeTabGroup
         tabgroup.openTab(item: item)
+    }
+
+    /// bind active tap group to listen to file selection changes.
+    func switchToActiveTabGroup() {
+        cancellable?.cancel()
+        cancellable = nil
+        cancellable = activeTabGroup.$selected
+            .sink { [weak self] tab in
+                self?.tabBarItemIdSubject.send(tab?.id)
+            }
     }
 }

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -59,7 +59,8 @@ struct WorkspaceView: View {
                     .environmentObject(workspace.statusBarModel)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .onChange(of: focusedEditor) { newValue in
-                        if let newValue {
+                        /// update active tab group only if the new one is not the same with it.
+                        if let newValue, tabManager.activeTabGroup != newValue {
                             tabManager.activeTabGroup = newValue
                         }
                     }


### PR DESCRIPTION
### Description
This PR includes a bug fix for aligning file selection state on the Project Navigator (outline view) with the current active tab in  editor's tab group.

### Related Issues
https://github.com/CodeEditApp/CodeEdit/issues/1294

### Checklist
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots
https://github.com/CodeEditApp/CodeEdit/assets/67727096/b290ab84-e7d7-4e4b-8ea1-071055edc2d4


