### PR TITLE
fix: Code highlights incorrectly disabled on files with extension name '.c++' 🐞

### DIFF
--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -152,10 +152,20 @@ struct CodeFileView: View {
             return .default
         }
         return codeFile.language ?? CodeLanguage.detectLanguageFrom(
-            url: url,
+            url: updatedURL(for: url),
             prefixBuffer: codeFile.content.getFirstLines(5),
             suffixBuffer: codeFile.content.getLastLines(5)
         )
+    }
+    // To solve the issue of not highlighting text of files with `c++` extensions
+    // as it doesn't recognize it as `cpp` files
+    private func updatedURL(for url: URL) -> URL {
+        switch url.pathExtension {
+        case "c++":
+            return url.deletingPathExtension().appendingPathExtension("cpp")
+        default:
+            return url
+        }
     }
 
     private func getBracketPairHighlight() -> BracketPairHighlight? {


### PR DESCRIPTION
### Description
I have fixed the issue of not highlighting text of files with `c++` extensions by changing the url given to the method that returns the CodeLanguage to be with `cpp` extension to correctly recognize it,
I think there would be a better solution to add `c++` extension to extensions on the `init` at `CodeLanguage` on `CodeEditLanguages` package.

```Swift
 /// A language structure for `C++`
    static let cpp: CodeLanguage = .init(
        id: .cpp,
        tsName: "cpp",
        extensions: ["cc", "cpp", "hpp", "h"],
        parentURL: CodeLanguage.c.queryURL,
        highlights: ["injections"]
    )
```

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1404
* closes #1404

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->
![Screenshot 2023-08-14 at 11 48 28 PM](https://github.com/CodeEditApp/CodeEdit/assets/53402452/bfd8dadc-64ee-4ce4-9306-e338d2ce8dcc)
![Screenshot 2023-08-14 at 11 48 47 PM](https://github.com/CodeEditApp/CodeEdit/assets/53402452/6fe2609c-5a11-417d-a98e-1d5c1e57d6ab)

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
