### PR TITLE
feat: discard changes support for `SourceControlToolbarBottom`

### DIFF
--- a/CodeEdit/Features/Git/Client/GitClient+Status.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+Status.swift
@@ -38,4 +38,9 @@ extension GitClient {
     func discardChanges(for file: URL) async throws {
         _ = try await run("restore \(file.relativePath)")
     }
+
+    /// Discard unstaged changes
+    func discardAllChanges() async throws {
+        _ = try await run("restore .")
+    }
 }

--- a/CodeEdit/Features/Git/SourceControlManager.swift
+++ b/CodeEdit/Features/Git/SourceControlManager.swift
@@ -151,7 +151,7 @@ final class SourceControlManager: ObservableObject {
             }
         }
     }
-    
+
     /// Discard changes for repository
     func discardAllChanges() {
         Task {

--- a/CodeEdit/Features/Git/SourceControlManager.swift
+++ b/CodeEdit/Features/Git/SourceControlManager.swift
@@ -151,6 +151,19 @@ final class SourceControlManager: ObservableObject {
             }
         }
     }
+    
+    /// Discard changes for repository
+    func discardAllChanges() {
+        Task {
+            do {
+                try await gitClient.discardAllChanges()
+                // TODO: Refresh content of active and unmodified document,
+                // requires CodeEditTextView changes
+            } catch {
+                await showAlertForError(title: "Failed to discard changes", error: error)
+            }
+        }
+    }
 
     /// Commit files selected by user
     func commit(message: String) async throws {

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/SourceControlToolbarBottom.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/SourceControlToolbarBottom.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct SourceControlToolbarBottom: View {
+    @EnvironmentObject private var workspace: WorkspaceDocument
+
     var body: some View {
         HStack(spacing: 0) {
             sourceControlMenu
@@ -23,8 +25,11 @@ struct SourceControlToolbarBottom: View {
 
     private var sourceControlMenu: some View {
         Menu {
-            Button("Discard Changes...") {}
-                .disabled(true) // TODO: Implementation Needed
+            Button("Discard Changes...") {
+                if discardChangesDialog() {
+                    print("Discard Changes")
+                }
+            }
             Button("Stash Changes...") {}
                 .disabled(true) // TODO: Implementation Needed
             Button("Commit...") {}
@@ -37,5 +42,18 @@ struct SourceControlToolbarBottom: View {
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .frame(maxWidth: 30)
+    }
+
+    /// Renders a Discarh Changes Dialog
+    func discardChangesDialog() -> Bool {
+        let alert = NSAlert()
+
+        alert.messageText = "Do you want to discard all uncommitted, local changes?"
+        alert.informativeText = "This operation cannot be undone."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Discard")
+        alert.addButton(withTitle: "Cancel")
+
+        return alert.runModal() == .alertFirstButtonReturn
     }
 }

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/SourceControlToolbarBottom.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/SourceControlToolbarBottom.swift
@@ -27,7 +27,7 @@ struct SourceControlToolbarBottom: View {
         Menu {
             Button("Discard Changes...") {
                 if discardChangesDialog() {
-                    print("Discard Changes")
+                    workspace.sourceControlManager?.discardAllChanges()
                 }
             }
             Button("Stash Changes...") {}

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/SourceControlToolbarBottom.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/SourceControlToolbarBottom.swift
@@ -25,7 +25,7 @@ struct SourceControlToolbarBottom: View {
 
     private var sourceControlMenu: some View {
         Menu {
-            Button("Discard Changes...") {
+            Button("Discard All Changes...") {
                 if discardChangesDialog() {
                     workspace.sourceControlManager?.discardAllChanges()
                 }

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/SourceControlToolbarBottom.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/SourceControlToolbarBottom.swift
@@ -44,7 +44,7 @@ struct SourceControlToolbarBottom: View {
         .frame(maxWidth: 30)
     }
 
-    /// Renders a Discarh Changes Dialog
+    /// Renders a Discard Changes Dialog
     func discardChangesDialog() -> Bool {
         let alert = NSAlert()
 


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Provides support to discard all unstagged changes in the repository by spawning tho
`git restore .` command.

### Related Issues

Based on todo.

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/34756077/2c45de60-ff3d-4bdf-889f-d3104a535e62

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
