### PR TITLE
Project navigator files watch fixes

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
@@ -189,6 +189,7 @@ final class CEWorkspaceFileManager {
         DispatchQueue.main.async {
             var files: Set<CEWorkspaceFile> = []
             for event in events {
+                // Event returns file/folder that was changed, but in tree we need to update it's parent
                 let parent = "/" + event.path.split(separator: "/").dropLast().joined(separator: "/")
                 guard let parentItem = self.getFile(parent) else {
                     return
@@ -196,7 +197,7 @@ final class CEWorkspaceFileManager {
 
                 switch event.eventType {
                 case .changeInDirectory, .itemChangedOwner, .itemModified:
-                    // Can be ignored for now
+                    // Can be ignored for now, these I think not related to tree changes
                     continue
                 case .rootChanged:
                     // TODO: Handle workspace root changing.

--- a/CodeEdit/Features/CEWorkspace/Models/DirectoryEventStream.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/DirectoryEventStream.swift
@@ -86,7 +86,11 @@ class DirectoryEventStream {
             debounceDuration,
             FSEventStreamCreateFlags(
                 kFSEventStreamCreateFlagUseCFTypes
+                // This will listen for file changes
                 | kFSEventStreamCreateFlagFileEvents
+                // This provides additional information, like fileId,
+                // it is useful when file renamed, because it's firing to separate events with old and new path,
+                // but they can be linked by file id
                 | kFSEventStreamCreateFlagUseExtendedData
             )
         ) {
@@ -131,6 +135,7 @@ class DirectoryEventStream {
         var events: [Event] = []
 
         for (index, dictionary) in eventDictionaries.enumerated() {
+            // Get get file id use dictionary[kFSEventStreamEventExtendedFileIDKey] as? UInt64
             guard let path = dictionary[kFSEventStreamEventExtendedDataPathKey] as? String,
                   let event = getEventFromFlags(eventFlags[index])
             else {

--- a/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorModeSelector.swift
+++ b/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorModeSelector.swift
@@ -39,7 +39,7 @@ struct FindNavigatorModeSelector: View {
             if let firstMode = selectedMode.first {
                 newSelectedMode.append(contentsOf: [firstMode, searchMode])
                 if let thirdMode = searchMode.children.first {
-                    if let selectedThirdMode = selectedMode.third, (searchMode.children.contains(selectedThirdMode)) {
+                    if let selectedThirdMode = selectedMode.third, searchMode.children.contains(selectedThirdMode) {
                         newSelectedMode.append(selectedThirdMode)
                     } else {
                         newSelectedMode.append(thirdMode)

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
@@ -68,9 +68,12 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
         var controller: ProjectNavigatorViewController?
 
         func fileManagerUpdated(updatedItems: Set<CEWorkspaceFile>) {
+            guard let outlineView = controller?.outlineView else { return }
+
             for item in updatedItems {
-                controller?.outlineView?.reloadItem(item)
+                outlineView.reloadItem(item, reloadChildren: true)
             }
+
             controller?.updateSelection(itemID: workspace.editorManager.activeEditor.selectedTab?.id)
         }
 


### PR DESCRIPTION
### Description

I didn't find if there is a issue for this. But project navigator file watch was broken for me.
I decided to check if I can fix it.  Works great for me now (see attached screen recording). 

I updated `DirectoryEventStream` to listen for file changes instead of folders. This can be useful in other places for example when file modified, plus now it returns correct event type (previously it always returned `changeInDirectory` for me).

Fixed bug in files diff (`CEWorkspaceFileManager.rebuildFiles`): it somethings recreated `CEWorkspaceFile` for folders that already in `flattenedFileItems`

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [ ] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/CodeEditApp/CodeEdit/assets/42622715/eadd42b4-d0e8-4d85-a670-8a1a0535b540

