### PR TITLE
feat: capability to open changed file in temp tab

### DIFF
--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Views/Changes/SourceControlNavigatorChangedFileView.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Views/Changes/SourceControlNavigatorChangedFileView.swift
@@ -8,7 +8,10 @@
 import SwiftUI
 
 struct SourceControlNavigatorChangedFileView: View {
+    @EnvironmentObject var workspace: WorkspaceDocument
+
     @ObservedObject var sourceControlManager: SourceControlManager
+
     var changedFile: CEWorkspaceFile
 
     var folder: String? {
@@ -67,8 +70,9 @@ struct SourceControlNavigatorChangedFileView: View {
                 Divider()
             }
             Group {
-                Button("Open in New Tab") {}
-                    .disabled(true) // TODO: Implementation Needed
+                Button("Open in New Tab") {
+                    openInTemporaryTab()
+                }
                 Button("Open in New Window") {}
                     .disabled(true) // TODO: Implementation Needed
                 Button("Open with External Editor") {}
@@ -85,6 +89,11 @@ struct SourceControlNavigatorChangedFileView: View {
             }
         }
         .padding(.horizontal)
+    }
+    
+    /// Opens the file in a new temporary tab
+    func openInTemporaryTab() {
+        self.workspace.editorManager.activeEditor.openTab(item: self.changedFile, asTemporary: true)
     }
 
     func toggleSelectedFileState() {

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Views/Changes/SourceControlNavigatorChangedFileView.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Views/Changes/SourceControlNavigatorChangedFileView.swift
@@ -90,7 +90,7 @@ struct SourceControlNavigatorChangedFileView: View {
         }
         .padding(.horizontal)
     }
-    
+
     /// Opens the file in a new temporary tab
     func openInTemporaryTab() {
         self.workspace.editorManager.activeEditor.openTab(item: self.changedFile, asTemporary: true)


### PR DESCRIPTION
### Description

Provides access to tho `workspace` to open a modified file from the Source Version Control
Panel.

### Related Issues

N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [-] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/34756077/84ef653f-6ea0-4357-ab06-97878d2d6b1c


