### PR TITLE
TextEditingSettingsView.swift: fix typo in setting name

### DIFF
--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -138,7 +138,7 @@ private extension TextEditingSettingsView {
     @ViewBuilder private var bracketPairHighlight: some View {
         Group {
             Picker(
-                "Braket Pair Highlight",
+                "Bracket Pair Highlight",
                 selection: $textEditing.bracketHighlight.highlightType
             ) {
                 Text("Disabled").tag(SettingsData.TextEditingSettings.BracketPairHighlight.HighlightType.disabled)
@@ -150,7 +150,7 @@ private extension TextEditingSettingsView {
             if [.bordered, .underline].contains(textEditing.bracketHighlight.highlightType) {
                 Toggle("Use Custom Color", isOn: $textEditing.bracketHighlight.useCustomColor)
                 SettingsColorPicker(
-                    "Braket Pair Highlight Color",
+                    "Bracket Pair Highlight Color",
                     color: $textEditing.bracketHighlight.color.swiftColor
                 )
                 .foregroundColor(


### PR DESCRIPTION
### Description

Updated the label for bracket matching setting to correct typos 

### Related Issues

* none

### Checklist

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
~~- [] The issues this PR addresses are related to each other~~
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
~~- [] My changes are all related to the related issue above~~
~~- [] I documented my code~~

### Screenshots

Before
<img width="745" alt="Xnapper-2023-06-22-12 19 13" src="https://github.com/CodeEditApp/CodeEdit/assets/552452/41fd3390-5043-4423-a82d-4db32cd000ef">

After
<img width="745" alt="Xnapper-2023-06-22-12 33 53" src="https://github.com/CodeEditApp/CodeEdit/assets/552452/d6775de8-312e-4f10-9766-0bdfd91eb0fb">

