### PR TITLE
Using grouped form design in the file inspector

### DIFF
--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -39,7 +39,7 @@
     {
       "identity" : "codeedittextview",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
+      "location" : "https://github.com/CodeEditApp/CodeEditTextView",
       "state" : {
         "revision" : "8150e91dd81c698fde068e7cdf06a6f43d7ddd17",
         "version" : "0.6.4"
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/ConcurrencyPlus",
       "state" : {
-        "revision" : "b5ba8d5ea6bfe9e43ccc44aa63f9b458057fa0f4",
-        "version" : "0.4.1"
+        "revision" : "8dc56499412a373d617d50d059116bccf44b9874",
+        "version" : "0.4.2"
       }
     },
     {
@@ -221,8 +221,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
-        "revision" : "5b3f3996c7a2a84d5f4ba0e03cd7d584154778f2",
-        "version" : "0.3.1"
+        "revision" : "84196bab1c7f05ad8c3c2a5bfb3058b1211e189f",
+        "version" : "0.6.1"
       }
     },
     {

--- a/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
+++ b/CodeEdit/Features/InspectorSidebar/InspectorSidebarView.swift
@@ -69,7 +69,7 @@ struct InspectorSidebarView: View {
         .clipShape(Rectangle())
         .frame(
             minWidth: CodeEditWindowController.minSidebarWidth,
-            idealWidth: 260,
+            idealWidth: 300,
             minHeight: 0,
             maxHeight: .infinity,
             alignment: .top
@@ -93,5 +93,6 @@ struct InspectorSidebarView: View {
                 Divider()
             }
         }
+        .formStyle(.grouped)
     }
 }

--- a/CodeEdit/Features/InspectorSidebar/Models/FileInspectorModel.swift
+++ b/CodeEdit/Features/InspectorSidebar/Models/FileInspectorModel.swift
@@ -85,10 +85,10 @@ public final class FileInspectorModel: ObservableObject {
                            IndentUsing(name: "Tabs", id: "tabs")]
 
     @Published
-    var tabWidth: Double = 4
+    var tabWidth: Int = 4
 
     @Published
-    var indentWidth: Double = 4
+    var indentWidth: Int = 4
 
     @Published
     var wrapLines: Bool = true

--- a/CodeEdit/Features/InspectorSidebar/Models/FileInspectorModel.swift
+++ b/CodeEdit/Features/InspectorSidebar/Models/FileInspectorModel.swift
@@ -85,10 +85,10 @@ public final class FileInspectorModel: ObservableObject {
                            IndentUsing(name: "Tabs", id: "tabs")]
 
     @Published
-    var tabWidth: Int = 4
+    var tabWidth: Double = 4
 
     @Published
-    var indentWidth: Int = 4
+    var indentWidth: Double = 4
 
     @Published
     var wrapLines: Bool = true

