### PR TITLE
fix: Fix misplaced terminal icon in macOS Sonoma

### DIFF
--- a/CodeEdit/Features/UtilityArea/TerminalUtility/UtilityAreaTerminalTab.swift
+++ b/CodeEdit/Features/UtilityArea/TerminalUtility/UtilityAreaTerminalTab.swift
@@ -34,9 +34,16 @@ struct UtilityAreaTerminalTab: View {
         )
 
         Label {
-            TextField("Name", text: terminalTitle)
-                .focused($isFocused)
-                .padding(.leading, -8)
+            if #available(macOS 14, *) {
+                // Fix the icon misplacement issue introduced since macOS 14
+                TextField("Name", text: terminalTitle)
+                    .focused($isFocused)
+            } else {
+                // A padding is needed for macOS 13
+                TextField("Name", text: terminalTitle)
+                    .focused($isFocused)
+                    .padding(.leading, -8)
+            }
         } icon: {
             Image(systemName: "terminal")
         }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

There was a negative padding for `TextField`, which causes issues on macOS 14. But, removing it makes the gap (for macOS 13 and earlier) between the icon and the title too large, so there's a system specific check to not cause issue on older OS.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* fix #1432

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

![image](https://github.com/CodeEditApp/CodeEdit/assets/72877496/29ee4171-c6b5-48f2-b80a-68a8710b749c)

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
