### PR TITLE
Use File System Events To Monitor Workspace

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -243,7 +243,9 @@
 		58FD7608291EA1CB0051D6E4 /* CommandPaletteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD7605291EA1CB0051D6E4 /* CommandPaletteViewModel.swift */; };
 		58FD7609291EA1CB0051D6E4 /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD7607291EA1CB0051D6E4 /* CommandPaletteView.swift */; };
 		5C4BB1E128212B1E00A92FB2 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4BB1E028212B1E00A92FB2 /* World.swift */; };
+		6C049A372A49E2DB00D42923 /* DirectoryEventStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C049A362A49E2DB00D42923 /* DirectoryEventStream.swift */; };
 		6C05A8AF284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */; };
+		6C092EC62A4E803300489202 /* CodeEditTextView in Frameworks */ = {isa = PBXBuildFile; productRef = 6C092EC52A4E803300489202 /* CodeEditTextView */; };
 		6C0D0C6829E861B000AE4D3F /* SettingsSidebarFix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0D0C6729E861B000AE4D3F /* SettingsSidebarFix.swift */; };
 		6C0F3A3C2A1D0D5000223D19 /* CodeEditKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6C0F3A3B2A1D0D5000223D19 /* CodeEditKit */; };
 		6C147C4029A328BC0089B630 /* SplitViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C147C3F29A328560089B630 /* SplitViewData.swift */; };
@@ -314,7 +316,6 @@
 		6CC9E4B229B5669900C97388 /* Environment+ActiveTabGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC9E4B129B5669900C97388 /* Environment+ActiveTabGroup.swift */; };
 		6CD0375F2A3504540071C4DA /* FuzzySearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD0375E2A3504540071C4DA /* FuzzySearch.swift */; };
 		6CD03B6A29FC773F001BD1D0 /* SettingsInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD03B6929FC773F001BD1D0 /* SettingsInjector.swift */; };
-		6CD601B52A420E0900E8C324 /* CodeEditTextView in Frameworks */ = {isa = PBXBuildFile; productRef = 6CD601B42A420E0900E8C324 /* CodeEditTextView */; };
 		6CDA84AD284C1BA000C1CC3A /* TabBarContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AC284C1BA000C1CC3A /* TabBarContextMenu.swift */; };
 		6CDEFC9629E22C2700B7C684 /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = 6CDEFC9529E22C2700B7C684 /* Introspect */; };
 		6CE622692A2A174A0013085C /* InspectorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE622682A2A174A0013085C /* InspectorTab.swift */; };
@@ -700,6 +701,7 @@
 		58FD7605291EA1CB0051D6E4 /* CommandPaletteViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandPaletteViewModel.swift; sourceTree = "<group>"; };
 		58FD7607291EA1CB0051D6E4 /* CommandPaletteView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandPaletteView.swift; sourceTree = "<group>"; };
 		5C4BB1E028212B1E00A92FB2 /* World.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = World.swift; sourceTree = "<group>"; };
+		6C049A362A49E2DB00D42923 /* DirectoryEventStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryEventStream.swift; sourceTree = "<group>"; };
 		6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkspaceDocument+Listeners.swift"; sourceTree = "<group>"; };
 		6C0D0C6729E861B000AE4D3F /* SettingsSidebarFix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSidebarFix.swift; sourceTree = "<group>"; };
 		6C147C3D29A3281D0089B630 /* TabGroupData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabGroupData.swift; sourceTree = "<group>"; };
@@ -861,7 +863,7 @@
 				6C0F3A3C2A1D0D5000223D19 /* CodeEditKit in Frameworks */,
 				6C5BE5222A3D5666002DA0FC /* WindowManagement in Frameworks */,
 				6C66C31329D05CDC00DE9ED2 /* GRDB in Frameworks */,
