### PR TITLE
Fixing Font bugs

### DIFF
--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -36,6 +36,8 @@ struct CodeFileView: View {
 
     private let isEditable: Bool
 
+    private let systemFont: NSFont = .monospacedSystemFont(ofSize: 11, weight: .medium)
+
     init(codeFile: CodeFileDocument, isEditable: Bool = true) {
         self.codeFile = codeFile
         self.isEditable = isEditable
@@ -142,7 +144,10 @@ struct CodeFileView: View {
             self.selectedTheme = theme
         }
         .onChange(of: settingsFont) { _ in
-            font = Settings.shared.preferences.textEditing.font.current()
+            font = NSFont(
+                name: settingsFont.name,
+                size: CGFloat(settingsFont.size)
+            ) ?? systemFont
         }
         .onChange(of: bracketHighlight) { _ in
             bracketPairHighlight = getBracketPairHighlight()

--- a/CodeEdit/Features/Settings/Views/MonospacedFontPicker.swift
+++ b/CodeEdit/Features/Settings/Views/MonospacedFontPicker.swift
@@ -83,9 +83,9 @@ struct MonospacedFontPicker: View {
                 }
             }
         }
-        .onChange(of: selectedFontName) { selection in
+        .onChange(of: selectedFontName) { _ in
             if selectedFontName != "SF Mono" {
-                pushIntoRecentFonts(selection)
+                pushIntoRecentFonts(selectedFontName)
             }
         }
         .onAppear(perform: getFonts)


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
This PR addresses 2 bugs, one where the top 3 fonts would not update till after clicking on the 2nd font after system default and then also the editor font being 1 font update behind.
<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #1328 
* closes #1338

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] The issues this PR addresses are related to each other
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

https://github.com/CodeEditApp/CodeEdit/assets/25121427/8f9418cb-97d2-4761-b7d1-6b1dc6529488


<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
