### PR TITLE
Add Indexing Progress, Index Off Main Thread

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -289,6 +289,8 @@
 		6C14CEB028777D3C001468FE /* FindNavigatorListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C14CEAF28777D3C001468FE /* FindNavigatorListViewController.swift */; };
 		6C14CEB32877A68F001468FE /* FindNavigatorMatchListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C14CEB22877A68F001468FE /* FindNavigatorMatchListCell.swift */; };
 		6C18620A298BF5A800C663EA /* RecentProjectsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C186209298BF5A800C663EA /* RecentProjectsListView.swift */; };
+		6C1CC9982B1E770B0002349B /* AsyncFileIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1CC9972B1E770B0002349B /* AsyncFileIterator.swift */; };
+		6C1CC99B2B1E7CBC0002349B /* FindNavigatorIndexBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1CC99A2B1E7CBC0002349B /* FindNavigatorIndexBar.swift */; };
 		6C2149412A1BB9AB00748382 /* LogStream in Frameworks */ = {isa = PBXBuildFile; productRef = 6C2149402A1BB9AB00748382 /* LogStream */; };
 		6C2C155829B4F49100EA60A5 /* SplitViewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2C155729B4F49100EA60A5 /* SplitViewItem.swift */; };
 		6C2C155A29B4F4CC00EA60A5 /* Variadic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2C155929B4F4CC00EA60A5 /* Variadic.swift */; };
