### PR TITLE
Update file inspector data when expected

### DIFF
--- a/CodeEdit/Features/InspectorSidebar/Views/FileInspectorView.swift
+++ b/CodeEdit/Features/InspectorSidebar/Views/FileInspectorView.swift
@@ -29,6 +29,20 @@ struct FileInspectorView: View {
 
     @State var wrapLines: Bool = false
 
+    func updateFileOptions(_ textEditingOverride: SettingsData.TextEditingSettings? = nil) {
+        let textEditingSettings = textEditingOverride ?? textEditing
+        indentOption = file?.fileDocument?.indentOption ?? textEditingSettings.indentOption
+        defaultTabWidth = file?.fileDocument?.defaultTabWidth ?? textEditingSettings.defaultTabWidth
+        wrapLines = file?.fileDocument?.wrapLines ?? textEditingSettings.wrapLinesToEditorWidth
+    }
+
+    func updateInspectorSource() {
+        file = tabManager.activeTabGroup.selected
+        fileName = file?.name ?? ""
+        language = file?.fileDocument?.language
+        updateFileOptions()
+    }
+
     var body: some View {
         Group {
             if file != nil {
@@ -50,26 +64,20 @@ struct FileInspectorView: View {
                 NoSelectionInspectorView()
             }
         }
-        .onReceive(tabManager.activeTabGroup.objectWillChange) { _ in
-            file = tabManager.activeTabGroup.selected
-            fileName = file?.name ?? ""
-            language = file?.fileDocument?.language
-            indentOption = file?.fileDocument?.indentOption ?? textEditing.indentOption
-            defaultTabWidth = file?.fileDocument?.defaultTabWidth ?? textEditing.defaultTabWidth
-            wrapLines = file?.fileDocument?.wrapLines ?? textEditing.wrapLinesToEditorWidth
-        }
         .onAppear {
-            file = tabManager.activeTabGroup.selected
-            fileName = file?.name ?? ""
-            language = file?.fileDocument?.language
-            indentOption = file?.fileDocument?.indentOption ?? textEditing.indentOption
-            defaultTabWidth = file?.fileDocument?.defaultTabWidth ?? textEditing.defaultTabWidth
-            wrapLines = file?.fileDocument?.wrapLines ?? textEditing.wrapLinesToEditorWidth
+            updateInspectorSource()
+        }
+        .onReceive(tabManager.activeTabGroup.objectWillChange) { _ in
+            updateInspectorSource()
+        }
+        .onChange(of: tabManager.activeTabGroup) { _ in
+            updateInspectorSource()
+        }
+        .onChange(of: tabManager.activeTabGroup.selected) { _ in
+            updateInspectorSource()
         }
         .onChange(of: textEditing) { newValue in
-            indentOption = file?.fileDocument?.indentOption ?? newValue.indentOption
-            defaultTabWidth = file?.fileDocument?.defaultTabWidth ?? newValue.defaultTabWidth
-            wrapLines = file?.fileDocument?.wrapLines ?? newValue.wrapLinesToEditorWidth
+            updateFileOptions(newValue)
         }
     }
 


### PR DESCRIPTION
### Description

Updates the file in the inspector when 
- a new tab is selected
- a file is opened from the project navigator or open quickly overlay
- when a different editor is selected in a split layout

### Related Issues

n/a

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/806104/e8b4c993-f490-422b-9908-1cfb2ae9a11f
