### PR TITLE
Dim editors without focus

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		B6AB09A12AAABAAE0003A3A6 /* EditorTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AB09A02AAABAAE0003A3A6 /* EditorTabs.swift */; };
 		B6AB09A32AAABFEC0003A3A6 /* EditorTabBarLeadingAccessories.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AB09A22AAABFEC0003A3A6 /* EditorTabBarLeadingAccessories.swift */; };
 		B6AB09A52AAAC00F0003A3A6 /* EditorTabBarTrailingAccessories.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AB09A42AAAC00F0003A3A6 /* EditorTabBarTrailingAccessories.swift */; };
+		B6AB09B32AB919CF0003A3A6 /* View+actionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AB09B22AB919CF0003A3A6 /* View+actionBar.swift */; };
 		B6C6A42A297716A500A3D28F /* EditorTabCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C6A429297716A500A3D28F /* EditorTabCloseButton.swift */; };
 		B6C6A42E29771A8D00A3D28F /* EditorTabButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C6A42D29771A8D00A3D28F /* EditorTabButtonStyle.swift */; };
 		B6C6A43029771F7100A3D28F /* EditorTabBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C6A42F29771F7100A3D28F /* EditorTabBackground.swift */; };
@@ -816,6 +817,7 @@
 		B6AB09A02AAABAAE0003A3A6 /* EditorTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabs.swift; sourceTree = "<group>"; };
 		B6AB09A22AAABFEC0003A3A6 /* EditorTabBarLeadingAccessories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabBarLeadingAccessories.swift; sourceTree = "<group>"; };
 		B6AB09A42AAAC00F0003A3A6 /* EditorTabBarTrailingAccessories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabBarTrailingAccessories.swift; sourceTree = "<group>"; };
+		B6AB09B22AB919CF0003A3A6 /* View+actionBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+actionBar.swift"; sourceTree = "<group>"; };
 		B6C6A429297716A500A3D28F /* EditorTabCloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabCloseButton.swift; sourceTree = "<group>"; };
 		B6C6A42D29771A8D00A3D28F /* EditorTabButtonStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorTabButtonStyle.swift; sourceTree = "<group>"; };
 		B6C6A42F29771F7100A3D28F /* EditorTabBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabBackground.swift; sourceTree = "<group>"; };
@@ -2179,6 +2181,7 @@
 			children = (
 				B6CF632529E541520085880A /* Models */,
 				B61DA9DE29D929E100BF4A43 /* GeneralSettingsView.swift */,
+				B6AB09B22AB919CF0003A3A6 /* View+actionBar.swift */,
 			);
 			path = GeneralSettings;
 			sourceTree = "<group>";
@@ -3170,6 +3173,7 @@
 				B6AB09A12AAABAAE0003A3A6 /* EditorTabs.swift in Sources */,
 				04C3255B2801F86400C8DA2D /* ProjectNavigatorViewController.swift in Sources */,
 				587B9E6029301D8F00AC7927 /* GitLabOAuthRouter.swift in Sources */,
+				B6AB09B32AB919CF0003A3A6 /* View+actionBar.swift in Sources */,
 				6C05A8AF284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift in Sources */,
 				588847632992A2A200996D95 /* CEWorkspaceFile.swift in Sources */,
 				6C2C155D29B4F4E500EA60A5 /* SplitViewReader.swift in Sources */,

--- a/CodeEdit/Features/Editor/Views/EditorView.swift
+++ b/CodeEdit/Features/Editor/Views/EditorView.swift
@@ -11,6 +11,9 @@ struct EditorView: View {
     @AppSettings(\.general.showEditorPathBar)
     var showEditorPathBar
 
+    @AppSettings(\.general.dimEditorsWithoutFocus)
+    var dimEditorsWithoutFocus
+
     @ObservedObject var editor: Editor
 
     @FocusState.Binding var focus: Editor?
@@ -30,6 +33,7 @@ struct EditorView: View {
                            : 0
                         )
                     }
