### PR TITLE
feat: Improve Shell Integration Setup Process (#1387)

### DIFF
--- a/CodeEdit/Features/DebugArea/Views/DebugAreaTerminalTab.swift
+++ b/CodeEdit/Features/DebugArea/Views/DebugAreaTerminalTab.swift
@@ -19,7 +19,7 @@ struct DebugAreaTerminalTab: View {
     @FocusState private var isFocused: Bool
 
     var body: some View {
-        var terminalTitle = Binding<String>(
+        let terminalTitle = Binding<String>(
             get: {
                 self.terminal.title
             }, set: {

--- a/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
+++ b/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
@@ -92,15 +92,6 @@ struct TerminalEmulatorView: NSViewRepresentable {
         }
     }
 
-    private func setupShellTitle(shell: String) {
-        if let shellSetupScript = Bundle.main.url(forResource: "codeedit_shell_integration", withExtension: shell) {
-            let scriptPath = (shellSetupScript.absoluteString[7..<shellSetupScript.absoluteString.count]) ?? ""
-            terminal.send(txt: "source \(scriptPath)\n")
-        }
-
-        terminal.send(txt: "clear\n")
-    }
-
     private func getTerminalCursor() -> CursorStyle {
             let blink = terminalSettings.cursorBlink
             switch terminalSettings.cursorStyle {
@@ -126,6 +117,84 @@ struct TerminalEmulatorView: NSViewRepresentable {
 
         if getpwuid_r(getuid(), &pwd, buffer, bufsize, &result) != 0 { return "/bin/bash" }
         return String(cString: pwd.pw_shell)
+    }
+
+    /// Check if the source command for shell integration already exists
+    /// Returns true if it already exists or encountered an error, so no new commands will be added to user's source file
+    /// Returns false if it's not there, new commands will be added to user's source file
+    private func shellIntegrationInstalled(sourceScriptPath: String, command: String) -> Bool {
+        do {
+            // Get user's shell's source file
+            let sourceScript = try String(contentsOfFile: sourceScriptPath)
+            let sourceScriptSeperatedByLines = sourceScript.components(separatedBy: .newlines)
+            // Check line by line
+            for line in sourceScriptSeperatedByLines where line == command {
+                // If one line matches the command, no new commands are needed
+                return true
+            }
+            // If no line matches the command, new command is needed
+            return false
+        } catch {
+            if let error = error as NSError? {
+                switch error._code {
+                case 260:
+                    // If error 260 is thrown, it's just the source file is missing
+                    // Create a new file and add new command
+                    FileManager.default.createFile(atPath: sourceScriptPath, contents: nil, attributes: nil)
+                    return false
+                default:
+                    // Otherwise just abort the shell integration setup
+                    print("Cannot setup shell integration, error: \(error)")
+                    return true
+                }
+            }
+        }
+    }
+
+    /// Configure shell integration script
+    private func setupShellIntegration(shell: String, environment: [String]) {
+        // Get user's home dir
+        var homePath: String = ""
+        environment.forEach { value in
+            if value.starts(with: "HOME=") {
+                homePath = value
+            }
+        }
+        homePath.removeSubrange(homePath.startIndex..<homePath.index(homePath.startIndex, offsetBy: 5))
+
+        if let shellIntegrationScript = Bundle.main.url(
+            forResource: "codeedit_shell_integration", withExtension: shell
+        ) {
+            // Get the path of shell integration script
+            let shellIntegrationScriptPath = (
+                shellIntegrationScript.absoluteString[7..<shellIntegrationScript.absoluteString.count]
+            ) ?? ""
+            
+            // Get the path of user's shell's source file
+            // Only zsh and bash are supported for now
+            var sourceScriptPath: String = ""
+            switch shell {
+            case "bash":
+                sourceScriptPath = homePath + "/.profile"
+            case "zsh":
+                sourceScriptPath = homePath + "/.zshrc"
+            default:
+                return
+            }
+
+            // Get the command for setting up shell integration
+            let sourceCommand = "[[ \"$TERM_PROGRAM\" == \"CodeEditApp_Terminal\" ]] &&"
+                            + " . \"\(shellIntegrationScriptPath)\""
+
+            // Add the shell integration setup command if needed
+            if !shellIntegrationInstalled(sourceScriptPath: sourceScriptPath, command: sourceCommand) {
+                if let handle = FileHandle(forWritingAtPath: sourceScriptPath) {
+                    handle.seekToEndOfFile()
+                    handle.write("\n\(sourceCommand)\n".data(using: .utf8)!)
+                    handle.closeFile()
+                }
+            }
+        }
     }
 
     /// Returns true if the `option` key should be treated as the `meta` key.
@@ -214,8 +283,12 @@ struct TerminalEmulatorView: NSViewRepresentable {
             // multiple workspaces. This works for now but most probably will need
             // to be changed later on
             FileManager.default.changeCurrentDirectoryPath(url.path)
+
             var terminalEnvironment: [String] = Terminal.getEnvironmentVariables()
             terminalEnvironment.append("TERM_PROGRAM=CodeEditApp_Terminal")
+
+            setupShellIntegration(shell: shellName, environment: terminalEnvironment)
+
             terminal.startProcess(executable: shell, environment: terminalEnvironment, execName: shellIdiom)
             terminal.font = font
             terminal.configureNativeColors()
@@ -227,8 +300,6 @@ struct TerminalEmulatorView: NSViewRepresentable {
             terminal.cursorStyleChanged(source: terminal.getTerminal(), newStyle: getTerminalCursor())
             terminal.layer?.backgroundColor = .clear
             terminal.optionAsMetaKey = optionAsMeta
-
-            setupShellTitle(shell: shellName)
         }
         terminal.appearance = colorAppearance
         scroller?.isHidden = true

--- a/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
+++ b/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
@@ -286,7 +286,7 @@ struct TerminalEmulatorView: NSViewRepresentable {
 
             var terminalEnvironment: [String] = Terminal.getEnvironmentVariables()
             terminalEnvironment.append("TERM_PROGRAM=CodeEditApp_Terminal")
-            
+
             setupShellIntegration(shell: shellName, environment: terminalEnvironment)
 
             terminal.startProcess(executable: shell, environment: terminalEnvironment, execName: shellIdiom)

--- a/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
+++ b/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
@@ -214,7 +214,9 @@ struct TerminalEmulatorView: NSViewRepresentable {
             // multiple workspaces. This works for now but most probably will need
             // to be changed later on
             FileManager.default.changeCurrentDirectoryPath(url.path)
-            terminal.startProcess(executable: shell, execName: shellIdiom)
+            var terminalEnvironment: [String] = Terminal.getEnvironmentVariables()
+            terminalEnvironment.append("TERM_PROGRAM=CodeEditApp_Terminal")
+            terminal.startProcess(executable: shell, environment: terminalEnvironment, execName: shellIdiom)
             terminal.font = font
             terminal.configureNativeColors()
             terminal.installColors(self.colors)

--- a/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
+++ b/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
@@ -120,7 +120,7 @@ struct TerminalEmulatorView: NSViewRepresentable {
     }
 
     /// Check if the source command for shell integration already exists
-    /// Returns true if it already exists or encountered an error, so no new commands will be added to user's source file
+    /// Returns true if it already exists or encountered an error, no new commands will be added to user's source file
     /// Returns false if it's not there, new commands will be added to user's source file
     private func shellIntegrationInstalled(sourceScriptPath: String, command: String) -> Bool {
         do {
@@ -169,7 +169,7 @@ struct TerminalEmulatorView: NSViewRepresentable {
             let shellIntegrationScriptPath = (
                 shellIntegrationScript.absoluteString[7..<shellIntegrationScript.absoluteString.count]
             ) ?? ""
-            
+
             // Get the path of user's shell's source file
             // Only zsh and bash are supported for now
             var sourceScriptPath: String = ""
@@ -286,7 +286,7 @@ struct TerminalEmulatorView: NSViewRepresentable {
 
             var terminalEnvironment: [String] = Terminal.getEnvironmentVariables()
             terminalEnvironment.append("TERM_PROGRAM=CodeEditApp_Terminal")
-
+            
             setupShellIntegration(shell: shellName, environment: terminalEnvironment)
 
             terminal.startProcess(executable: shell, environment: terminalEnvironment, execName: shellIdiom)


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

In PR #1298 , some commands are executed automatically when creating a new terminal to let the terminal title change according to the program running. But these commands will be shown to the user during the setup process.

In this PR, I moved the shell integration setup commands into user's shell's source files (`~/.zshrc`, `~/.profile`, etc.) and moved the shell integration check & install into a dedicated function directly in our App (instead of having an shell script), so no commands needs to be executed in user's terminal when it's created.

This is briefly how it works:

1. The user created a terminal
2. A function is called to check if the user have our shell integration installed
3. 
	- If it's installed, nothing happens because our script is already sourced for every terminal running inside CodeEdit.
	- If it's not, add the source command in user's source file. It's done before the real terminal have been created, so the terminal created right after that and every other terminal created later will have the correct script sourced.

This still works for both zsh (with or without ohmyzsh) and bash.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* resolve #1387

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] The issues this PR addresses are related to each other
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->


https://github.com/CodeEditApp/CodeEdit/assets/72877496/186c3d48-e335-410f-9cee-4a7358b047e5

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
