### PR TITLE
Unsaved changes tab indicator

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		04540D5E27DD08C300E91B77 /* WorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */; };
 		04660F6A27E51E5C00477777 /* CodeEditWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6927E51E5C00477777 /* CodeEditWindowController.swift */; };
 		0485EB1F27E7458B00138301 /* WorkspaceCodeFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485EB1E27E7458B00138301 /* WorkspaceCodeFileView.swift */; };
-		04BC1CDE2AD9B4B000A83EA5 /* FileEditorTabCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BC1CDD2AD9B4B000A83EA5 /* FileEditorTabCloseButton.swift */; };
+		04BC1CDE2AD9B4B000A83EA5 /* EditorFileTabCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BC1CDD2AD9B4B000A83EA5 /* EditorFileTabCloseButton.swift */; };
 		04C3255B2801F86400C8DA2D /* ProjectNavigatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285FEC6D27FE4B4A00E57D53 /* ProjectNavigatorViewController.swift */; };
 		04C3255C2801F86900C8DA2D /* ProjectNavigatorMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285FEC7127FE4EEF00E57D53 /* ProjectNavigatorMenu.swift */; };
 		200412EF280F3EAC00BCAF5C /* HistoryInspectorNoHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200412EE280F3EAC00BCAF5C /* HistoryInspectorNoHistoryView.swift */; };
@@ -483,7 +483,7 @@
 		04660F6927E51E5C00477777 /* CodeEditWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditWindowController.swift; sourceTree = "<group>"; };
 		0468438427DC76E200F8E88E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0485EB1E27E7458B00138301 /* WorkspaceCodeFileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCodeFileView.swift; sourceTree = "<group>"; };
-		04BC1CDD2AD9B4B000A83EA5 /* FileEditorTabCloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEditorTabCloseButton.swift; sourceTree = "<group>"; };
+		04BC1CDD2AD9B4B000A83EA5 /* EditorFileTabCloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFileTabCloseButton.swift; sourceTree = "<group>"; };
 		200412EE280F3EAC00BCAF5C /* HistoryInspectorNoHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryInspectorNoHistoryView.swift; sourceTree = "<group>"; };
 		201169D62837B2E300F92B46 /* SourceControlNavigatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlNavigatorView.swift; sourceTree = "<group>"; };
 		201169D82837B31200F92B46 /* SourceControlSearchToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlSearchToolbar.swift; sourceTree = "<group>"; };
@@ -2332,9 +2332,9 @@
 				58AFAA272933C65C00482B53 /* Models */,
 				B6C6A42F29771F7100A3D28F /* EditorTabBackground.swift */,
 				B6C6A42D29771A8D00A3D28F /* EditorTabButtonStyle.swift */,
+				04BC1CDD2AD9B4B000A83EA5 /* EditorFileTabCloseButton.swift */,
 				B6C6A429297716A500A3D28F /* EditorTabCloseButton.swift */,
 				587FB98F29C1246400B519DD /* EditorTabView.swift */,
-				04BC1CDD2AD9B4B000A83EA5 /* FileEditorTabCloseButton.swift */,
 			);
 			path = Tab;
 			sourceTree = "<group>";
@@ -3207,7 +3207,7 @@
 				58D01C99293167DC00C5B6B4 /* String+MD5.swift in Sources */,
 				20EBB505280C329800F3A5DA /* HistoryInspectorItemView.swift in Sources */,
 				5878DAB2291D627C00DD95A3 /* EditorPathBarView.swift in Sources */,
-				04BC1CDE2AD9B4B000A83EA5 /* FileEditorTabCloseButton.swift in Sources */,
+				04BC1CDE2AD9B4B000A83EA5 /* EditorFileTabCloseButton.swift in Sources */,
 				6C6BD70129CD172700235D17 /* ExtensionsListView.swift in Sources */,
 				043C321627E3201F006AE443 /* WorkspaceDocument.swift in Sources */,
 				58F2EAEC292FB2B0004A9BDE /* IgnoredFiles.swift in Sources */,

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		04540D5E27DD08C300E91B77 /* WorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */; };
 		04660F6A27E51E5C00477777 /* CodeEditWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04660F6927E51E5C00477777 /* CodeEditWindowController.swift */; };
 		0485EB1F27E7458B00138301 /* WorkspaceCodeFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485EB1E27E7458B00138301 /* WorkspaceCodeFileView.swift */; };
