### PR TITLE
Fix issue #1427 | UtilityAreaTerminal model changed to ObservableObject

### DIFF
--- a/CodeEdit/Features/UtilityArea/TerminalUtility/UtilityAreaTerminalTab.swift
+++ b/CodeEdit/Features/UtilityArea/TerminalUtility/UtilityAreaTerminalTab.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct UtilityAreaTerminalTab: View {
-    @Binding var terminal: UtilityAreaTerminal
+    @ObservedObject var terminal: UtilityAreaTerminal
 
     var removeTerminals: (_ ids: Set<UUID>) -> Void
 

--- a/CodeEdit/Features/UtilityArea/TerminalUtility/UtilityAreaTerminalView.swift
+++ b/CodeEdit/Features/UtilityArea/TerminalUtility/UtilityAreaTerminalView.swift
@@ -7,13 +7,13 @@
 
 import SwiftUI
 
-struct UtilityAreaTerminal: Identifiable, Equatable {
-    var id: UUID
-    var url: URL?
-    var title: String
-    var terminalTitle: String
-    var shell: String
-    var customTitle: Bool
+final class UtilityAreaTerminal: ObservableObject, Identifiable, Equatable {
+    let id: UUID
+    @Published var url: URL?
+    @Published var title: String
+    @Published var terminalTitle: String
+    @Published var shell: String
+    @Published var customTitle: Bool
 
     init(id: UUID, url: URL, title: String, shell: String) {
         self.id = id
@@ -22,6 +22,10 @@ struct UtilityAreaTerminal: Identifiable, Equatable {
         self.url = url
         self.shell = shell
         self.customTitle = false
+    }
+
+    static func == (lhs: UtilityAreaTerminal, rhs: UtilityAreaTerminal) -> Bool {
+        lhs.id == rhs.id
     }
 }
 
@@ -188,9 +192,9 @@ struct UtilityAreaTerminalView: View {
             )
         } leadingSidebar: { _ in
             List(selection: $model.selectedTerminals) {
-                ForEach($model.terminals, id: \.self.id) { $terminal in
+                ForEach(model.terminals, id: \.self.id) { terminal in
                     UtilityAreaTerminalTab(
-                        terminal: $terminal,
+                        terminal: terminal,
                         removeTerminals: model.removeTerminals,
                         isSelected: model.selectedTerminals.contains(terminal.id),
                         selectedIDs: model.selectedTerminals


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

1. When the user presses the "-" button to close the selected terminal tab, the app crashes. This was not happening everytime. The crash is reproducible if the app is idle for a while and then the tab was removed.
2. If a terminal tab is in editable state(rename state) and then remove/minus button is tapped the app crashes.

### Related Issues

closes https://github.com/CodeEditApp/CodeEdit/issues/1427

* #1427

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/CodeEditApp/CodeEdit/assets/28269317/02a2e841-d516-4f23-b766-ef5d07a5db2b

