### PR TITLE
Fix issue #1488 | Utility area sidebar state specific to individual w…

### DIFF
--- a/CodeEdit/Features/UtilityArea/DebugUtility/UtilityAreaDebugView.swift
+++ b/CodeEdit/Features/UtilityArea/DebugUtility/UtilityAreaDebugView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct UtilityAreaDebugView: View {
     @EnvironmentObject private var model: UtilityAreaViewModel
-    
+
     @State var tabSelection = 0
 
     var body: some View {

--- a/CodeEdit/Features/UtilityArea/DebugUtility/UtilityAreaDebugView.swift
+++ b/CodeEdit/Features/UtilityArea/DebugUtility/UtilityAreaDebugView.swift
@@ -8,10 +8,12 @@
 import SwiftUI
 
 struct UtilityAreaDebugView: View {
+    @EnvironmentObject private var model: UtilityAreaViewModel
+    
     @State var tabSelection = 0
 
     var body: some View {
-        UtilityAreaTabView { _ in
+        UtilityAreaTabView(model: model.tabViewModel) { _ in
             Text("Nothing to debug")
                 .font(.system(size: 16))
                 .foregroundColor(.secondary)

--- a/CodeEdit/Features/UtilityArea/OutputUtility/UtilityAreaOutputView.swift
+++ b/CodeEdit/Features/UtilityArea/OutputUtility/UtilityAreaOutputView.swift
@@ -26,7 +26,7 @@ struct UtilityAreaOutputView: View {
     }
 
     var body: some View {
-        UtilityAreaTabView { _ in
+        UtilityAreaTabView(model: model.tabViewModel) { _ in
             Group {
                 if selectedOutputSource == nil {
                     Text("No output")

--- a/CodeEdit/Features/UtilityArea/TerminalUtility/UtilityAreaTerminalView.swift
+++ b/CodeEdit/Features/UtilityArea/TerminalUtility/UtilityAreaTerminalView.swift
@@ -121,7 +121,7 @@ struct UtilityAreaTerminalView: View {
     }
 
     var body: some View {
-        UtilityAreaTabView { tabState in
+        UtilityAreaTabView(model: model.tabViewModel) { tabState in
             ZStack {
                 if model.selectedTerminals.isEmpty {
                     Text("No Selection")

--- a/CodeEdit/Features/UtilityArea/ViewModels/UtilityAreaTabViewModel.swift
+++ b/CodeEdit/Features/UtilityArea/ViewModels/UtilityAreaTabViewModel.swift
@@ -15,6 +15,4 @@ class UtilityAreaTabViewModel: ObservableObject {
     @Published var hasLeadingSidebar: Bool = false
 
     @Published var hasTrailingSidebar: Bool = false
-
-    public static let shared: UtilityAreaTabViewModel = .init()
 }

--- a/CodeEdit/Features/UtilityArea/ViewModels/UtilityAreaViewModel.swift
+++ b/CodeEdit/Features/UtilityArea/ViewModels/UtilityAreaViewModel.swift
@@ -39,6 +39,9 @@ class UtilityAreaViewModel: ObservableObject {
 
     /// The tab bar items for the DebugAreaView
     @Published var tabItems: [UtilityAreaTab] = UtilityAreaTab.allCases
+    
+    /// The tab bar view model for UtilityAreaTabView
+    @Published var tabViewModel = UtilityAreaTabViewModel()
 
     /// Returns the font for status bar items to use
     private(set) var toolbarFont: Font = .system(size: 11, weight: .medium)

--- a/CodeEdit/Features/UtilityArea/ViewModels/UtilityAreaViewModel.swift
+++ b/CodeEdit/Features/UtilityArea/ViewModels/UtilityAreaViewModel.swift
@@ -39,7 +39,7 @@ class UtilityAreaViewModel: ObservableObject {
 
     /// The tab bar items for the DebugAreaView
     @Published var tabItems: [UtilityAreaTab] = UtilityAreaTab.allCases
-    
+
     /// The tab bar view model for UtilityAreaTabView
     @Published var tabViewModel = UtilityAreaTabViewModel()
 

--- a/CodeEdit/Features/UtilityArea/Views/UtilityAreaTabView.swift
+++ b/CodeEdit/Features/UtilityArea/Views/UtilityAreaTabView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct UtilityAreaTabView<Content: View, LeadingSidebar: View, TrailingSidebar: View>: View {
-    @ObservedObject var model: UtilityAreaTabViewModel = UtilityAreaTabViewModel.shared
+    @ObservedObject var model: UtilityAreaTabViewModel
 
     let content: (UtilityAreaTabViewModel) -> Content
     let leadingSidebar: (UtilityAreaTabViewModel) -> LeadingSidebar?
@@ -18,12 +18,15 @@ struct UtilityAreaTabView<Content: View, LeadingSidebar: View, TrailingSidebar: 
     let hasTrailingSidebar: Bool
 
     init(
+        model: UtilityAreaTabViewModel,
         @ViewBuilder content: @escaping (UtilityAreaTabViewModel) -> Content,
         @ViewBuilder leadingSidebar: @escaping (UtilityAreaTabViewModel) -> LeadingSidebar,
         @ViewBuilder trailingSidebar: @escaping (UtilityAreaTabViewModel) -> TrailingSidebar,
         hasLeadingSidebar: Bool = true,
         hasTrailingSidebar: Bool = true
     ) {
+        self.model = model
+
         self.content = content
         self.leadingSidebar = leadingSidebar
         self.trailingSidebar = trailingSidebar
@@ -32,10 +35,14 @@ struct UtilityAreaTabView<Content: View, LeadingSidebar: View, TrailingSidebar: 
         self.hasTrailingSidebar = hasTrailingSidebar
     }
 
-    init(@ViewBuilder content: @escaping (UtilityAreaTabViewModel) -> Content) where
+    init(
+        model: UtilityAreaTabViewModel,
+        @ViewBuilder content: @escaping (UtilityAreaTabViewModel) -> Content
+    ) where
         LeadingSidebar == EmptyView,
         TrailingSidebar == EmptyView {
         self.init(
+            model: model,
             content: content,
             leadingSidebar: { _ in EmptyView() },
             trailingSidebar: { _ in EmptyView() },
@@ -45,10 +52,12 @@ struct UtilityAreaTabView<Content: View, LeadingSidebar: View, TrailingSidebar: 
     }
 
     init(
+        model: UtilityAreaTabViewModel,
         @ViewBuilder content: @escaping (UtilityAreaTabViewModel) -> Content,
         @ViewBuilder leadingSidebar: @escaping (UtilityAreaTabViewModel) -> LeadingSidebar
     ) where TrailingSidebar == EmptyView {
         self.init(
+            model: model,
             content: content,
             leadingSidebar: leadingSidebar,
             trailingSidebar: { _ in EmptyView() },
@@ -57,10 +66,12 @@ struct UtilityAreaTabView<Content: View, LeadingSidebar: View, TrailingSidebar: 
     }
 
     init(
+        model: UtilityAreaTabViewModel,
         @ViewBuilder content: @escaping (UtilityAreaTabViewModel) -> Content,
         @ViewBuilder trailingSidebar: @escaping (UtilityAreaTabViewModel) -> TrailingSidebar
     ) where LeadingSidebar == EmptyView {
         self.init(
+            model: model,
             content: content,
             leadingSidebar: { _ in EmptyView() },
             trailingSidebar: trailingSidebar,


### PR DESCRIPTION

<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

When the user closes the utility area sidebar for one workspace, it closes the utility area sidebar for all workspaces.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1488 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

https://github.com/CodeEditApp/CodeEdit/assets/28269317/783a8efb-fb4d-4933-98cc-fdf4cc2397da