### PR TITLE
Added ability to focus a single editor

### DIFF
--- a/CodeEdit/Features/SplitView/Model/SplitViewData.swift
+++ b/CodeEdit/Features/SplitView/Model/SplitViewData.swift
@@ -66,6 +66,18 @@ final class SplitViewData: ObservableObject {
         }
     }
 
+    func getTabGroup(with id: TabGroupData.ID) -> TabGroup? {
+        for tabgroup in tabgroups {
+            if case .one(let tabGroupData) = tabgroup {
+                if tabGroupData.id == id {
+                    return tabgroup
+                }
+            }
+        }
+
+        return nil
+    }
+
     /// Flattens the splitviews.
     func flatten() {
         for index in tabgroups.indices {

--- a/CodeEdit/Features/Tabs/Models/TabManager.swift
+++ b/CodeEdit/Features/Tabs/Models/TabManager.swift
@@ -14,7 +14,7 @@ class TabManager: ObservableObject {
     /// Collection of all the tabgroups.
     @Published var tabGroups: TabGroup
 
-    @Published var focusActive: Bool
+    @Published var isFocusingActiveTabGroup: Bool
 
     /// The TabGroup with active focus.
     @Published var activeTabGroup: TabGroupData {
@@ -38,7 +38,7 @@ class TabManager: ObservableObject {
         self.activeTabGroup = tab
         self.activeTabGroupHistory.prepend { [weak tab] in tab }
         self.tabGroups = .horizontal(.init(.horizontal, tabgroups: [.one(tab)]))
-        self.focusActive = false
+        self.isFocusingActiveTabGroup = false
         switchToActiveTabGroup()
     }
 

--- a/CodeEdit/Features/Tabs/Models/TabManager.swift
+++ b/CodeEdit/Features/Tabs/Models/TabManager.swift
@@ -14,6 +14,8 @@ class TabManager: ObservableObject {
     /// Collection of all the tabgroups.
     @Published var tabGroups: TabGroup
 
+    @Published var focusActive: Bool
+
     /// The TabGroup with active focus.
     @Published var activeTabGroup: TabGroupData {
         didSet {
@@ -36,6 +38,7 @@ class TabManager: ObservableObject {
         self.activeTabGroup = tab
         self.activeTabGroupHistory.prepend { [weak tab] in tab }
         self.tabGroups = .horizontal(.init(.horizontal, tabgroups: [.one(tab)]))
+        self.focusActive = false
         switchToActiveTabGroup()
     }
 

--- a/CodeEdit/Features/Tabs/TabGroup/TabGroupData.swift
+++ b/CodeEdit/Features/Tabs/TabGroup/TabGroupData.swift
@@ -77,6 +77,11 @@ final class TabGroupData: ObservableObject, Identifiable {
         parent?.closeTabGroup(with: id)
     }
 
+    /// Gets the tabgroup.
+    func getTabGroup() -> TabGroup? {
+        return parent?.getTabGroup(with: id)
+    }
+
     /// Closes a tab in the tabgroup.
     /// This will also write any changes to the file on disk and will add the tab to the tab history.
     /// - Parameter item: the tab to close.

--- a/CodeEdit/Features/Tabs/Views/TabBarAccessory.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarAccessory.swift
@@ -13,19 +13,23 @@ struct TabBarAccessoryIcon: View {
     static let iconFont = Font.system(size: 14, weight: .regular, design: .default)
 
     private let icon: Image
+    private let isActive: Bool
     private let action: () -> Void
 
-    init(icon: Image, action: @escaping () -> Void) {
+    init(icon: Image, isActive: Bool = false, action: @escaping () -> Void) {
         self.icon = icon
+        self.isActive = isActive
         self.action = action
     }
 
     var body: some View {
         Button(
             action: action,
-            label: { icon }
+            label: {
+                icon
+            }
         )
-        .buttonStyle(.icon(size: 24))
+        .buttonStyle(.icon(isActive: isActive, size: 24))
     }
 }
 

--- a/CodeEdit/Features/Tabs/Views/TabBarView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarView.swift
@@ -459,7 +459,7 @@ struct TabBarView: View {
     // MARK: Accessories
 
     private var leadingAccessories: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: 0) {
             if let otherGroup = tabManager.tabGroups.findSomeTabGroup(except: tabgroup) {
                 TabBarAccessoryIcon(
                     icon: .init(systemName: "multiply"),
@@ -569,7 +569,7 @@ struct TabBarView: View {
         }
         .foregroundColor(.secondary)
         .buttonStyle(.plain)
-        .padding(.horizontal, 7)
+        .padding(.horizontal, 5)
         .opacity(activeState != .inactive ? 1.0 : 0.5)
         .frame(maxHeight: .infinity) // Fill out vertical spaces.
         .background {
@@ -580,10 +580,10 @@ struct TabBarView: View {
     }
 
     private var trailingAccessories: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: 0) {
             splitviewButton
         }
-        .padding(.horizontal, 10)
+        .padding(.horizontal, 7)
         .opacity(activeState != .inactive ? 1.0 : 0.5)
         .frame(maxHeight: .infinity) // Fill out vertical spaces.
         .background {

--- a/CodeEdit/Features/Tabs/Views/TabBarView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarView.swift
@@ -477,25 +477,25 @@ struct TabBarView: View {
                     }
                 )
                 .help("Close this Editor")
-                .disabled(tabManager.focusActive)
-                .opacity(tabManager.focusActive ? 0.5 : 1)
+                .disabled(tabManager.isFocusingActiveTabGroup)
+                .opacity(tabManager.isFocusingActiveTabGroup ? 0.5 : 1)
 
                 TabBarAccessoryIcon(
                     icon: .init(
-                        systemName: tabManager.focusActive
+                        systemName: tabManager.isFocusingActiveTabGroup
                         ? "arrow.down.forward.and.arrow.up.backward"
                         : "arrow.up.left.and.arrow.down.right"
                     ),
-                    isActive: tabManager.focusActive,
+                    isActive: tabManager.isFocusingActiveTabGroup,
                     action: {
-                        if !tabManager.focusActive {
+                        if !tabManager.isFocusingActiveTabGroup {
                             tabManager.activeTabGroup = tabgroup
                         }
-                        tabManager.focusActive.toggle()
+                        tabManager.isFocusingActiveTabGroup.toggle()
                     }
                 )
                 .help(
-                    tabManager.focusActive
+                    tabManager.isFocusingActiveTabGroup
                       ? "Unfocus this Editor"
                       : "Focus this Editor"
                 )
@@ -617,8 +617,8 @@ struct TabBarView: View {
             }
         }
         .buttonStyle(.icon)
-        .disabled(tabManager.focusActive)
-        .opacity(tabManager.focusActive ? 0.5 : 1)
+        .disabled(tabManager.isFocusingActiveTabGroup)
+        .opacity(tabManager.isFocusingActiveTabGroup ? 0.5 : 1)
     }
 
     func split(edge: Edge) {

--- a/CodeEdit/Features/Tabs/Views/TabBarView.swift
+++ b/CodeEdit/Features/Tabs/Views/TabBarView.swift
@@ -477,6 +477,28 @@ struct TabBarView: View {
                     }
                 )
                 .help("Close this Editor")
+                .disabled(tabManager.focusActive)
+                .opacity(tabManager.focusActive ? 0.5 : 1)
+
+                TabBarAccessoryIcon(
+                    icon: .init(
+                        systemName: tabManager.focusActive
+                        ? "arrow.down.forward.and.arrow.up.backward"
+                        : "arrow.up.left.and.arrow.down.right"
+                    ),
+                    isActive: tabManager.focusActive,
+                    action: {
+                        if !tabManager.focusActive {
+                            tabManager.activeTabGroup = tabgroup
+                        }
+                        tabManager.focusActive.toggle()
+                    }
+                )
+                .help(
+                    tabManager.focusActive
+                      ? "Unfocus this Editor"
+                      : "Focus this Editor"
+                )
 
                 Divider()
                     .frame(height: 10)
@@ -595,6 +617,8 @@ struct TabBarView: View {
             }
         }
         .buttonStyle(.icon)
+        .disabled(tabManager.focusActive)
+        .opacity(tabManager.focusActive ? 0.5 : 1)
     }
 
     func split(edge: Edge) {

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -42,15 +42,20 @@ struct WorkspaceView: View {
             VStack {
                 SplitViewReader { proxy in
                     SplitView(axis: .vertical) {
-                        EditorView(tabgroup: tabManager.tabGroups, focus: $focusedEditor)
-                            .collapsable()
-                            .collapsed($debugAreaModel.isMaximized)
-                            .frame(minHeight: 170 + 29 + 29)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .holdingPriority(.init(1))
-                            .safeAreaInset(edge: .bottom, spacing: 0) {
-                                StatusBarView(proxy: proxy)
-                            }
+                        EditorView(
+                            tabgroup: tabManager.focusActive
+                            ? tabManager.activeTabGroup.getTabGroup() ?? tabManager.tabGroups
+                            : tabManager.tabGroups,
+                            focus: $focusedEditor
+                        )
+                        .collapsable()
+                        .collapsed($debugAreaModel.isMaximized)
+                        .frame(minHeight: 170 + 29 + 29)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .holdingPriority(.init(1))
+                        .safeAreaInset(edge: .bottom, spacing: 0) {
+                            StatusBarView(proxy: proxy)
+                        }
                         DebugAreaView()
                             .collapsable()
                             .collapsed($debugAreaModel.isCollapsed)

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -43,7 +43,7 @@ struct WorkspaceView: View {
                 SplitViewReader { proxy in
                     SplitView(axis: .vertical) {
                         EditorView(
-                            tabgroup: tabManager.focusActive
+                            tabgroup: tabManager.isFocusingActiveTabGroup
                             ? tabManager.activeTabGroup.getTabGroup() ?? tabManager.tabGroups
                             : tabManager.tabGroups,
                             focus: $focusedEditor


### PR DESCRIPTION
### Description

Added focus editor button in the tab bar that is visible only when multiple editors exist. When clicking this button, it hides all other editors. When clicked again, it shows all other editors.

### Related Issues

- closes #1413

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/806104/3d0e8c9c-1169-4311-beca-077fd458e22e

### Note to reviewers

SwiftLint fixes to unrelated files are in #1412.
