### PR TITLE
Split string into lines not words

### DIFF
--- a/CodeEdit/Features/Documents/WorkspaceDocument+Search.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument+Search.swift
@@ -197,7 +197,7 @@ extension WorkspaceDocument {
             }
 
             await withTaskGroup(of: SearchResultMatchModel?.self) { group in
-                for (lineNumber, line) in string.components(separatedBy: .whitespacesAndNewlines).lazy.enumerated() {
+                for (lineNumber, line) in string.components(separatedBy: .newlines).lazy.enumerated() {
                     group.addTask {
                         let rawNoSpaceLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
                         let noSpaceLine = rawNoSpaceLine.lowercased()


### PR DESCRIPTION
In the search index PR, there's a tiny hiccup: `for (lineNumber, line) in string.components(separatedBy: .whitespacesAndNewlines)`. This loop divides the string into words, not lines. 
I replaced it with `.newlines`. Which also speeds the search up a bit more.
Sorry I missed that earlier 🫣

Old results:
<img width="277" alt="Screenshot 2023-12-04 at 7 40 11 PM" src="https://github.com/CodeEditApp/CodeEdit/assets/83090745/5787bfc7-fdda-4023-b5d6-7935cb7e2a9f">

Proper new results: 
<img width="285" alt="Screenshot 2023-12-04 at 7 43 04 PM" src="https://github.com/CodeEditApp/CodeEdit/assets/83090745/cfa51d15-34dc-4588-b54e-4393ab15cb1b">
