### PR TITLE
#1484 Search Results are in lowercases letters : Fixed

### DIFF
--- a/CodeEdit/Features/Documents/WorkspaceDocument+Search.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument+Search.swift
@@ -84,7 +84,7 @@ extension WorkspaceDocument {
                             return SearchResultMatchModel(
                                 lineNumber: lineNumber,
                                 file: CEWorkspaceFile(url: url),
-                                lineContent: String(noSpaceLine),
+                                lineContent: String(rawNoSpaceLine),
                                 keywordRange: range
                             )
                         }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

When conducting a search, I observed that the search results are displaying text in lowercase, deviating from the original case of the text.
Fix: While appending found cases to main result data, it should be in the same case as it is present in the actual file

### Related Issues

* closes CodeEditApp/CodeEdit/issues/1484


### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


![Screenshot 2023-11-26 at 9 09 46 PM](https://github.com/CodeEditApp/CodeEdit/assets/19923083/0a30cb7e-05db-4d48-9a3c-55f79e7ba918)
