### PR TITLE
Move change theme listener from code file to workspace

### DIFF
--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -141,13 +141,6 @@ struct CodeFileView: View {
             guard let theme = newValue else { return }
             self.selectedTheme = theme
         }
-        .onChange(of: colorScheme) { newValue in
-            if matchAppearance {
-                themeModel.selectedTheme = newValue == .dark
-                ? themeModel.selectedDarkTheme
-                : themeModel.selectedLightTheme
-            }
-        }
         .onChange(of: settingsFont) { _ in
             font = Settings.shared.preferences.textEditing.font.current()
         }

--- a/CodeEdit/Features/Tabs/TabGroup/WorkspaceTabGroupView.swift
+++ b/CodeEdit/Features/Tabs/TabGroup/WorkspaceTabGroupView.swift
@@ -17,6 +17,12 @@ struct WorkspaceTabGroupView: View {
     @EnvironmentObject
     private var tabManager: TabManager
 
+    @Environment(\.colorScheme)
+    private var colorScheme
+    @AppSettings(\.theme.matchAppearance) var matchAppearance
+    @StateObject
+    private var themeModel: ThemeModel = .shared
+
     var body: some View {
         VStack {
             if let selected = tabgroup.selected {
@@ -65,6 +71,13 @@ struct WorkspaceTabGroupView: View {
         .focused($focus, equals: tabgroup)
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("CodeEditor.didBeginEditing"))) { _ in
             tabgroup.temporaryTab = nil
+        }
+        .onChange(of: colorScheme) { newValue in
+            if matchAppearance {
+                themeModel.selectedTheme = newValue == .dark
+                ? themeModel.selectedDarkTheme
+                : themeModel.selectedLightTheme
+            }
         }
     }
 }

--- a/CodeEdit/Features/Tabs/TabGroup/WorkspaceTabGroupView.swift
+++ b/CodeEdit/Features/Tabs/TabGroup/WorkspaceTabGroupView.swift
@@ -17,12 +17,6 @@ struct WorkspaceTabGroupView: View {
     @EnvironmentObject
     private var tabManager: TabManager
 
-    @Environment(\.colorScheme)
-    private var colorScheme
-    @AppSettings(\.theme.matchAppearance) var matchAppearance
-    @StateObject
-    private var themeModel: ThemeModel = .shared
-
     var body: some View {
         VStack {
             if let selected = tabgroup.selected {
@@ -71,13 +65,6 @@ struct WorkspaceTabGroupView: View {
         .focused($focus, equals: tabgroup)
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("CodeEditor.didBeginEditing"))) { _ in
             tabgroup.temporaryTab = nil
-        }
-        .onChange(of: colorScheme) { newValue in
-            if matchAppearance {
-                themeModel.selectedTheme = newValue == .dark
-                ? themeModel.selectedDarkTheme
-                : themeModel.selectedLightTheme
-            }
         }
     }
 }

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -33,6 +33,11 @@ struct WorkspaceView: View {
     @Environment(\.colorScheme)
     private var colorScheme
 
+    @AppSettings(\.theme.matchAppearance) var matchAppearance
+
+    @StateObject
+    private var themeModel: ThemeModel = .shared
+
     @State
     private var terminalCollapsed = true
 
@@ -75,7 +80,13 @@ struct WorkspaceView: View {
                             focusedEditor = newValue
                         }
                     }
-
+                    .onChange(of: colorScheme) { newValue in
+                        if matchAppearance {
+                            themeModel.selectedTheme = newValue == .dark
+                            ? themeModel.selectedDarkTheme
+                            : themeModel.selectedLightTheme
+                        }
+                    }
                 }
             }
             .background(EffectView(.contentBackground))


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
Currently is onChange event attached to CodeFileView.
If no editor is open & "Automatically change theme based on system appearance" is set, theme is not changing.
Maybe move this to workspace ?

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #1324
* closes #1325

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [ ] I documented my code
