### PR TITLE
FIX: When deleting a file from the project navigator, the alert says (Function) in place of the filename

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -167,7 +167,7 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
     }
 
     /// Returns the file name with optional extension (e.g.: `Package.swift`)
-    func fileName(typeHidden: Bool) -> String {
+    func fileName(typeHidden: Bool = false) -> String {
         typeHidden ? url.deletingPathExtension().lastPathComponent : name
     }
 

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
@@ -99,7 +99,7 @@ extension CEWorkspaceFileManager {
         let deleteConfirmation = NSAlert()
         let message: String
         if !file.isFolder || file.isEmptyFolder { // if its a file or an empty folder, call it by its name
-            message = String(describing: file.fileName())
+            message = file.fileName()
         } else {
             let childrenCount = try? fileManager.contentsOfDirectory(
                 at: file.url,

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
@@ -99,7 +99,7 @@ extension CEWorkspaceFileManager {
         let deleteConfirmation = NSAlert()
         let message: String
         if !file.isFolder || file.isEmptyFolder { // if its a file or an empty folder, call it by its name
-            message = file.fileName()
+            message = file.name
         } else {
             let childrenCount = try? fileManager.contentsOfDirectory(
                 at: file.url,

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
@@ -99,7 +99,7 @@ extension CEWorkspaceFileManager {
         let deleteConfirmation = NSAlert()
         let message: String
         if !file.isFolder || file.isEmptyFolder { // if its a file or an empty folder, call it by its name
-            message = String(describing: file.fileName)
+            message = String(describing: file.fileName())
         } else {
             let childrenCount = try? fileManager.contentsOfDirectory(
                 at: file.url,


### PR DESCRIPTION
Correcting function call to obtain the file name as a string – adding '()' for accurate results.

* closes #1487 

<img width="372" alt="Screenshot 2023-11-25 at 9 43 43 PM" src="https://github.com/CodeEditApp/CodeEdit/assets/83090745/e674afa5-9f35-4f8f-87f3-19765d142c8e">
