### PR TITLE
Remove list row separators between terminal tabs

### DIFF
--- a/CodeEdit/Features/UtilityArea/TerminalUtility/UtilityAreaTerminalView.swift
+++ b/CodeEdit/Features/UtilityArea/TerminalUtility/UtilityAreaTerminalView.swift
@@ -196,6 +196,7 @@ struct UtilityAreaTerminalView: View {
                         selectedIDs: model.selectedTerminals
                     )
                     .tag(terminal.id)
+                    .listRowSeparator(.hidden)
                 }
                 .onMove(perform: moveItems)
             }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Removed the dividers between the terminal tabs see screen recording below.

### Related Issues

* close #1485 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots
https://github.com/CodeEditApp/CodeEdit/assets/128280019/7398e485-aabe-47d2-828e-099ede59d503