+		04BC1CDE2AD9B4B000A83EA5 /* FileEditorTabCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BC1CDD2AD9B4B000A83EA5 /* FileEditorTabCloseButton.swift */; };
 		04C3255B2801F86400C8DA2D /* ProjectNavigatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285FEC6D27FE4B4A00E57D53 /* ProjectNavigatorViewController.swift */; };
 		04C3255C2801F86900C8DA2D /* ProjectNavigatorMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285FEC7127FE4EEF00E57D53 /* ProjectNavigatorMenu.swift */; };
 		200412EF280F3EAC00BCAF5C /* HistoryInspectorNoHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200412EE280F3EAC00BCAF5C /* HistoryInspectorNoHistoryView.swift */; };
@@ -482,6 +483,7 @@
 		04660F6927E51E5C00477777 /* CodeEditWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditWindowController.swift; sourceTree = "<group>"; };
 		0468438427DC76E200F8E88E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0485EB1E27E7458B00138301 /* WorkspaceCodeFileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCodeFileView.swift; sourceTree = "<group>"; };
+		04BC1CDD2AD9B4B000A83EA5 /* FileEditorTabCloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEditorTabCloseButton.swift; sourceTree = "<group>"; };
 		200412EE280F3EAC00BCAF5C /* HistoryInspectorNoHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryInspectorNoHistoryView.swift; sourceTree = "<group>"; };
 		201169D62837B2E300F92B46 /* SourceControlNavigatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlNavigatorView.swift; sourceTree = "<group>"; };
 		201169D82837B31200F92B46 /* SourceControlSearchToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlSearchToolbar.swift; sourceTree = "<group>"; };
@@ -2332,6 +2334,7 @@
 				B6C6A42D29771A8D00A3D28F /* EditorTabButtonStyle.swift */,
 				B6C6A429297716A500A3D28F /* EditorTabCloseButton.swift */,
 				587FB98F29C1246400B519DD /* EditorTabView.swift */,
+				04BC1CDD2AD9B4B000A83EA5 /* FileEditorTabCloseButton.swift */,
 			);
 			path = Tab;
 			sourceTree = "<group>";
@@ -3204,6 +3207,7 @@
 				58D01C99293167DC00C5B6B4 /* String+MD5.swift in Sources */,
 				20EBB505280C329800F3A5DA /* HistoryInspectorItemView.swift in Sources */,
 				5878DAB2291D627C00DD95A3 /* EditorPathBarView.swift in Sources */,
+				04BC1CDE2AD9B4B000A83EA5 /* FileEditorTabCloseButton.swift in Sources */,
 				6C6BD70129CD172700235D17 /* ExtensionsListView.swift in Sources */,
 				043C321627E3201F006AE443 /* WorkspaceDocument.swift in Sources */,
 				58F2EAEC292FB2B0004A9BDE /* IgnoredFiles.swift in Sources */,

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import UniformTypeIdentifiers
+import Combine
 
 /// An object containing all necessary information and actions for a specific file in the workspace
 ///
@@ -54,7 +55,16 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
     /// If the item already is the top-level ``CEWorkspaceFile`` this returns `nil`.
     var parent: CEWorkspaceFile?
 
-    var fileDocument: CodeFileDocument?
+    var fileDocument: CodeFileDocument? {
+        didSet {
+            fileDocumentSubject.send()
+        }
+    }
+    
+    var fileDocumentPublisher: AnyPublisher<Void, Never> {
+        fileDocumentSubject.eraseToAnyPublisher()
+    }
+    let fileDocumentSubject = PassthroughSubject<Void, Never>()
 
     var fileIdentifier = UUID().uuidString
 

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -60,11 +60,12 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
             fileDocumentSubject.send()
         }
     }
-    
+
+    /// Publisher for fileDocument property
     var fileDocumentPublisher: AnyPublisher<Void, Never> {
         fileDocumentSubject.eraseToAnyPublisher()
     }
-    let fileDocumentSubject = PassthroughSubject<Void, Never>()
+    private let fileDocumentSubject = PassthroughSubject<Void, Never>()
 
     var fileIdentifier = UUID().uuidString
 

