### PR TITLE
Red close button unsaved indicator

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -55,16 +55,16 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
     /// If the item already is the top-level ``CEWorkspaceFile`` this returns `nil`.
     var parent: CEWorkspaceFile?
 
-    private let fileDocumentSubject = PassthroughSubject<Void, Never>()
+    private let fileDocumentSubject = PassthroughSubject<CodeFileDocument?, Never>()
 
     var fileDocument: CodeFileDocument? {
         didSet {
-            fileDocumentSubject.send()
+            fileDocumentSubject.send(fileDocument)
         }
     }
 
     /// Publisher for fileDocument property
-    var fileDocumentPublisher: AnyPublisher<Void, Never> {
+    var fileDocumentPublisher: AnyPublisher<CodeFileDocument?, Never> {
         fileDocumentSubject.eraseToAnyPublisher()
     }
 

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -7,6 +7,7 @@
 
 import Cocoa
 import SwiftUI
+import Combine
 
 final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, ObservableObject {
     static let minSidebarWidth: CGFloat = 242
@@ -22,6 +23,8 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
     var navigatorSidebarViewModel: NavigatorSidebarViewModel?
 
     var splitViewController: NSSplitViewController!
+
+    internal var cancellables = [AnyCancellable]()
 
     init(window: NSWindow, workspace: WorkspaceDocument) {
         super.init(window: window)
@@ -45,6 +48,10 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
 
         setupToolbar()
         registerCommands()
+    }
+
+    deinit {
+        cancellables.forEach({ $0.cancel() })
     }
 
     @available(*, unavailable)
@@ -106,6 +113,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
         splitVC.addSplitViewItem(inspector)
 
         self.splitViewController = splitVC
+        self.listenToDocumentEdited(workspace: workspace)
     }
 
     private func setupToolbar() {


### PR DESCRIPTION
### Description

Support for window close unsaved indicator if any tabs have modified content. 
See screencast below for example.

Not sure if this a good solution, it's listening for all files `isDocumentEdited` and all tabs (if file modified and then tab closed before saving, we also need to recalculate if whole window is dirty)

### Related Issues

* #1437

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/CodeEditApp/CodeEdit/assets/42622715/b96c9514-823b-4887-b077-15eefd5634ca