@@ -786,6 +788,8 @@
 		6C14CEAF28777D3C001468FE /* FindNavigatorListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorListViewController.swift; sourceTree = "<group>"; };
 		6C14CEB22877A68F001468FE /* FindNavigatorMatchListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorMatchListCell.swift; sourceTree = "<group>"; };
 		6C186209298BF5A800C663EA /* RecentProjectsListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentProjectsListView.swift; sourceTree = "<group>"; };
+		6C1CC9972B1E770B0002349B /* AsyncFileIterator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncFileIterator.swift; sourceTree = "<group>"; };
+		6C1CC99A2B1E7CBC0002349B /* FindNavigatorIndexBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNavigatorIndexBar.swift; sourceTree = "<group>"; };
 		6C2C155729B4F49100EA60A5 /* SplitViewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewItem.swift; sourceTree = "<group>"; };
 		6C2C155929B4F4CC00EA60A5 /* Variadic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variadic.swift; sourceTree = "<group>"; };
 		6C2C155C29B4F4E500EA60A5 /* SplitViewReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewReader.swift; sourceTree = "<group>"; };
@@ -2135,6 +2139,7 @@
 		611191F82B08CC8000D4459B /* Indexer */ = {
 			isa = PBXGroup;
 			children = (
+				6C1CC9972B1E770B0002349B /* AsyncFileIterator.swift */,
 				611191F92B08CC9000D4459B /* SearchIndexer.swift */,
 				611191FB2B08CCB800D4459B /* SearchIndexer+AsyncController.swift */,
 				611191FF2B08CCD700D4459B /* SearchIndexer+Memory.swift */,
@@ -2692,6 +2697,7 @@
 			isa = PBXGroup;
 			children = (
 				D7012EE727E757850001E1EF /* FindNavigatorView.swift */,
+				6C1CC99A2B1E7CBC0002349B /* FindNavigatorIndexBar.swift */,
 				D7E201AF27E8C07300CB86D0 /* FindNavigatorSearchBar.swift */,
 				D7E201B127E8D50000CB86D0 /* FindNavigatorModeSelector.swift */,
 				6C14CEB12877A5BE001468FE /* FindNavigatorResultList */,
@@ -3196,6 +3202,7 @@
 				B6F0517029D9E36800D72287 /* LocationsSettingsView.swift in Sources */,
 				B62AEDDC2A27C1B3009A9F52 /* OSLogType+Color.swift in Sources */,
 				587B9E6329301D8F00AC7927 /* GitLabAccount.swift in Sources */,
+				6C1CC99B2B1E7CBC0002349B /* FindNavigatorIndexBar.swift in Sources */,
 				285FEC7027FE4B9800E57D53 /* ProjectNavigatorTableViewCell.swift in Sources */,
 				6CB9144B29BEC7F100BC47F2 /* (null) in Sources */,
 				587B9E7429301D8F00AC7927 /* URL+URLParameters.swift in Sources */,
@@ -3341,6 +3348,7 @@
 				04BA7C242AE2E7CD00584E1C /* SourceControlNavigatorSyncView.swift in Sources */,
 				587B9DA529300ABD00AC7927 /* PressActionsModifier.swift in Sources */,
 				6C147C4029A328BC0089B630 /* SplitViewData.swift in Sources */,
+				6C1CC9982B1E770B0002349B /* AsyncFileIterator.swift in Sources */,
 				587B9E9029301D8F00AC7927 /* BitBucketTokenRouter.swift in Sources */,
 				B6C6A42E29771A8D00A3D28F /* EditorTabButtonStyle.swift in Sources */,
 				58822525292C280D00E83CDE /* StatusBarMenuStyle.swift in Sources */,

--- a/CodeEdit/Features/Documents/Indexer/AsyncFileIterator.swift
+++ b/CodeEdit/Features/Documents/Indexer/AsyncFileIterator.swift
@@ -1,0 +1,48 @@
+//
+//  AsyncFileIterator.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 12/4/23.
+//
+
+import Foundation
+
+/// Given a list of file URLs, asynchronously fetches their contents and returns them iteratively.
+/// Returns files as a ``SearchIndexer/AsyncManager/TextFile`` struct, used to index workspaces.
+struct AsyncFileIterator: AsyncSequence, AsyncIteratorProtocol {
+    typealias TextFile = SearchIndexer.AsyncManager.TextFile
+    typealias Element = (TextFile, Int)
+
+    let fileURLs: [URL]
+    var currentIdx = 0
+
+    mutating func next() async -> Element? {
+        guard !Task.isCancelled else {
+            return nil
+        }
+
+        defer {
+            currentIdx += 1
+        }
+
+        // Loop until we either find a loadable file or run out of URLs
+        var foundContent: TextFile?
+        while foundContent == nil {
+            guard currentIdx < fileURLs.count else {
+                return nil
+            }
+
+            let fileURL = fileURLs[currentIdx]
+            if let content = try? String(contentsOf: fileURL) {
+                foundContent = TextFile(url: fileURL.standardizedFileURL, text: content)
+            } else {
+                currentIdx += 1
+            }
+        }
+        return (foundContent!, currentIdx)
+    }
+
+    func makeAsyncIterator() -> AsyncFileIterator {
+        self
+    }
+}

--- a/CodeEdit/Features/Documents/Indexer/SearchIndexer+AsyncController.swift
+++ b/CodeEdit/Features/Documents/Indexer/SearchIndexer+AsyncController.swift
@@ -44,7 +44,7 @@ extension SearchIndexer {
 
             return AsyncStream { configuration in
                 var moreResultsAvailable = true
-                while moreResultsAvailable {
+                while moreResultsAvailable && !Task.isCancelled {
                     let results = search.getNextSearchResultsChunk(limit: maxResults, timeout: timeout)
                     moreResultsAvailable = results.moreResultsAvailable
                     configuration.yield(results)

--- a/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorIndexBar.swift
+++ b/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorIndexBar.swift
@@ -1,0 +1,67 @@
+//
+//  FindNavigatorIndexBar.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 12/4/23.
+//
+
+import SwiftUI
+
+struct FindNavigatorIndexBar: View {
+    @ObservedObject private var state: WorkspaceDocument.SearchState
+    @State private var progress: Double = 0.0
+    @State private var shouldShow: Bool = false
+
+    init(state: WorkspaceDocument.SearchState) {
+        self.state = state
+    }
+
+    var body: some View {
+        Group {
+            if shouldShow {
+                HStack(alignment: .center) {
+                    ProgressView(value: progress, total: 1.0) {
+                        EmptyView()
+                    } currentValueLabel: {
+                        HStack {
+                            Text("Indexing \(Int(progress * 100))%")
+                                .font(.system(size: 10))
+                                .animation(.none)
+                        }
+                    }
+                }
+                .transition(.asymmetric(insertion: .identity, removal: .move(edge: .top).combined(with: .opacity)))
+            }
+        }
+        .onAppear {
+            updateWithNewStatus(state.indexStatus)
+        }
+        .onReceive(state.$indexStatus) { newStatus in
+            updateWithNewStatus(newStatus)
+        }
+    }
+
+    /// Updates the bar with a new status update.
+    /// - Parameter status: The new status.
+    private func updateWithNewStatus(_ status: WorkspaceDocument.SearchState.IndexStatus) {
+            switch status {
+            case .none:
+                self.progress = 0.0
+                shouldShow = false
+            case .indexing(let progress):
+                if shouldShow {
+                    withAnimation {
+                        self.progress = progress
+                    }
+                } else {
+                    shouldShow = true
+                    self.progress = progress
+                }
+            case .done:
+                self.progress = 1.0
+                withAnimation(.default.delay(0.3)) {
+                    shouldShow = false
+                }
+            }
+    }
+}

--- a/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorView.swift
+++ b/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorView.swift
@@ -33,6 +33,7 @@ struct FindNavigatorView: View {
             VStack {
                 FindNavigatorModeSelector(state: state)
                 FindNavigatorSearchBar(state: state, title: "", text: $searchText)
+                FindNavigatorIndexBar(state: state)
                 HStack {
                     Button {} label: {
                         Text("In Workspace")


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

- Explicitly do all indexing work off the main thread, including gathering file URLs.
- Add a published indexing progress variable.
- Add a progress bar for indexing that takes enough time. For most small projects this will never be shown, for large projects it's a helpful indicator.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* No issues.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

https://github.com/CodeEditApp/CodeEdit/assets/35942988/36690cd1-ea2f-4d1a-b790-3c3940c7492f

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
