### PR TITLE
New files should not be saved to location until manually saved

### DIFF
--- a/CodeEdit/CodeEditApp.swift
+++ b/CodeEdit/CodeEditApp.swift
@@ -10,11 +10,22 @@ import WindowManagement
 
 @main
 struct CodeEditApp: App {
-    @NSApplicationDelegateAdaptor var appdelegate: AppDelegate
+
+    /// The base URL of CodeEdit
+    ///
+    /// Points to `~/Library/Application Support/CodeEdit/`
+    static var applicationSupportURL: URL {
+        FileManager
+            .default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/CodeEdit", isDirectory: true)
+    }
+
     @ObservedObject var settings = Settings.shared
+    @NSApplicationDelegateAdaptor var appDelegate: AppDelegate
 
     @Environment(\.openWindow)
-    var openWindow
+    private var openWindow
 
     let updater: SoftwareUpdater = SoftwareUpdater()
 

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -122,6 +122,10 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
         try? url.resourceValues(forKeys: [.contentTypeKey]).contentType
     }
 
+    var isDraft: Bool {
+        url.absoluteString.contains(/\/Users\/[0-9a-zA-Z]+\/Library\/Application%20Support\/CodeEdit/)
+    }
+
     /// Returns a `Color` for a specific `fileType`
     ///
     /// If not specified otherwise this will return `Color.accentColor`

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -124,7 +124,7 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
 
     /// When a file is created directly into the editor, it will be stored in a temporary folder. 
     /// With this variable it is possible to check if this file is such a temporal file
-    var isDraft: Bool {
+    var isScratch: Bool {
         url.absoluteString.contains(/\/Users\/[0-9a-zA-Z]+\/Library\/Application%20Support\/CodeEdit/)
     }
 

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -122,6 +122,8 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
         try? url.resourceValues(forKeys: [.contentTypeKey]).contentType
     }
 
+    /// When a file is created directly into the editor, it will be stored in a temporary folder. 
+    /// With this variable it is possible to check if this file is such a temporal file
     var isDraft: Bool {
         url.absoluteString.contains(/\/Users\/[0-9a-zA-Z]+\/Library\/Application%20Support\/CodeEdit/)
     }

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -9,6 +9,7 @@ import Cocoa
 import SwiftUI
 import Combine
 
+// swiftlint:disable type_body_length
 final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, ObservableObject {
     static let minSidebarWidth: CGFloat = 242
 
@@ -222,25 +223,26 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
         workspace?.editorManager.activeEditor.selectedTab?.file.fileDocument
     }
 
-    private func saveDocumentAs(_ file: CEWorkspaceFile) {
+    private func saveDocumentAs(_ file: CEWorkspaceFile, _ sender: Any) {
+        file.fileDocument?.save(sender)
         let dialog = NSSavePanel()
 
         if dialog.runModal() == .OK {
             if let url = dialog.url {
                 print(url.path)
-                workspace?.workspaceFileManager?.move(file: file, to: url)
                 workspace?.editorManager.activeEditor.closeSelectedTab()
-                workspace?.editorManager.activeEditor.openTab(item: CEWorkspaceFile(url: url), asTemporary: false)
+                workspace?.workspaceFileManager?.move(file: file, to: url)
+                workspace?.editorManager.openTab(item: CEWorkspaceFile(url: url))
             }
         }
     }
 
     @IBAction func saveDocument(_ sender: Any) {
         guard let codeFile = getCurrentWorkspaceFile() else { return }
-        codeFile.fileDocument?.save(sender)
         if codeFile.isDraft {
-            saveDocumentAs(codeFile)
-            return
+            saveDocumentAs(codeFile, sender)
+        } else {
+            codeFile.fileDocument?.save(sender)
         }
         workspace?.editorManager.activeEditor.temporaryTab = nil
     }
@@ -311,3 +313,5 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
         }
     }
 }