+                    .opacity(dimEditorsWithoutFocus && editor != editorManager.activeEditor ? 0.5 : 1)
             } else {
                 VStack {
                     Spacer()

--- a/CodeEdit/Features/Settings/Pages/GeneralSettings/GeneralSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/GeneralSettings/GeneralSettingsView.swift
@@ -381,24 +381,3 @@ private extension GeneralSettingsView {
         $0.timeStyle = .medium
     }
 }
-
-extension View {
-    func actionBar<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        self
-            .padding(.bottom, 24)
-            .overlay(alignment: .bottom) {
-                VStack(spacing: -1) {
-                    Divider()
-                    HStack(spacing: 0) {
-                        content()
-                            .buttonStyle(.icon(font: Font.system(size: 11, weight: .medium), size: 24))
-                    }
-                    .frame(height: 16)
-                    .padding(.vertical, 4)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .frame(height: 24)
-                .background(.separator)
-            }
-    }
-}

--- a/CodeEdit/Features/Settings/Pages/GeneralSettings/GeneralSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/GeneralSettings/GeneralSettingsView.swift
@@ -39,6 +39,7 @@ struct GeneralSettingsView: View {
                 fileIconStyle
                 tabBarStyle
                 showEditorPathBar
+                dimEditorsWithoutFocus
                 navigatorTabBarPosition
                 inspectorTabBarPosition
             }
@@ -106,6 +107,10 @@ private extension GeneralSettingsView {
 
     var showEditorPathBar: some View {
         Toggle("Show Path Bar", isOn: $settings.showEditorPathBar)
+    }
+
+    var dimEditorsWithoutFocus: some View {
+        Toggle("Dim editors without focus", isOn: $settings.dimEditorsWithoutFocus)
     }
 
     var fileExtensions: some View {

--- a/CodeEdit/Features/Settings/Pages/GeneralSettings/Models/GeneralSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/GeneralSettings/Models/GeneralSettings.swift
@@ -24,6 +24,9 @@ extension SettingsData {
         /// Show editor path bar
         var showEditorPathBar: Bool = true
 
+        /// Dims editors without focus
+        var dimEditorsWithoutFocus: Bool = false
+
         /// The show file extensions behavior of the app
         var fileExtensionsVisibility: FileExtensionsVisibility = .showAll
 
@@ -89,6 +92,10 @@ extension SettingsData {
                 Bool.self,
                 forKey: .showEditorPathBar
             ) ?? true
+            self.dimEditorsWithoutFocus = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .dimEditorsWithoutFocus
+            ) ?? false
             self.fileExtensionsVisibility = try container.decodeIfPresent(
                 FileExtensionsVisibility.self,
                 forKey: .fileExtensionsVisibility

--- a/CodeEdit/Features/Settings/Pages/GeneralSettings/View+actionBar.swift
+++ b/CodeEdit/Features/Settings/Pages/GeneralSettings/View+actionBar.swift
@@ -1,0 +1,29 @@
+//
+//  View+actionBar.swift
+//  CodeEdit
+//
+//  Created by Austin Condiff on 9/18/23.
+//
+
+import SwiftUI
+
+extension View {
+    func actionBar<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        self
+            .padding(.bottom, 24)
+            .overlay(alignment: .bottom) {
+                VStack(spacing: -1) {
+                    Divider()
+                    HStack(spacing: 0) {
+                        content()
+                            .buttonStyle(.icon(font: Font.system(size: 11, weight: .medium), size: 24))
+                    }
+                    .frame(height: 16)
+                    .padding(.vertical, 4)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(height: 24)
+                .background(.separator)
+            }
+    }
+}

--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -16,6 +16,8 @@ struct ViewCommands: Commands {
     var useNewWindowingSystem
     @AppSettings(\.general.showEditorPathBar)
     var showEditorPathBar
+    @AppSettings(\.general.dimEditorsWithoutFocus)
+    var dimEditorsWithoutFocus
 
     @State var windowController: CodeEditWindowController?
 
@@ -118,6 +120,8 @@ struct ViewCommands: Commands {
                 Button("\(showEditorPathBar ? "Hide" : "Show") Path Bar") {
                     showEditorPathBar.toggle()
                 }
+
+                Toggle("Dim editors without focus", isOn: $dimEditorsWithoutFocus)
 
                 Divider()
             }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Provide users the option to dim editors without focus. 
This adds a setting to toggle this functionality on or off (defaults to off). 
Adds a View menu item to toggle editor dimming.

### Related Issues

* closes #1422

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/806104/a42ac504-5877-464e-8bcf-87ce3675ce9f
