### PR TITLE
Fixed close tab and close window shortcut

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -299,6 +299,10 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
             }
         }
     }
+
+    @IBAction func closeCurrentTab(_ sender: Any) {
+        workspace?.tabManager.activeTabGroup.closeCurrentTab()
+    }
 }
 
 extension CodeEditWindowController {

--- a/CodeEdit/Features/Tabs/TabGroup/TabGroupData.swift
+++ b/CodeEdit/Features/Tabs/TabGroup/TabGroupData.swift
@@ -114,6 +114,15 @@ final class TabGroupData: ObservableObject, Identifiable {
         }
     }
 
+    /// Closes the currently opened tab in the tab group.
+    func closeCurrentTab() {
+        guard let selectedTab = selected else {
+            return
+        }
+
+        closeTab(item: selectedTab)
+    }
+
     /// Opens a tab in the tabgroup.
     /// If a tab for the item already exists, it is used instead.
     /// - Parameters:

--- a/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
@@ -167,7 +167,7 @@ struct TabBarItemView: View {
                         // Close Tab Shortcut:
                         // Using an invisible button to contain the keyboard shortcut is simply
                         // because the keyboard shortcut has an unexpected bug when working with
-                        // custom buttonStyle. This is an workaround and it works as expected.
+                        // custom buttonStyle. This is a workaround and it works as expected.
                         Button(
                             action: closeAction,
                             label: { EmptyView() }

--- a/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
@@ -174,7 +174,7 @@ struct TabBarItemView: View {
                         )
                         .frame(width: 0, height: 0)
                         .keyboardShortcut("w", modifiers: [.command])
-                        .hidden()
+                        .opacity(0)
                     }
                     // Switch Tab Shortcut:
                     // Using an invisible button to contain the keyboard shortcut is simply

--- a/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
@@ -163,19 +163,6 @@ struct TabBarItemView: View {
             .padding(.horizontal, tabBarStyle == .native ? 28 : 23)
             .overlay {
                 ZStack {
-                    if isActive {
-                        // Close Tab Shortcut:
-                        // Using an invisible button to contain the keyboard shortcut is simply
-                        // because the keyboard shortcut has an unexpected bug when working with
-                        // custom buttonStyle. This is a workaround and it works as expected.
-                        Button(
-                            action: closeAction,
-                            label: { EmptyView() }
-                        )
-                        .frame(width: 0, height: 0)
-                        .keyboardShortcut("w", modifiers: [.command])
-                        .opacity(0)
-                    }
                     // Switch Tab Shortcut:
                     // Using an invisible button to contain the keyboard shortcut is simply
                     // because the keyboard shortcut has an unexpected bug when working with

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -39,7 +39,7 @@ struct FileCommands: Commands {
             Button("Close Tab") {
                 NSApp.sendAction(#selector(CodeEditWindowController.closeCurrentTab(_:)), to: nil, from: nil)
             }
-            .keyboardShortcut("w", modifiers: [.command])
+            .keyboardShortcut("w")
 
             Button("Close Editor") {
                 NSApp.sendAction(#selector(NSWindow.close), to: nil, from: nil)

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -36,6 +36,11 @@ struct FileCommands: Commands {
         }
 
         CommandGroup(replacing: .saveItem) {
+            Button("Close Tab") {
+                NSApp.sendAction(#selector(CodeEditWindowController.closeCurrentTab(_:)), to: nil, from: nil)
+            }
+            .keyboardShortcut("w", modifiers: [.command])
+
             Button("Close Editor") {
                 NSApp.sendAction(#selector(NSWindow.close), to: nil, from: nil)
             }

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -36,13 +36,8 @@ struct FileCommands: Commands {
         }
 
         CommandGroup(replacing: .saveItem) {
-            Button("Close Tab") {
-                NSApp.sendAction(#selector(NSWindow.close), to: nil, from: nil)
-            }
-            .keyboardShortcut("w")
-
             Button("Close Editor") {
-
+                NSApp.sendAction(#selector(NSWindow.close), to: nil, from: nil)
             }
             .keyboardShortcut("w", modifiers: [.control, .shift, .command])
 


### PR DESCRIPTION
### Description

The `command + w` shortcut closes the editor instead of the current file. The functionality to close the current file was already implemented in `CodeEdit/Features/Tabs/Views/TabBarItemView.swift`. The fix was to remove this shortcut from `CodeEdit/Features/WindowCommands/FileCommands.swift` where it explicitly closes the editor. I moved this code to the correct keyboard shortcut (⌃⇧⌘W) which is the same as the one in Xcode.

### Related Issues

Closes #1370 

### Checklist

- [x] I read and understood the contributing guide
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