-				6CD601B52A420E0900E8C324 /* CodeEditTextView in Frameworks */,
+				6C092EC62A4E803300489202 /* CodeEditTextView in Frameworks */,
 				58F2EB1E292FB954004A9BDE /* Sparkle in Frameworks */,
 				6C2149412A1BB9AB00748382 /* LogStream in Frameworks */,
 				6C147C4529A329350089B630 /* OrderedCollections in Frameworks */,
@@ -1856,6 +1858,7 @@
 				5894E59629FEF7740077E59C /* CEWorkspaceFile+Recursion.swift */,
 				58A2E40629C3975D005CB615 /* CEWorkspaceFileIcon.swift */,
 				58710158298EB80000951BA4 /* CEWorkspaceFileManager.swift */,
+				6C049A362A49E2DB00D42923 /* DirectoryEventStream.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2482,7 +2485,7 @@
 				6CDEFC9529E22C2700B7C684 /* Introspect */,
 				6C0F3A3B2A1D0D5000223D19 /* CodeEditKit */,
 				6C5BE5212A3D5666002DA0FC /* WindowManagement */,
-				6CD601B42A420E0900E8C324 /* CodeEditTextView */,
+				6C092EC52A4E803300489202 /* CodeEditTextView */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -2578,7 +2581,7 @@
 				6CDEFC9429E22C2700B7C684 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 				6C0F3A3A2A1D0D5000223D19 /* XCRemoteSwiftPackageReference "CodeEditKit" */,
 				6C5BE5202A3D5666002DA0FC /* XCRemoteSwiftPackageReference "SwiftUI-WindowManagement" */,
-				6CD601B32A420E0900E8C324 /* XCRemoteSwiftPackageReference "CodeEditTextView" */,
+				6C092EC42A4E803300489202 /* XCRemoteSwiftPackageReference "CodeEditTextView" */,
 			);
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
 			projectDirPath = "";
@@ -2935,6 +2938,7 @@
 				286471AB27ED51FD0039369D /* ProjectNavigatorView.swift in Sources */,
 				B6E41C7C29DE2B110088F9F4 /* AccountsSettingsProviderRow.swift in Sources */,
 				B62AEDB52A1FE295009A9F52 /* DebugAreaDebugView.swift in Sources */,
+				6C049A372A49E2DB00D42923 /* DirectoryEventStream.swift in Sources */,
 				6CAAF68A29BC9C2300A1F48A /* (null) in Sources */,
 				6C6BD6EF29CD12E900235D17 /* ExtensionManagerWindow.swift in Sources */,
 				6CFF967629BEBCD900182D6F /* FileCommands.swift in Sources */,
@@ -3963,6 +3967,14 @@
 				version = 2.3.0;
 			};
 		};
+		6C092EC42A4E803300489202 /* XCRemoteSwiftPackageReference "CodeEditTextView" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CodeEditApp/CodeEditTextView";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.6.6;
+			};
+		};
 		6C0F3A3A2A1D0D5000223D19 /* XCRemoteSwiftPackageReference "CodeEditKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/CodeEditApp/CodeEditKit";
@@ -4011,14 +4023,6 @@
 				minimumVersion = 0.2.0;
 			};
 		};
-		6CD601B32A420E0900E8C324 /* XCRemoteSwiftPackageReference "CodeEditTextView" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CodeEditApp/CodeEditTextView";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.6.6;
-			};
-		};
 		6CDEFC9429E22C2700B7C684 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect";
@@ -4049,6 +4053,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 58F2EB1C292FB954004A9BDE /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		6C092EC52A4E803300489202 /* CodeEditTextView */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6C092EC42A4E803300489202 /* XCRemoteSwiftPackageReference "CodeEditTextView" */;
+			productName = CodeEditTextView;
 		};
 		6C0F3A3B2A1D0D5000223D19 /* CodeEditKit */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -4093,11 +4102,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6C147C4329A329350089B630 /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = DequeModule;
