### PR TITLE
Remove dark appearances from light appearances section (and in dark appearances) in themes settings

### DIFF
--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsView.swift
@@ -89,14 +89,6 @@ struct ThemeSettingsView: View {
                                 action: activateTheme
                             ).id(theme)
                         }
-                        ForEach(selectedAppearance == .dark ? themeModel.lightThemes : themeModel.darkThemes) { theme in
-                            Divider()
-                            ThemeSettingsThemeRow(
-                                theme: $themeModel.themes[themeModel.themes.firstIndex(of: theme)!],
-                                active: getThemeActive(theme),
-                                action: activateTheme
-                            ).id(theme)
-                        }
                     }
                 }
                 .padding(-10)


### PR DESCRIPTION
### Description

this PR fixes a bug where dark appearances would appear in the light appearances section and light appearances would appear in the dark appearances section.

### Related Issues

* close #1373 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

#### Before:


<img width="827" alt="shot 8" src="https://github.com/CodeEditApp/CodeEdit/assets/128280019/a11ec75d-ef07-4457-8efa-c78521783e89"> <img width="827" alt="shot 9" src="https://github.com/CodeEditApp/CodeEdit/assets/128280019/6e8ec7f6-1cb8-4af0-9e63-9c6478e86b55">

#### After:

<img width="827" alt="shot 11" src="https://github.com/CodeEditApp/CodeEdit/assets/128280019/6e184c3c-62d6-4228-a679-b8ce092d321b"> <img width="827" alt="shot 10" src="https://github.com/CodeEditApp/CodeEdit/assets/128280019/cf7d4b11-8acd-441e-b523-c3e71d7b41d9">
