### PR TITLE
Added a clear button with the shortcut Command + K to clear the terminal

### DIFF
--- a/CodeEdit/Features/DebugArea/Views/DebugAreaTerminalView.swift
+++ b/CodeEdit/Features/DebugArea/Views/DebugAreaTerminalView.swift
@@ -182,7 +182,7 @@ struct DebugAreaTerminalView: View {
                         // clear terminal and scroll backbuffer
                         model.terminals.forEach {
                             if model.selectedTerminals.contains($0.id) {
-                                $0.terminalEmulatorView.terminal.send(txt: "clear\n")
+                                $0.terminalEmulatorView.terminal.send(txt: "printf '\\33c\\e[3J'\n")
                             }
                         }
                     } label: {

--- a/CodeEdit/Features/DebugArea/Views/DebugAreaTerminalView.swift
+++ b/CodeEdit/Features/DebugArea/Views/DebugAreaTerminalView.swift
@@ -8,20 +8,36 @@
 import SwiftUI
 
 struct DebugAreaTerminal: Identifiable, Equatable {
+    static func == (lhs: DebugAreaTerminal, rhs: DebugAreaTerminal) -> Bool {
+        lhs.id == rhs.id
+    }
+
     var id: UUID
     var url: URL?
     var title: String
     var terminalTitle: String
     var shell: String
     var customTitle: Bool
+    var terminalEmulatorView: TerminalEmulatorView
 
-    init(id: UUID, url: URL, title: String, shell: String) {
+    init(
+        id: UUID,
+        url: URL,
+        title: String,
+        shell: String,
+        titleChange: @escaping (_ title: String) -> Void
+    ) {
         self.id = id
         self.title = title
         self.terminalTitle = title
         self.url = url
         self.shell = shell
         self.customTitle = false
+        self.terminalEmulatorView = TerminalEmulatorView(
+            url: url,
+            shellType: shell,
+            onTitleChange: titleChange
+        )
     }
 }
 
@@ -56,7 +72,13 @@ struct DebugAreaTerminalView: View {
                 id: id,
                 url: workspace.workspaceFileManager?.folderUrl ?? URL(filePath: "/"),
                 title: "terminal",
-                shell: ""
+                shell: "",
+                titleChange: { newTitle in
+                    // This can be called whenever, even in a view update so it needs to be dispatched.
+                    DispatchQueue.main.async {
+                        handleTitleChange(id: id, title: newTitle)
+                    }
+                }
             )
         ]
 
@@ -71,7 +93,13 @@ struct DebugAreaTerminalView: View {
                 id: id,
                 url: URL(filePath: "\(id)"),
                 title: "terminal",
-                shell: shell ?? ""
+                shell: shell ?? "",
+                titleChange: { newTitle in
+                    // This can be called whenever, even in a view update so it needs to be dispatched.
+                    DispatchQueue.main.async {
+                        handleTitleChange(id: id, title: newTitle)
+                    }
+                }
             )
         )
 
@@ -130,21 +158,12 @@ struct DebugAreaTerminalView: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
                 ForEach(model.terminals) { terminal in
-                    TerminalEmulatorView(
-                        url: terminal.url!,
-                        shellType: terminal.shell,
-                        onTitleChange: { newTitle in
-                            // This can be called whenever, even in a view update so it needs to be dispatched.
-                            DispatchQueue.main.async {
-                                handleTitleChange(id: terminal.id, title: newTitle)
-                            }
-                        }
-                    )
-                    .padding(.top, 10)
-                    .padding(.horizontal, 10)
-                    .contentShape(Rectangle())
-                    .disabled(terminal.id != model.selectedTerminals.first)
-                    .opacity(terminal.id == model.selectedTerminals.first ? 1 : 0)
+                    terminal.terminalEmulatorView
+                        .padding(.top, 10)
+                        .padding(.horizontal, 10)
+                        .contentShape(Rectangle())
+                        .disabled(terminal.id != model.selectedTerminals.first)
+                        .opacity(terminal.id == model.selectedTerminals.first ? 1 : 0)
                 }
             }
             .paneToolbar {
@@ -159,6 +178,18 @@ struct DebugAreaTerminalView: View {
                     } label: {
                         Image(systemName: "trash")
                     }
+                    Button {
+                        // clear terminal and scroll backbuffer
+                        model.terminals.forEach {
+                            if model.selectedTerminals.contains($0.id) {
+                                $0.terminalEmulatorView.terminal.send(txt: "clear\n")
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "clear")
+                    }
+                    .help("Clear terminal")
+                    .keyboardShortcut("k")
                     Button {
                         // split terminal
                     } label: {


### PR DESCRIPTION
### Description

Added a new button at the bottom of the DebugAreaTerminalView for clearing the terminal, with the clear icon. The terminal can also be cleared with the command + K keyboard shortcut. The button also has a tooltip indicating that it is used for clearing the terminal

### Related Issues

Closes #891 
Closes #1143 

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/38476845/27ab4e4b-70ea-4a9e-872e-7ad5d4721c28