-		};
-		6CD601B42A420E0900E8C324 /* CodeEditTextView */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6CD601B32A420E0900E8C324 /* XCRemoteSwiftPackageReference "CodeEditTextView" */;
-			productName = CodeEditTextView;
 		};
 		6CDEFC9529E22C2700B7C684 /* Introspect */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
@@ -14,8 +14,6 @@ protocol CEWorkspaceFileManagerObserver: AnyObject {
 
 /// This class is used to load the files of the machine into a CodeEdit workspace.
 final class CEWorkspaceFileManager {
-    private var lock: NSLock = NSLock()
-
     private(set) var fileManager = FileManager.default
     private(set) var ignoredFilesAndFolders: Set<String>
     private(set) var flattenedFileItems: [String: CEWorkspaceFile]
@@ -115,9 +113,8 @@ final class CEWorkspaceFileManager {
 
     /// Called by `fsEventStream` when an event occurs.
     ///
-    /// This method can be called by separate threads, though measures are taken to minimize instances where this is
-    /// called more than once at a time.
-    /// This will always obtain a lock before modifying any of the file tree.
+    /// This method may be called on a background thread, but all work done by this function will be queued on the main
+    /// thread.
     /// - Parameters:
     ///   - directory: The directory where the event occurred.
     ///   - event: The event that occurred.

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
@@ -182,12 +182,10 @@ final class CEWorkspaceFileManager {
 
         fileItem.children = fileItem.children?.sortItems(foldersOnTop: true)
         fileItem.children?.forEach({
-            if $0.isFolder {
+            if deep && $0.isFolder {
                 try? rebuildFiles(fromItem: $0, deep: deep)
             }
-            if deep {
-                flattenedFileItems[$0.id] = $0
-            }
+            flattenedFileItems[$0.id] = $0
         })
     }
 

--- a/CodeEdit/Features/CEWorkspace/Models/DirectoryEventStream.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/DirectoryEventStream.swift
@@ -1,0 +1,123 @@
+//
+//  DirectoryEventStream.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 6/26/23.
+//
+
+import Foundation
+
+enum FSEvent {
+    case changeInDirectory
+    case rootChanged
+    case itemChangedOwner
+    case itemCreated
+    case itemCloned
+    case itemModified
+    case itemRemoved
+    case itemRenamed
+}
+
+class DirectoryEventStream {
+    typealias EventCallback = (String, FSEvent, Bool) -> Void
+
+    private var streamRef: FSEventStreamRef?
+    private var callback: EventCallback
+    private let debounceDuration: TimeInterval = 0.05
+
+    init(directory: String, callback: @escaping EventCallback) {
+        self.callback = callback
+        let selfPtr = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+
+        var context = FSEventStreamContext(
+            version: 0,
+            info: selfPtr,
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+        let contextPtr = withUnsafeMutablePointer(to: &context) { ptr in UnsafeMutablePointer(ptr) }
+
+        let cfDirectory = directory as CFString
+        let pathsToWatch = [cfDirectory] as CFArray
+
+        if let ref = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            // swiflint:ignore:next opening_brace
+            { streamRef, clientCallBackInfo, numEvents, eventPaths, eventFlags, eventIds in
+                guard let clientCallBackInfo else { return }
+                Unmanaged<DirectoryEventStream>
+                    .fromOpaque(clientCallBackInfo)
+                    .takeUnretainedValue()
+                    .eventStreamHandler(streamRef, numEvents, eventPaths, eventFlags, eventIds)
+            },
+            contextPtr,
+            pathsToWatch,
+            UInt64(kFSEventStreamEventIdSinceNow),
+            debounceDuration,
+            UInt32(
+                kFSEventStreamCreateFlagNoDefer
+                & kFSEventStreamCreateFlagWatchRoot
+            )
+        ) {
+            self.streamRef = ref
+            FSEventStreamSetDispatchQueue(ref, DispatchQueue(label: "com.CodeEdit.app.fseventsqueue", qos: .default))
+            FSEventStreamStart(ref)
+        }
+    }
+
+    deinit {
+        streamRef = nil
+    }
+
+    /// Cancels the fs events watcher.
+    /// This class will have to be re-initialized to begin streaming events again.
+    public func cancel() {
+        streamRef = nil
+    }
+
+    private func eventStreamHandler(
+        _ streamRef: ConstFSEventStreamRef,
+        _ numEvents: Int,
+        _ eventPaths: UnsafeMutableRawPointer,
+        _ eventFlags: UnsafePointer<FSEventStreamEventFlags>,
+        _ eventIds: UnsafePointer<FSEventStreamEventId>
+    ) {
+        var eventPaths = eventPaths.bindMemory(to: UnsafePointer<CChar>.self, capacity: numEvents)
+        for idx in 0..<numEvents {
+            let pathPtr = eventPaths.advanced(by: idx).pointee
+            let path = String(cString: pathPtr)
+            let flags = eventFlags.advanced(by: idx).pointee
+            guard let event = getEventFromFlags(flags) else {
+                continue
+            }
+            callback(
+                path,
+                event,
+                Int(flags) & kFSEventStreamEventFlagMustScanSubDirs > 0 ? true : false // Deep scan?
+            )
+        }
+    }
+
+    func getEventFromFlags(_ raw: FSEventStreamEventFlags) -> FSEvent? {
+        if raw == 0 {
+            return .changeInDirectory
+        } else if raw & UInt32(kFSEventStreamEventFlagRootChanged) > 0 {
+            return .rootChanged
+        } else if raw & UInt32(kFSEventStreamEventFlagItemChangeOwner) > 0 {
+            return .itemChangedOwner
+        } else if raw & UInt32(kFSEventStreamEventFlagItemCreated) > 0 {
+            return .itemCreated
+        } else if raw & UInt32(kFSEventStreamEventFlagItemCloned) > 0 {
+            return .itemCloned
+        } else if raw & UInt32(kFSEventStreamEventFlagItemModified) > 0 {
+            return .itemModified
+        } else if raw & UInt32(kFSEventStreamEventFlagItemRemoved) > 0 {
+            return .itemRemoved
+        } else if raw & UInt32(kFSEventStreamEventFlagItemRenamed) > 0 {
+            return .itemRenamed
+        } else {
+            return nil
+        }
+    }
+}

--- a/CodeEdit/Features/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument.swift
@@ -32,7 +32,7 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     }
 
     public var filter: String = "" {
-        didSet { workspaceFileManager?.onRefresh() }
+        didSet { workspaceFileManager?.notifyObservers() }
     }
 
     var debugAreaModel = DebugAreaViewModel()
@@ -118,14 +118,9 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     // MARK: Set Up Workspace
 
     private func initWorkspaceState(_ url: URL) throws {
-//        self.workspaceClient = try .default(
-//            fileManager: .default,
-//            folderURL: url,
-//            ignoredFilesAndFolders: ignoredFilesAndDirectory
-//        )
         self.workspaceFileManager = .init(
             folderUrl: url,
-            ignoredFilesAndFolders: ignoredFilesAndDirectory
+            ignoredFilesAndFolders: Set(ignoredFilesAndDirectory)
         )
         self.searchState = .init(self)
         self.quickOpenViewModel = .init(fileURL: url)

--- a/CodeEdit/Features/NavigatorSidebar/OutlineView/FileSystemTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorSidebar/OutlineView/FileSystemTableViewCell.swift
@@ -37,15 +37,7 @@ class FileSystemTableViewCell: StandardTableViewCell {
     }
 
     func addIcon(item: CEWorkspaceFile) {
-        var imageName = item.systemImage
-        if item.watcherCode == nil {
-            imageName = "exclamationmark.arrow.triangle.2.circlepath"
-        }
-        if item.watcher == nil && !item.activateWatcher() {
-            // watcher failed to activate
-            imageName = "eye.trianglebadge.exclamationmark"
-        }
-        let image = NSImage(systemSymbolName: imageName, accessibilityDescription: nil)!
+        let image = NSImage(systemSymbolName: item.systemImage, accessibilityDescription: nil)!
         fileItem = item
         icon.image = image
         icon.contentTintColor = color(for: item)

--- a/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
+++ b/CodeEdit/Features/NavigatorSidebar/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
@@ -21,10 +21,7 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
         let controller = ProjectNavigatorViewController()
         controller.workspace = workspace
         controller.iconColor = prefs.preferences.general.fileIconStyle
-        workspace.workspaceFileManager?.onRefresh = {
-            controller.outlineView.reloadData()
-            controller.updateSelection(itemID: workspace.tabManager.activeTabGroup.selected?.id)
-        }
+        workspace.workspaceFileManager?.addObserver(context.coordinator)
 
         context.coordinator.controller = controller
 
@@ -46,7 +43,7 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
         Coordinator(workspace)
     }
 
-    class Coordinator: NSObject {
+    class Coordinator: NSObject, CEWorkspaceFileManagerObserver {
         init(_ workspace: WorkspaceDocument) {
             self.workspace = workspace
             super.init()
@@ -70,5 +67,13 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
         var workspace: WorkspaceDocument
         var controller: ProjectNavigatorViewController?
 
+        func fileManagerUpdated() {
+            controller?.outlineView.reloadData()
+            controller?.updateSelection(itemID: workspace.tabManager.activeTabGroup.selected?.id)
+        }
+
+        deinit {
+            workspace.workspaceFileManager?.removeObserver(self)
+        }
     }
 }


### PR DESCRIPTION
### Description

Removes the existing file system watching code and replaces it with MacOS's [File System Events](https://developer.apple.com/documentation/coreservices/file_system_events?language=objc) API. This API isn't bound by process file descriptor limits and is built for recursive directory monitoring. In place of file descriptors it uses kernel updates to notify our process that events have occurred.

Changes in detail:
- Removes all references to `watcherCode` from `CEWorkspaceFile`
- Removes all unnecessary subjects, publishers, and watcher code from `CEWorkspaceFileManager`.
- Adds an observer API to the `CEWorkspaceFileManager` that allows more than one subscriber to listen for updates to the file tree. 
  - This has been designed for multiple observers. So if we need to monitor file changes in the future with another API like extensions at the same time as the project navigator, that's supported. It also further decouples this file management from UI code through delegation.
- Modifies tests to use the new observation method
- Adds a `DirectoryEventStream` class.
  - This class uses the afore mentioned file system events API and converts the raw response to some more swift-like data.
  - On initialization it starts the stream. By default it will use a `0.05ms` event debounce and queue events to be received on the `default` qos dispatch queue.
  - `0.05ms` was chosen after testing with larger and smaller sizes to find a time that feels snappy while reducing extra events.
  - The stream can be listened to by setting a completion handler on the stream object which will be called whenever a valid event is found. See the `FSEvents` enum for more info on valid events. The stream will send events on a background thread, so any UI related code will have to be dispatched by the receiver.

This has implications for @Wouter01's branch getting rid of `CEWorkspaceFile`. Thankfully, most of the changes here won't effect that PR besides removing some of the work halfway done there. As discussed on Discord, we'll merge this monitoring system in favor of the NSDocument subclassing Wouter was doing and perform any updates needed to use the new `Resource` protocol on that branch.

### Related Issues

- Closes #1146 
- Closes #1188 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Moving files is snappy and updates consistently (even moving a large project's `node_modules` folder had little to no noticeable effect on this):

https://github.com/CodeEditApp/CodeEdit/assets/35942988/cc5cda31-11f9-4600-995f-3d4048601fe2

Files created/modified/deleted  in the built-in terminal or by other applications update quickly and consistently:

https://github.com/CodeEditApp/CodeEdit/assets/35942988/fa54403b-4929-44ad-9d92-0e0e3f826aba

