### PR TITLE
Removed closing animation for the tabs

### DIFF
--- a/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarItemView.swift
@@ -103,11 +103,7 @@ struct TabBarItemView: View {
     /// Close the current tab.
     func closeAction() {
         isAppeared = false
-        withAnimation(
-            .easeOut(duration: tabBarStyle == .native ? 0.15 : 0.20)
-        ) {
-            tabgroup.closeTab(item: item)
-        }
+        tabgroup.closeTab(item: item)
     }
 
     init(


### PR DESCRIPTION
### Description

Removes the animation when closing a file to be like Xcode.

### Related Issues

Closes #1073

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

The current animation when closing tabs:
![animation](https://github.com/CodeEditApp/CodeEdit/assets/29493784/88058a93-417e-491b-9aab-1781a617fb14)

How it looks now:
![no-animation](https://github.com/CodeEditApp/CodeEdit/assets/29493784/f7c31e80-49a1-4a31-9036-9a0896185204)

