### PR TITLE
feat: use dedicated icon for rust files

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileIcon.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileIcon.swift
@@ -43,6 +43,7 @@ enum FileIcon {
         case mod
         case Makefile
         case ts
+        case rs
     }
     // swiftlint:enable identifier_name
 
@@ -92,6 +93,8 @@ enum FileIcon {
             return "m.square"
         case .Makefile:
             return "terminal"
+        case .rs:
+            return "r.square"
         default:
             return "doc"
         }
@@ -112,17 +115,19 @@ enum FileIcon {
         case .sh:
             return .green
         case .vue:
-            return Color(red: 0.255, green: 0.722, blue: 0.514, opacity: 1.000)
+            return Color(red: 0.255, green: 0.722, blue: 0.514, opacity: 1.0)
         case .h:
-            return Color(red: 0.667, green: 0.031, blue: 0.133, opacity: 1.000)
+            return Color(red: 0.667, green: 0.031, blue: 0.133, opacity: 1.0)
         case .m:
-            return Color(red: 0.271, green: 0.106, blue: 0.525, opacity: 1.000)
+            return Color(red: 0.271, green: 0.106, blue: 0.525, opacity: 1.0)
         case .go:
             return Color(red: 0.02, green: 0.675, blue: 0.757, opacity: 1.0)
         case .sum, .mod:
             return Color(red: 0.925, green: 0.251, blue: 0.478, opacity: 1.0)
         case .Makefile:
             return Color(red: 0.937, green: 0.325, blue: 0.314, opacity: 1.0)
+        case .rs:
+            return .orange
         default:
             return .accentColor
         }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Provides a dedicated icon for Rust files where the R in the square is provided
along with the color Orange.

### Related Issues

Theres no related issue.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [-] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [-] My changes are all related to the related issue above
- [-] I documented my code

### Screenshots

<img width="271" alt="tabs" src="https://github.com/CodeEditApp/CodeEdit/assets/34756077/536b5347-cf8f-4410-8beb-74840bc6a6f4">

<img width="274" alt="nav" src="https://github.com/CodeEditApp/CodeEdit/assets/34756077/3864c4aa-9e54-42f4-aabc-0bbac9b9119b">