--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -55,7 +55,10 @@ struct CodeFileView: View {
             .$content
             .dropFirst()
             .sink { _ in
-                codeFile.isDirty = true
+                // Publish only when changed
+                if !codeFile.isDirty {
+                    codeFile.isDirty = true
+                }
             }
             .store(in: &cancellables)
 

--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -54,17 +54,6 @@ struct CodeFileView: View {
         codeFile
             .$content
             .dropFirst()
-            .sink { _ in
-                // Publish only when changed
-                if !codeFile.isDirty {
-                    codeFile.isDirty = true
-                }
-            }
-            .store(in: &cancellables)
-
-        codeFile
-            .$content
-            .dropFirst()
             .debounce(
                 for: 0.25,
                 scheduler: DispatchQueue.main

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -242,9 +242,6 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
     @IBAction func saveDocument(_ sender: Any) {
         guard let codeFile = getSelectedCodeFile() else { return }
         codeFile.save(sender)
-        if codeFile.isDirty {
-            codeFile.isDirty = false
-        }
         workspace?.editorManager.activeEditor.temporaryTab = nil
     }
 

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -242,7 +242,9 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
     @IBAction func saveDocument(_ sender: Any) {
         guard let codeFile = getSelectedCodeFile() else { return }
         codeFile.save(sender)
-        codeFile.isDirty = false
+        if codeFile.isDirty {
+            codeFile.isDirty = false
+        }
         workspace?.editorManager.activeEditor.temporaryTab = nil
     }
 

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorFileTabCloseButton.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorFileTabCloseButton.swift
@@ -17,7 +17,7 @@ struct EditorFileTabCloseButton: View {
     @Binding var closeButtonGestureActive: Bool
     var item: CEWorkspaceFile
 
-    @State private var isDirty: Bool = false
+    @State private var isDocumentEdited: Bool = false
     @State private var id: Int = 0
 
     var body: some View {
@@ -27,18 +27,18 @@ struct EditorFileTabCloseButton: View {
             isDragging: isDragging,
             closeAction: closeAction,
             closeButtonGestureActive: $closeButtonGestureActive,
-            isDirty: isDirty
+            isDocumentEdited: isDocumentEdited
         )
         .id(id)
         // Detects if file document changed, when this view created item.fileDocument is nil
         .onReceive(item.fileDocumentPublisher, perform: { _ in
-            // Force rerender so isDirty publisher is updated
+            // Force rerender so isDocumentEdited publisher is updated
             self.id += 1
         })
         .onReceive(
-            item.fileDocument?.$isDirty.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()
+            item.fileDocument?.isDocumentEditedPublisher.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()
         ) { newValue in
-            self.isDirty = newValue
+            self.isDocumentEdited = newValue
         }
     }
 }

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorFileTabCloseButton.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorFileTabCloseButton.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 import Combine
 
-struct FileEditorTabCloseButton: View {
+struct EditorFileTabCloseButton: View {
     var isActive: Bool
     var isHoveringTab: Bool
     var isDragging: Bool

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabCloseButton.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabCloseButton.swift
@@ -13,7 +13,7 @@ struct EditorTabCloseButton: View {
     var isDragging: Bool
     var closeAction: () -> Void
     @Binding var closeButtonGestureActive: Bool
-    var isDirty: Bool = false
+    var isDocumentEdited: Bool = false
 
     @Environment(\.colorScheme)
     var colorScheme
@@ -29,15 +29,21 @@ struct EditorTabCloseButton: View {
     var body: some View {
         HStack(alignment: .center) {
             if tabBarStyle == .xcode {
-                Image(systemName: isDirty && !isHoveringTab ? "circlebadge.fill" : "xmark")
-                    .font(.system(size: isDirty && !isHoveringTab ? 9.5 : 11.5, weight: .regular, design: .rounded))
+                Image(systemName: isDocumentEdited && !isHoveringTab ? "circlebadge.fill" : "xmark")
+                    .font(
+                        .system(
+                            size: isDocumentEdited && !isHoveringTab ? 9.5 : 11.5,
+                            weight: .regular,
+                            design: .rounded
+                        )
+                    )
                     .foregroundColor(
                         isActive
                         ? colorScheme == .dark ? .primary : Color(.controlAccentColor)
                         : .secondary
                     )
             } else {
-                Image(systemName: isDirty && !isHoveringTab ? "circlebadge.fill" : "xmark")
+                Image(systemName: isDocumentEdited && !isHoveringTab ? "circlebadge.fill" : "xmark")
                     .font(.system(size: 9.5, weight: .medium, design: .rounded))
             }
         }
@@ -85,7 +91,7 @@ struct EditorTabCloseButton: View {
         }
         .accessibilityLabel(Text("Close"))
         // Only show when the mouse is hovering and there is no tab dragging.
-        .opacity((isHoveringTab || isDirty == true) && !isDragging ? 1 : 0)
+        .opacity((isHoveringTab || isDocumentEdited == true) && !isDragging ? 1 : 0)
         .animation(.easeInOut(duration: 0.08), value: isHoveringTab)
         .padding(.leading, 4)
     }

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabView.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabView.swift
@@ -160,7 +160,7 @@ struct EditorTabView: View {
             .overlay {
                 ZStack {
                     // Close Button with is file changed indicator
-                    FileEditorTabCloseButton(
+                    EditorFileTabCloseButton(
                         isActive: isActive,
                         isHoveringTab: isHovering,
                         isDragging: draggingTabId != nil || onDragTabId != nil,

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabView.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Combine
 
 struct EditorTabView: View {
 
@@ -46,8 +45,6 @@ struct EditorTabView: View {
     ///
     /// By default, this value is `false`. When the root view is appeared, it turns `true`.
     @State private var isAppeared: Bool = false
-
-    @State private var isDirty: Bool = false
 
     /// The expected tab width in native tab bar style.
     private var expectedWidth: CGFloat
@@ -162,20 +159,17 @@ struct EditorTabView: View {
             .padding(.horizontal, tabBarStyle == .native ? 28 : 23)
             .overlay {
                 ZStack {
-                    // Close Button
-                    EditorTabCloseButton(
+                    // Close Button with is file changed indicator
+                    FileEditorTabCloseButton(
                         isActive: isActive,
                         isHoveringTab: isHovering,
                         isDragging: draggingTabId != nil || onDragTabId != nil,
                         closeAction: closeAction,
                         closeButtonGestureActive: $closeButtonGestureActive,
-                        isDirty: isDirty
+                        item: item
                     )
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .onReceive(item.fileDocument?.$isDirty.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
-                    isDirty = item.fileDocument?.isDirty ?? false
-                }
             }
             .opacity(
                 // Inactive states for tab bar item content.

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Tab/FileEditorTabCloseButton.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Tab/FileEditorTabCloseButton.swift
@@ -1,0 +1,44 @@
+//
+//  FileEditorTabCloseButton.swift
+//  CodeEdit
+//
+//  Created by Albert Vinizhanau on 10/13/23.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+struct FileEditorTabCloseButton: View {
+    var isActive: Bool
+    var isHoveringTab: Bool
+    var isDragging: Bool
+    var closeAction: () -> Void
+    @Binding var closeButtonGestureActive: Bool
+    var item: CEWorkspaceFile
+
+    @State private var isDirty: Bool = false
+    @State private var id: Int = 0
+
+    var body: some View {
+        EditorTabCloseButton(
+            isActive: isActive,
+            isHoveringTab: isHoveringTab,
+            isDragging: isDragging,
+            closeAction: closeAction,
+            closeButtonGestureActive: $closeButtonGestureActive,
+            isDirty: isDirty
+        )
+        .id(id)
+        // Detects if file document changed, when this view created item.fileDocument is nil
+        .onReceive(item.fileDocumentPublisher, perform: { _ in
+            // Force rerender so isDirty publisher is updated
+            self.id += 1
+        })
+        .onReceive(
+            item.fileDocument?.$isDirty.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()
+        ) { newValue in
+            self.isDirty = newValue
+        }
+    }
+}


### PR DESCRIPTION
### Description

Changes to [1441](https://github.com/CodeEditApp/CodeEdit/pull/1441) PR

 * Added `fileDocumentPublisher` to `CEWorkspaceFile`, to detect when `fileDocument` changed (needed because initially it's nil)
* Added `isDocumentEditedPublisher` to `CodeFileDocument` and override for `updateChangeCount` methods (it is called when document changed/saved) to publish `isDocumentEdited` property.

### Related Issues

* #1437

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
