### PR TITLE
Updating search keys in General Settings

### DIFF
--- a/CodeEdit/Features/Settings/Pages/GeneralSettings/Models/GeneralSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/GeneralSettings/Models/GeneralSettings.swift
@@ -1,5 +1,5 @@
 //
-//  GeneralPreferences.swift
+//  GeneralSettings.swift
 //  CodeEditModules/Settings
 //
 //  Created by Nanashi Li on 2022/04/08.
@@ -27,6 +27,8 @@ extension SettingsData {
                 "Appearance",
                 "File Icon Style",
                 "Tab Bar Style",
+                "Show Path Bar",
+                "Dim editors without focus",
                 "Navigator Tab Bar Position",
                 "Inspector Tab Bar Position",
                 "Show Issues",
@@ -38,7 +40,13 @@ extension SettingsData {
                 "File Extensions",
                 "Project Navigator Size",
                 "Find Navigator Detail",
-                "Issue Navigator Detail"
+                "Issue Navigator Detail",
+                "Show “Open With CodeEdit“ option in Finder",
+                "'codeedit' Shell command",
+                "Dialog Warnings",
+                "Check for updates",
+                "Automatically check for app updates",
+                "Include pre-release versions"
             ]
             .map { NSLocalizedString($0, comment: "") }
         }


### PR DESCRIPTION
### Description

Added the search keys required for CE's settings to be fully searchable.

Search Keys added:

- `Show Path Bar`: N/A
- `Dim editors without focus`: N/A
- `Issue Navigator Detail`: Might want to dim the text in a way that shows that this setting is disabled
- `Show “Open With CodeEdit“ option in Finder`: N/A
- `'codeedit' Shell command`: same as Issue Navigator Detail
- `Dialog Warnings`: same as 'codeedit' Shell comand and Issue Navigator Detail
- `Check for app updates`: N/A
- `Automatically check for app updates`: N/A
- `Include pre-release versions`: N/A

### Related Issues

No issue related but might be useful to have an issue that opens and closes when a new setting is being added. That way CE's settings remain fully searchable.

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

I won't provide any screenshots as this PR is quite self-explanatory, but if anybody needs it I'll upload one.
