### PR TITLE
Fixes Welcome Window on macOS Sonoma

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -165,14 +165,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         window.makeKeyAndOrderFront(self)
         return true
     }
-    
+
     /// Tries to focus a window with specified sceneId
     /// - Parameter type: Id of a window to be focused.
     /// - Returns: `true` if window exist and focused, otherwise - `false`
     private func tryFocusWindow(id: SceneID) -> Bool {
         guard let window = NSApp.windows.filter({ $0.identifier?.rawValue == id.rawValue }).first
         else { return false }
-        
+
         window.makeKeyAndOrderFront(self)
         return true
     }

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -75,10 +75,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
     func handleOpen() {
         let behavior = Settings.shared.preferences.general.reopenBehavior
-
         switch behavior {
         case .welcome:
-            NSApp.openWindow(.welcome)
+            if !tryFocusWindow(id: .welcome) {
+                NSApp.openWindow(.welcome)
+            }
         case .openPanel:
             CodeEditDocumentController.shared.openDocument(self)
         case .newDocument:
@@ -161,6 +162,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         guard let window = NSApp.windows.filter({ ($0.contentView as? NSHostingView<T>) != nil }).first
         else { return false }
 
+        window.makeKeyAndOrderFront(self)
+        return true
+    }
+    
+    /// Tries to focus a window with specified sceneId
+    /// - Parameter type: Id of a window to be focused.
+    /// - Returns: `true` if window exist and focused, otherwise - `false`
+    private func tryFocusWindow(id: SceneID) -> Bool {
+        guard let window = NSApp.windows.filter({ $0.identifier?.rawValue == id.rawValue }).first
+        else { return false }
+        
         window.makeKeyAndOrderFront(self)
         return true
     }


### PR DESCRIPTION
### Description

Currently app tries to open welcome window which is already in `NSApp.windows`.
Added focus on welcome window if it exists in `NSApp.windows`

### Related Issues

* #1445 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
