### PR TITLE
fix:  Increase/Decrease Font Size command one step behind 🐞

### DIFF
--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -136,11 +136,11 @@ struct CodeFileView: View {
             guard let theme = newValue else { return }
             self.selectedTheme = theme
         }
-        .onChange(of: settingsFont) { _ in
+        .onChange(of: settingsFont) { newValue in
             font = NSFont(
                 name: settingsFont.name,
-                size: CGFloat(settingsFont.size)
-            ) ?? systemFont
+                size: CGFloat(newValue.size)
+            ) ?? systemFont.withSize(CGFloat(newValue.size))
         }
         .onChange(of: bracketHighlight) { _ in
             bracketPairHighlight = getBracketPairHighlight()


### PR DESCRIPTION
### Description
I have fixed an issue that consecutive increase/decrease font size commands, and then reversing once continues in the same direction on the first execution. Subsequent times works as expected. As an example:

<!DOCTYPE html>

Key Pressed | Result
-- | --
⌘+ | Font increases
⌘+ | Font increases
⌘+ | Font increases
⌘- | Font increases
⌘- | Font decreases
⌘- | Font decreases
⌘+ | Font decreases
⌘+ | Font increases


<!--- REQUIRED: Describe what changed in detail -->
I have set the font size to be the one from the newValue received, as when accessing it directly from settingsFont it will get the old one.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1396
* closes #1396


### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/53402452/35293def-8d2f-4a9e-8036-7ad9aade2e57



<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
