### PR TITLE
Fix Situationally Unusable Tab Groups

### DIFF
--- a/CodeEdit/Features/Tabs/TabGroup/TabGroupData.swift
+++ b/CodeEdit/Features/Tabs/TabGroup/TabGroupData.swift
@@ -81,6 +81,10 @@ final class TabGroupData: ObservableObject, Identifiable {
     /// This will also write any changes to the file on disk and will add the tab to the tab history.
     /// - Parameter item: the tab to close.
     func closeTab(item: Tab) {
+        if temporaryTab == item {
+            temporaryTab = nil
+        }
+
         historyOffset = 0
         if item != selected {
             history.prepend(item)
@@ -200,7 +204,6 @@ final class TabGroupData: ObservableObject, Identifiable {
         )
         item.fileDocument = codeFile
         CodeEditDocumentController.shared.addDocument(codeFile)
-        print("Opening file for item: ", item.url)
     }
 
     func goBackInHistory() {


### PR DESCRIPTION
### Description

Fixes a bug where if the user has only a temporary tab open in a group, closing that tab would cause the group to be unusable.

To reproduce:
- Open a tab (leave it temporary)
- Close the tab
- Try opening a new file
- The file will not open, the only way to regain the tab group is to close the group and open a new split.

To fix, the temporary tab had to be removed correctly in the `closeTab` function. Before it would cause the `openTab` function to take an incorrect path and assume every tab after had already been created, resulting in effectively a no-op when it tried opening another file.

### Related Issues

No issue opened afaik.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/35942988/31440488-991d-4fb1-8443-b6748d4c7043

