### PR TITLE
Performance improvements to fuzzysearch

### DIFF
--- a/CodeEdit/Features/QuickOpen/ViewModels/QuickOpenViewModel.swift
+++ b/CodeEdit/Features/QuickOpen/ViewModels/QuickOpenViewModel.swift
@@ -54,14 +54,16 @@ final class QuickOpenViewModel: ObservableObject {
                 }
 
                 /// sorts the filtered filePaths with the FuzzySearch
-                let orderedFiles = FuzzySearch.search(query: self.openQuicklyQuery, in: filteredFiles)
-                    .map { url in
-                        CEWorkspaceFile(url: url, children: nil)
-                    }
+                Task {
+                    let orderedFiles = await FuzzySearch.search(query: self.openQuicklyQuery, in: filteredFiles)
+                        .map { url in
+                            CEWorkspaceFile(url: url, children: nil)
+                        }
 
-                DispatchQueue.main.async {
-                    self.openQuicklyFiles = orderedFiles
-                    self.isShowingOpenQuicklyFiles = !self.openQuicklyFiles.isEmpty
+                    DispatchQueue.main.async {
+                        self.openQuicklyFiles = orderedFiles
+                        self.isShowingOpenQuicklyFiles = !self.openQuicklyFiles.isEmpty
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

While working on the filesystem refactoring, I noticed the fuzzysearch implementation had a few things making it more expensive than it should be. For example, the score function was calculated inside the sort function. This will recompute the score function needlessly as values are compared multiple times. 

I made some simple adjustments which fix this issue. There were also some synchronous calls to the file system, so I made the code asynchronous which speeds it up even more.

As a bonus, the fuzzy search will now also work better with tabs and newlines, instead of only spaces.

Here are some test results for a large project, where I search for "t", "te", "tes" and "test" respectively.

#### Before
2.480142417 seconds
2.406085875 seconds
6.783014 seconds
6.755943334 seconds

#### After
0.465098708 seconds
0.444613625 seconds
0.431536375 seconds
0.391247541 seconds

Note that these results are not ordered as the current implementation won't cancel a previous search when a new one is initiated. This is another issue and is out of scope of this PR (it'll probably be fixed in the file system PR)

### Related Issues

None

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