--- a/CodeEdit/Features/InspectorSidebar/Views/FileInspectorView.swift
+++ b/CodeEdit/Features/InspectorSidebar/Views/FileInspectorView.swift
@@ -174,7 +174,10 @@ struct FileInspectorView: View {
                 VStack(alignment: .center, spacing: 0) {
                     Stepper(
                         "",
-                        value: $inspectorModel.tabWidth,
+                        value: Binding<Double>(
+                            get: { Double(inspectorModel.tabWidth) },
+                            set: { inspectorModel.tabWidth = Int($0) }
+                        ),
                         in: 1...8,
                         step: 1,
                         format: .number
@@ -187,7 +190,10 @@ struct FileInspectorView: View {
                 VStack(alignment: .center, spacing: 0) {
                     Stepper(
                         "",
-                        value: $inspectorModel.indentWidth,
+                        value: Binding<Double>(
+                            get: { Double(inspectorModel.indentWidth) },
+                            set: { inspectorModel.indentWidth = Int($0) }
+                        ),
                         in: 1...8,
                         step: 1,
                         format: .number

--- a/CodeEdit/Features/InspectorSidebar/Views/FileInspectorView.swift
+++ b/CodeEdit/Features/InspectorSidebar/Views/FileInspectorView.swift
@@ -36,7 +36,6 @@ struct FileInspectorView: View {
                 wrapLines
             }
         }
-        .formStyle(.grouped)
     }
 
     private var fileName: some View {

--- a/CodeEdit/Features/InspectorSidebar/Views/FileInspectorView.swift
+++ b/CodeEdit/Features/InspectorSidebar/Views/FileInspectorView.swift
@@ -18,94 +18,57 @@ struct FileInspectorView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
-            InspectorSection("Identity and Type") {
-                InspectorField("Name") {
-                    TextField("", text: $inspectorModel.fileName)
-                }
-                InspectorField("Type") {
-                    fileType
-                }
-                Divider()
-                InspectorField("Location") {
-                    location
-                    HStack {
-                        Text(inspectorModel.fileName)
-                            .font(.system(size: 11))
-                        Spacer()
-                        Image(systemName: "folder.fill")
-                            .resizable()
-                            .foregroundColor(.secondary)
-                            .frame(width: 12, height: 10)
-                    }
-                }
-                InspectorField("Full Path") {
-                    HStack(alignment: .bottom) {
-                        Text(inspectorModel.fileURL)
-                            .foregroundColor(.primary)
-                            .fontWeight(.regular)
-                            .font(.system(size: 11))
-                            .lineLimit(4)
-                        Image(systemName: "arrow.forward.circle.fill")
-                            .resizable()
-                            .foregroundColor(.secondary)
-                            .frame(width: 10, height: 10)
-                    }
-                    .padding(.top, 2)
-                }
+        Form {
+            Section("Identity and Type") {
+                fileName
+                fileType
             }
-            InspectorSection("Text Settings") {
-                InspectorField("Text Encoding") {
-                    textEncoding
-                }
-                InspectorField("Line Endings") {
-                    lineEndings
-                }
-                Divider()
-                InspectorField("Indent Using") {
-                    indentUsing
-                }
-                InspectorField("Widths") {
-                    tabWidths
-                }
+            Section {
+                location
+            }
+            Section("Text Settings") {
+                textEncoding
+                lineEndings
+            }
+            Section {
+                indentUsing
+                tabWidths
+                wrapLines
             }
         }
-        .controlSize(.small)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 1)
+        .formStyle(.grouped)
+    }
+
+    private var fileName: some View {
+        TextField("Name", text: $inspectorModel.fileName)
     }
 
     private var fileType: some View {
-        Picker("", selection: $inspectorModel.fileTypeSelection) {
+        Picker("Type", selection: $inspectorModel.fileTypeSelection) {
             Group {
                 Section(header: Text("Sourcecode Objective-C")) {
                     ForEach(inspectorModel.languageTypeObjCList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Sourcecode C")) {
                     ForEach(inspectorModel.sourcecodeCList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Sourcecode C++")) {
                     ForEach(inspectorModel.sourcecodeCPlusList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Sourcecode Swift")) {
                     ForEach(inspectorModel.sourcecodeSwiftList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Sourcecode Assembly")) {
                     ForEach(inspectorModel.sourcecodeAssemblyList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
             }
@@ -113,31 +76,26 @@ struct FileInspectorView: View {
                 Section(header: Text("Sourcecode Objective-C")) {
                     ForEach(inspectorModel.sourcecodeScriptList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Property List / XML")) {
                     ForEach(inspectorModel.propertyList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Shell Script")) {
                     ForEach(inspectorModel.shellList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Mach-O")) {
                     ForEach(inspectorModel.machOList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Text")) {
                     ForEach(inspectorModel.textList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
             }
@@ -145,118 +103,107 @@ struct FileInspectorView: View {
                 Section(header: Text("Audio")) {
                     ForEach(inspectorModel.audioList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Image")) {
                     ForEach(inspectorModel.imageList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Video")) {
                     ForEach(inspectorModel.videoList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Archive")) {
                     ForEach(inspectorModel.archiveList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Other")) {
                     ForEach(inspectorModel.otherList) {
                         Text($0.name)
-                            .font(.system(size: 11))
                     }
                 }
             }
         }
-        .labelsHidden()
     }
 
     private var location: some View {
-        Picker("", selection: $inspectorModel.locationSelection) {
-            ForEach(inspectorModel.locationList) {
-                Text($0.name)
-                    .font(.system(size: 11))
+        Group {
+            LabeledContent("Location") {
+                Button("Choose...") {
+                    // open open dialog
+                }
+            }
+            ExternalLink(showInFinder: true, destination: URL(fileURLWithPath: inspectorModel.fileURL)) {
+                Text(inspectorModel.fileURL)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
             }
         }
-        .labelsHidden()
     }
 
     private var textEncoding: some View {
-        Picker("", selection: $inspectorModel.textEncodingSelection) {
+        Picker("Text Encoding", selection: $inspectorModel.textEncodingSelection) {
             ForEach(inspectorModel.textEncodingList) {
                 Text($0.name)
-                    .font(.system(size: 11))
             }
         }
-        .labelsHidden()
     }
 
     private var lineEndings: some View {
-        Picker("", selection: $inspectorModel.lineEndingsSelection) {
+        Picker("Line Endings", selection: $inspectorModel.lineEndingsSelection) {
             ForEach(inspectorModel.lineEndingsList) {
                 Text($0.name)
-                    .font(.system(size: 11))
             }
         }
-        .labelsHidden()
     }
 
     private var indentUsing: some View {
-        Picker("", selection: $inspectorModel.indentUsingSelection) {
+        Picker("Indent Using", selection: $inspectorModel.indentUsingSelection) {
             ForEach(inspectorModel.indentUsingList) {
                 Text($0.name)
-                    .font(.system(size: 11))
             }
         }
-        .labelsHidden()
     }
 
     private var tabWidths: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                HStack(alignment: .top, spacing: 2) {
-                    VStack(alignment: .center, spacing: 0) {
-                        TextField("", value: $inspectorModel.tabWidth, formatter: NumberFormatter())
-                            .labelsHidden()
-                            .frame(maxWidth: .infinity)
-                            .multilineTextAlignment(.trailing)
-                        Text("Tab")
-                            .foregroundColor(.primary)
-                            .fontWeight(.regular)
-                            .font(.system(size: 10))
-                    }
-                    Stepper(value: $inspectorModel.tabWidth, in: 1...8) {
-                        EmptyView()
-                    }
-                    .padding(.top, 1)
+        LabeledContent("Widths") {
+            HStack(spacing: 5) {
+                VStack(alignment: .center, spacing: 0) {
+                    Stepper(
+                        "",
+                        value: $inspectorModel.tabWidth,
+                        in: 1...8,
+                        step: 1,
+                        format: .number
+                    )
+                    .labelsHidden()
+                    Text("Tab")
+                        .foregroundColor(.primary)
+                        .font(.footnote)
                 }
-                HStack(alignment: .top, spacing: 2) {
-                    VStack(alignment: .center, spacing: 0) {
-                        TextField("", value: $inspectorModel.indentWidth, formatter: NumberFormatter())
-                            .labelsHidden()
-                            .frame(maxWidth: .infinity)
-                            .multilineTextAlignment(.trailing)
-                        Text("Indent")
-                            .foregroundColor(.primary)
-                            .fontWeight(.regular)
-                            .font(.system(size: 10))
-                    }
-                    Stepper(value: $inspectorModel.indentWidth, in: 1...8) {
-                        EmptyView()
-                    }
-                    .padding(.top, 1)
+                VStack(alignment: .center, spacing: 0) {
+                    Stepper(
+                        "",
+                        value: $inspectorModel.indentWidth,
+                        in: 1...8,
+                        step: 1,
+                        format: .number
+                    )
+                    .labelsHidden()
+                    Text("Indent")
+                        .foregroundColor(.primary)
+                        .font(.footnote)
                 }
             }
-            Toggle(isOn: $inspectorModel.wrapLines) {
-                Text("Wrap lines")
-            }.toggleStyle(CheckboxToggleStyle())
-                .padding(.vertical, 5)
+        }
+    }
+
+    private var wrapLines: some View {
+        Toggle(isOn: $inspectorModel.wrapLines) {
+            Text("Wrap lines")
         }
     }
 }

--- a/CodeEdit/Features/Settings/Views/ExternalLink.swift
+++ b/CodeEdit/Features/Settings/Views/ExternalLink.swift
@@ -29,17 +29,20 @@ import SwiftUI
 struct ExternalLink<Content: View, Icon: View>: View {
     let title: String?
     let subtitle: String?
+    let showInFinder: Bool
     let destination: URL
     let icon: (() -> Icon)?
     let content: () -> Content
 
     init(
         _ title: String,
+        showInFinder: Bool = false,
         destination: URL,
         subtitle: String? = nil,
         icon: (() -> Icon)? = nil
     ) where Content == EmptyView, Icon == EmptyView {
         self.title = title
+        self.showInFinder = showInFinder
         self.subtitle = subtitle
         self.destination = destination
         self.icon = icon
@@ -47,12 +50,14 @@ struct ExternalLink<Content: View, Icon: View>: View {
     }
 
     init(
+        showInFinder: Bool = false,
         destination: URL,
         @ViewBuilder content: @escaping () -> Content,
         title: String? = nil,
         subtitle: String? = nil,
         @ViewBuilder icon: @escaping() -> Icon = { EmptyView() }
     ) {
+        self.showInFinder = showInFinder
         self.title = title
         self.subtitle = subtitle
         self.destination = destination
@@ -61,7 +66,13 @@ struct ExternalLink<Content: View, Icon: View>: View {
     }
 
     var body: some View {
-        Button(action: { NSWorkspace.shared.open(destination) }, label: {
+        Button(action: {
+            if showInFinder {
+                NSWorkspace.shared.activateFileViewerSelecting([destination])
+            } else {
+                NSWorkspace.shared.open(destination)
+            }
+        }, label: {
             HStack(spacing: 8) {
                 icon?()
                 VStack(alignment: .leading, spacing: 2) {


### PR DESCRIPTION
### Description

As of recent, Apple is shifting to use the grouped form style in it's inspectors by default. We are now using a grouped form design in the file inspector to follow suit.

### Related Issues

n/a

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="587" alt="image" src="https://github.com/CodeEditApp/CodeEdit/assets/806104/a25658ec-af02-4f16-8260-2bdd082e007a">