### PR TITLE
Fixed inspector if >=5.9 or greater which now needs a viewModel

### DIFF
--- a/CodeEdit/WindowSplitView.swift
+++ b/CodeEdit/WindowSplitView.swift
@@ -47,7 +47,7 @@ struct WindowSplitView: View {
                         }
 #if swift(>=5.9) // Fix build on Xcode 14
                         .inspector(isPresented: $showInspector) {
-                            InspectorAreaView()
+                            InspectorAreaView(viewModel: InspectorAreaViewModel())
                                 .inspectorColumnWidth(min: 100, ideal: 200, max: 400)
                                 .toolbar {
                                     Spacer()


### PR DESCRIPTION
### Description

We forgot to add the viewModel argument in the Inspector which broke the build for those using Swift >= 5.9.