### PR TITLE
fix: Correct wrongly labeled settings properties

### DIFF
--- a/CodeEdit/Features/Settings/Models/SettingsData.swift
+++ b/CodeEdit/Features/Settings/Models/SettingsData.swift
@@ -25,7 +25,7 @@ struct SettingsData: Codable, Hashable {
     /// The general global setting
     var general: GeneralSettings = .init()
 
-    /// The global settings for text editing
+    /// The global settings for source control accounts
     var accounts: AccountsSettings = .init()
 
     /// The global settings for themes
@@ -37,7 +37,7 @@ struct SettingsData: Codable, Hashable {
     /// The global settings for text editing
     var textEditing: TextEditingSettings = .init()
 
-    /// The global settings for text editing
+    /// The global settings for source control
     var sourceControl: SourceControlSettings = .init()
 
     /// The global settings for keybindings

--- a/CodeEdit/Features/Settings/Pages/AccountsSettings/Models/AccountsSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/AccountsSettings/Models/AccountsSettings.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension SettingsData {
 
-    /// The global settings for text editing
+    /// The global settings for source control accounts
     struct AccountsSettings: Codable, Hashable {
         /// An integer indicating how many spaces a `tab` will generate
         var sourceControlAccounts: GitAccounts = .init()

--- a/CodeEdit/Features/Settings/Pages/Keybindings/Models/KeybindingsSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/Keybindings/Models/KeybindingsSettings.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension SettingsData {
 
-    /// The global settings for text editing
+    /// The global settings for keybindings
     struct KeybindingsSettings: Codable, Hashable {
         /// An integer indicating how many spaces a `tab` will generate
         var keybindings: [String: KeyboardShortcutWrapper] = .init()


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

When we type `@AppSettings(...`, Xcode will suggest properties like `sourceControl` that we can use. But some of the properties are wrongly documented as "The global settings for text editing", this PR fixes it.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] The issues this PR addresses are related to each other
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

#### Before

<img width="459" alt="image" src="https://github.com/CodeEditApp/CodeEdit/assets/72877496/bf940fac-b580-4a70-8339-864a7afa799b">

#### After

<img width="461" alt="image" src="https://github.com/CodeEditApp/CodeEdit/assets/72877496/78888135-d061-4260-a240-80d0b955a48b">

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