+
+// swiftlint:enable type_body_length

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -239,7 +239,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
 
     @IBAction func saveDocument(_ sender: Any) {
         guard let codeFile = getCurrentWorkspaceFile() else { return }
-        if codeFile.isDraft {
+        if codeFile.isScratch {
             saveDocumentAs(codeFile, sender)
         } else {
             codeFile.fileDocument?.save(sender)

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -219,8 +219,8 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
         }
     }
 
-    private func getSelectedCodeFile() -> CodeFileDocument? {
-        workspace?.editorManager.activeEditor.selectedTab?.file.fileDocument
+    private func getCurrentWorkspaceFile() -> CEWorkspaceFile? {
+        return workspace?.editorManager.activeEditor.selectedTab?.file
     }
 
     private func saveDocumentAs(_ file: CEWorkspaceFile, _ sender: Any) {

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -223,8 +223,15 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
     }
 
     @IBAction func saveDocument(_ sender: Any) {
-        guard let codeFile = getSelectedCodeFile() else { return }
-        codeFile.save(sender)
+        guard let codeFile = getCurrentWorkspaceFile() else { return }
+        print(codeFile.isDraft)
+        print(codeFile.url.absoluteString)
+        if codeFile.isDraft {
+            codeFile.fileDocument?.saveAs(sender)
+            // TODO: Need to replace the content of that saved tab with the newly saved file
+            return
+        }
+        codeFile.fileDocument?.save(sender)
         workspace?.editorManager.activeEditor.temporaryTab = nil
     }
 

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -222,16 +222,26 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
         workspace?.editorManager.activeEditor.selectedTab?.file.fileDocument
     }
 
+    private func saveDocumentAs(_ file: CEWorkspaceFile) {
+        let dialog = NSSavePanel()
+
+        if dialog.runModal() == .OK {
+            if let url = dialog.url {
+                print(url.path)
+                workspace?.workspaceFileManager?.move(file: file, to: url)
+                workspace?.editorManager.activeEditor.closeSelectedTab()
+                workspace?.editorManager.activeEditor.openTab(item: CEWorkspaceFile(url: url), asTemporary: false)
+            }
+        }
+    }
+
     @IBAction func saveDocument(_ sender: Any) {
         guard let codeFile = getCurrentWorkspaceFile() else { return }
-        print(codeFile.isDraft)
-        print(codeFile.url.absoluteString)
+        codeFile.fileDocument?.save(sender)
         if codeFile.isDraft {
-            codeFile.fileDocument?.saveAs(sender)
-            // TODO: Need to replace the content of that saved tab with the newly saved file
+            saveDocumentAs(codeFile)
             return
         }
-        codeFile.fileDocument?.save(sender)
         workspace?.editorManager.activeEditor.temporaryTab = nil
     }
 

--- a/CodeEdit/Features/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument.swift
@@ -18,7 +18,7 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
 
     var workspaceFileManager: CEWorkspaceFileManager?
 
-    var editorManager: EditorManager
+    var editorManager = EditorManager()
 
     private var workspaceState: [String: Any] {
         get {
@@ -39,12 +39,6 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     var sourceControlManager: SourceControlManager?
 
     private var cancellables = Set<AnyCancellable>()
-
-    override init() {
-        self.editorManager = EditorManager()
-        super.init()
-
-    }
 
     deinit {
         cancellables.forEach { $0.cancel() }

--- a/CodeEdit/Features/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument.swift
@@ -18,7 +18,7 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
 
     var workspaceFileManager: CEWorkspaceFileManager?
 
-    var editorManager = EditorManager()
+    var editorManager: EditorManager
 
     private var workspaceState: [String: Any] {
         get {
@@ -39,6 +39,12 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     var sourceControlManager: SourceControlManager?
 
     private var cancellables = Set<AnyCancellable>()
+
+    override init() {
+        self.editorManager = EditorManager()
+        super.init()
+
+    }
 
     deinit {
         cancellables.forEach { $0.cancel() }

--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -5,10 +5,10 @@
 //  Created by Wouter Hennen on 16/02/2023.
 //
 
+import AppKit
+import DequeModule
 import Foundation
 import OrderedCollections
-import DequeModule
-import AppKit
 
 final class Editor: ObservableObject, Identifiable {
     typealias Tab = EditorInstance
@@ -248,6 +248,10 @@ final class Editor: ObservableObject, Identifiable {
         guard let codeFile = file.fileDocument else { return true }
 
         if codeFile.isDocumentEdited {
+            if item.isDraft {
+                return openDraftSavePanel(for: item)
+            }
+
             let shouldClose = UnsafeMutablePointer<Bool>.allocate(capacity: 1)
             shouldClose.initialize(to: true)
             defer {
@@ -266,6 +270,41 @@ final class Editor: ObservableObject, Identifiable {
         return true
     }
 
+    /// Opens a custom NSAlert for saving a draft file
+    ///
+    /// (A draft file is a file that has been created
+    /// but is not saved anywhere outside the CodeEdit 'Application Support' folder)
+    /// - Returns: A boolean that tells whether the tab can be closed
+    private func openDraftSavePanel(for file: CEWorkspaceFile) -> Bool {
+        guard let currentWindow = NSApp.keyWindow else { return false }
+
+        let alert = NSAlert()
+        alert.messageText = "Do you want to save the contens of the draft file “untitled-1”?"
+        alert.informativeText = "Your changes will be lost if you don’t save them."
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Don't save").hasDestructiveAction = true
+        alert.addButton(withTitle: "Cancel")
+        let response = alert.runModal()
+        if response == NSApplication.ModalResponse.alertFirstButtonReturn {
+            print("Save file")
+            NSApp.sendAction(#selector(CodeEditWindowController.saveDocument(_:)), to: nil, from: nil)
+            return true
+        } else if response == NSApplication.ModalResponse.alertSecondButtonReturn {
+            print("Remove file")
+            let fileManager = FileManager.default
+
+            if fileManager.fileExists(atPath: file.url.path) {
+                do {
+                    try fileManager.removeItem(at: file.url)
+                } catch {
+                    fatalError(error.localizedDescription)
+                }
+            }
+            return true
+        }
+        return false
+    }
+
     /// Receives result of `canClose` and then, set `shouldClose` to `contextInfo`'s `pointee`.
     ///
     /// - Parameters:
@@ -275,7 +314,7 @@ final class Editor: ObservableObject, Identifiable {
     ///   - contextInfo: The additional info which will be set `shouldClose`.
     ///       `contextInfo` must be `UnsafeMutablePointer<Bool>`.
     @objc
-    func document(
+    private func document(
         _ document: NSDocument,
         shouldClose: Bool,
         contextInfo: UnsafeMutableRawPointer

--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -247,9 +247,9 @@ final class Editor: ObservableObject, Identifiable {
     private func canCloseTab(file: CEWorkspaceFile) -> Bool {
         guard let codeFile = file.fileDocument else { return true }
 
-        if file.isDocumentEdited {
-            if item.isScratch {
-                return openDraftSavePanel(for: item)
+        if codeFile.isDocumentEdited {
+            if file.isScratch {
+                return openDraftSavePanel(for: file)
             }
 
             let shouldClose = UnsafeMutablePointer<Bool>.allocate(capacity: 1)
@@ -267,12 +267,12 @@ final class Editor: ObservableObject, Identifiable {
             return shouldClose.pointee
         }
 
-        if item.isScratch {
+        if file.isScratch {
             let fileManager = FileManager.default
 
-            if fileManager.fileExists(atPath: item.url.path) {
+            if fileManager.fileExists(atPath: file.url.path) {
                 do {
-                    try fileManager.removeItem(at: item.url)
+                    try fileManager.removeItem(at: file.url)
                 } catch {
                     fatalError(error.localizedDescription)
                 }

--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -286,6 +286,8 @@ final class Editor: ObservableObject, Identifiable {
     ///
     /// (A draft file is a file that has been created
     /// but is not saved anywhere outside the CodeEdit 'Application Support' folder)
+    ///  - Parameters:
+    ///     - file: The draft file to be sa
     /// - Returns: A boolean that tells whether the tab can be closed
     private func openDraftSavePanel(for file: CEWorkspaceFile) -> Bool {
         guard let currentWindow = NSApp.keyWindow else { return false }

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorFileTabCloseButton.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorFileTabCloseButton.swift
@@ -36,7 +36,7 @@ struct EditorFileTabCloseButton: View {
             self.id += 1
         })
         .onReceive(
-            item.fileDocument?.isDocumentEditedPublisher.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()
+            item.fileDocument?.isDocumentEditedPublisher ?? Empty().eraseToAnyPublisher()
         ) { newValue in
             self.isDocumentEdited = newValue
         }

--- a/CodeEdit/Features/Settings/Models/Settings.swift
+++ b/CodeEdit/Features/Settings/Models/Settings.swift
@@ -50,7 +50,7 @@ final class Settings: ObservableObject {
     /// `~/Library/Application Support/CodeEdit/settings.json`
     private func loadSettings() -> SettingsData {
         if !filemanager.fileExists(atPath: settingsURL.path) {
-            try? filemanager.createDirectory(at: baseURL, withIntermediateDirectories: false)
+            try? filemanager.createDirectory(at: CodeEditApp.applicationSupportURL, withIntermediateDirectories: false)
             return .init()
         }
 
@@ -65,7 +65,7 @@ final class Settings: ObservableObject {
     /// Save``Settings`` model to
     /// `~/Library/Application Support/CodeEdit/settings.json`
     private func savePreferences(_ data: SettingsData) throws {
-        print("Saving...")
+        print("Saving preferences...")
         let data = try JSONEncoder().encode(data)
         let json = try JSONSerialization.jsonObject(with: data)
         let prettyJSON = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
@@ -75,20 +75,11 @@ final class Settings: ObservableObject {
     /// Default instance of the `FileManager`
     private let filemanager = FileManager.default
 
-    /// The base URL of settings.
-    ///
-    /// Points to `~/Library/Application Support/CodeEdit/`
-    internal var baseURL: URL {
-        filemanager
-            .homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Application Support/CodeEdit", isDirectory: true)
-    }
-
     /// The URL of the `settings.json` settings file.
     ///
     /// Points to `~/Library/Application Support/CodeEdit/settings.json`
     private var settingsURL: URL {
-        baseURL
+        CodeEditApp.applicationSupportURL
             .appendingPathComponent("settings")
             .appendingPathExtension("json")
     }

--- a/CodeEdit/Features/Settings/Pages/LocationsSettings/LocationsSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/LocationsSettings/LocationsSettingsView.swift
@@ -23,9 +23,9 @@ struct LocationsSettingsView: View {
 
 private extension LocationsSettingsView {
     @ViewBuilder private var applicationSupportLocation: some View {
-        ExternalLink(destination: Settings.shared.baseURL) {
+        ExternalLink(destination: CodeEditApp.applicationSupportURL) {
             Text("Application Support")
-            Text(Settings.shared.baseURL.path)
+            Text(CodeEditApp.applicationSupportURL.path)
                 .font(.footnote)
                 .foregroundColor(.secondary)
         }

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -73,17 +73,13 @@ struct FileCommands: Commands {
         }
     }
 
-    // TODO: This logic needs to become a command, not a function bound to the MenuBar
     private func createNewFile() {
         guard let windowController = getCurrentCEWindowController() else { return }
 
         let fileManager = FileManager.default
         let workspaceName = windowController.workspace?.workspaceFileManager?.folderUrl.lastPathComponent
 
-        var hashedWorkspaceName = "no-workspace".md5()
-        if let workspaceName {
-            hashedWorkspaceName = workspaceName.md5()
-        }
+        var hashedWorkspaceName = (workspaceName ?? "no-workspace").md5()
 
         let tempStorageDir = CodeEditApp.applicationSupportURL
             .appendingPathComponent("workspaces/\(hashedWorkspaceName)", isDirectory: true)
@@ -104,7 +100,7 @@ struct FileCommands: Commands {
             print(error)
             let alert = NSAlert()
             alert.messageText = "Error"
-            alert.informativeText = "An error occurred. Please try again later."
+            alert.informativeText = "An error occurred: \(error.localizedDescription)."
             alert.alertStyle = .critical
             alert.addButton(withTitle: "OK")
             alert.runModal()

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -16,7 +16,6 @@ struct FileCommands: Commands {
             Group {
                 Button("New") {
                     createNewFile()
-//                    NSDocumentController.shared.newDocument(nil)
                 }
                 .keyboardShortcut("n")
 

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -100,7 +100,7 @@ struct FileCommands: Commands {
             print("Saving new file at: \(tempFileURL.path)")
 
             let file = CEWorkspaceFile(url: tempFileURL)
-            windowController.workspace?.tabManager.openTab(item: file)
+            windowController.workspace?.editorManager.openTab(item: file)
         } catch {
             print(error)
             let alert = NSAlert()


### PR DESCRIPTION
### Description

This PR changes how new files are created, when they're not created via the project navigator.

Right now, the user is required to first create and save a file before it can be edited. This PR adds the possibility to create an unsaved scratch file, that is deleted when closed empty or has to be saved when the user closes it when there in content in it.

### Related Issues

* #1070 

### Checklist

#### General PR
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Remaining issues
- When the user tries to edited the file when it is no longer a scratch file, the save functionality doesn't work anymore. It's not clear why this happens...
- When the user decides to delete a scratch file, the editor will give a popup for the second time when the application is quit. It's not clear why this happens either...
