### PR TITLE
Fix filter button overflow

### DIFF
--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
@@ -27,6 +27,7 @@ struct ProjectNavigatorToolbarBottom: View {
                 .padding(.leading, 10)
             HStack {
                 sortButton
+                    .padding(.leading, 5)
                 TextField("Filter", text: $filter)
                     .textFieldStyle(.plain)
                     .font(.system(size: 12))


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. --> 

### Description
* Filter button/icon on Project Navigation Toolbar is overflowing on the left.
* I fixed this by adding filter button some extra padding to the left (similar to the right padding added for Clear Filter button).

### Related Issues
* Closes #1468 

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [ ] I documented my code --> _Simple change so no documentation needed_

### Screenshots

| Before                                                                                                               | After                                                                                                                |
|----------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
| <img width="813" src="https://github.com/CodeEditApp/CodeEdit/assets/28783605/52412057-eff0-4166-af41-e3dae83c9051"> | <img width="813" src="https://github.com/CodeEditApp/CodeEdit/assets/28783605/388c6a9a-1d1a-4dfa-a0f8-82e41f9fc350"> |
| <img width="399" src="https://github.com/CodeEditApp/CodeEdit/assets/28783605/33662d79-3dd8-4764-b3d9-33effdd0dba9"> | <img width="399" src="https://github.com/CodeEditApp/CodeEdit/assets/28783605/37e26f1d-8b6a-4ddf-b5ae-0485bbea6e80"> |


<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
