### PR TITLE
added upgrade alert

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -18,6 +18,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
         NSApp.closeWindow(.welcome, .about)
 
+        let upgradeAlert = NSAlert()
+        upgradeAlert.messageText = "Upgrade Available"
+        upgradeAlert.informativeText = "A new CodeEdit update is available, but can't be auto-updated. Please download the latest version to keep receiving the latest updates."
+        upgradeAlert.addButton(withTitle: "Download New Version")
+        switch upgradeAlert.runModal() {
+        case .alertFirstButtonReturn:
+            NSWorkspace.shared.open(URL(string: "https://github.com/CodeEditApp/CodeEdit/releases/latest")!)
+        default:
+            break
+        }
+
         DispatchQueue.main.async {
             var needToHandleOpen = true
 

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -20,7 +20,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
         let upgradeAlert = NSAlert()
         upgradeAlert.messageText = "Upgrade Available"
-        upgradeAlert.informativeText = "A new CodeEdit update is available, but can't be auto-updated. Please download the latest version to keep receiving the latest updates."
+        upgradeAlert.informativeText = """
+A new CodeEdit update is available, but can't be auto-updated.\
+ Please download the latest version to keep receiving the latest updates.
+"""
         upgradeAlert.addButton(withTitle: "Download New Version")
         switch upgradeAlert.runModal() {
         case .alertFirstButtonReturn:


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Adds an upgrade alert on launch. This is used for the latest version before changing the bundle identifier, as auto-updating the app won't work

### Screenshots
![Screenshot 2023-06-04 at 20 14 28](https://github.com/CodeEditApp/CodeEdit/assets/62355975/e86c1e86-43c3-4856-b686-7c5b271c1444)
