### PR TITLE
Update To New Text View

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -271,7 +271,6 @@
 		615AA21A2B0CFD480013FCCC /* LazyStringLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615AA2192B0CFD480013FCCC /* LazyStringLoader.swift */; };
 		6C049A372A49E2DB00D42923 /* DirectoryEventStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C049A362A49E2DB00D42923 /* DirectoryEventStream.swift */; };
 		6C05A8AF284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */; };
-		6C092EC62A4E803300489202 /* CodeEditTextView in Frameworks */ = {isa = PBXBuildFile; productRef = 6C092EC52A4E803300489202 /* CodeEditTextView */; };
 		6C092EDA2A53A58600489202 /* EditorLayout+StateRestoration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C092ED92A53A58600489202 /* EditorLayout+StateRestoration.swift */; };
 		6C092EE02A53BFCF00489202 /* WorkspaceStateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C092EDF2A53BFCF00489202 /* WorkspaceStateKey.swift */; };
 		6C0D0C6829E861B000AE4D3F /* SettingsSidebarFix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0D0C6729E861B000AE4D3F /* SettingsSidebarFix.swift */; };
@@ -352,6 +351,7 @@
 		6CE622692A2A174A0013085C /* InspectorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE622682A2A174A0013085C /* InspectorTab.swift */; };
 		6CE6226B2A2A1C730013085C /* UtilityAreaTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE6226A2A2A1C730013085C /* UtilityAreaTab.swift */; };
 		6CE6226E2A2A1CDE0013085C /* NavigatorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE6226D2A2A1CDE0013085C /* NavigatorTab.swift */; };
+		6CE952DD2B29236C00C29C31 /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6CE952DC2B29236C00C29C31 /* CodeEditSourceEditor */; };
 		6CED16E42A3E660D000EC962 /* String+Lines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CED16E32A3E660D000EC962 /* String+Lines.swift */; };
 		6CFF967429BEBCC300182D6F /* FindCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFF967329BEBCC300182D6F /* FindCommands.swift */; };
 		6CFF967629BEBCD900182D6F /* FileCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFF967529BEBCD900182D6F /* FileCommands.swift */; };
@@ -990,11 +990,11 @@
 				6C0F3A3C2A1D0D5000223D19 /* CodeEditKit in Frameworks */,
 				6C5BE5222A3D5666002DA0FC /* WindowManagement in Frameworks */,
 				6C66C31329D05CDC00DE9ED2 /* GRDB in Frameworks */,
-				6C092EC62A4E803300489202 /* CodeEditTextView in Frameworks */,
 				58F2EB1E292FB954004A9BDE /* Sparkle in Frameworks */,
 				6C2149412A1BB9AB00748382 /* LogStream in Frameworks */,
 				6C147C4529A329350089B630 /* OrderedCollections in Frameworks */,
 				6C6BD6F429CD142C00235D17 /* CollectionConcurrencyKit in Frameworks */,
+				6CE952DD2B29236C00C29C31 /* CodeEditSourceEditor in Frameworks */,
 				5879828A292ED15F0085B254 /* SwiftTerm in Frameworks */,
 				6CDEFC9629E22C2700B7C684 /* Introspect in Frameworks */,
 				2816F594280CF50500DD548B /* CodeEditSymbols in Frameworks */,
@@ -2851,7 +2851,7 @@
 				6CDEFC9529E22C2700B7C684 /* Introspect */,
 				6C0F3A3B2A1D0D5000223D19 /* CodeEditKit */,
 				6C5BE5212A3D5666002DA0FC /* WindowManagement */,
-				6C092EC52A4E803300489202 /* CodeEditTextView */,
+				6CE952DC2B29236C00C29C31 /* CodeEditSourceEditor */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -2947,7 +2947,7 @@
 				6CDEFC9429E22C2700B7C684 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 				6C0F3A3A2A1D0D5000223D19 /* XCRemoteSwiftPackageReference "CodeEditKit" */,
 				6C5BE5202A3D5666002DA0FC /* XCRemoteSwiftPackageReference "SwiftUI-WindowManagement" */,
-				6C092EC42A4E803300489202 /* XCRemoteSwiftPackageReference "CodeEditTextView" */,
+				6CE952D92B2922F300C29C31 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */,
 			);
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
 			projectDirPath = "";
@@ -4356,6 +4356,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		6CE952D92B2922F300C29C31 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../CodeEditSourceEditor;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -4395,14 +4402,6 @@
 			requirement = {
 				kind = exactVersion;
 				version = 2.3.0;
-			};
-		};
-		6C092EC42A4E803300489202 /* XCRemoteSwiftPackageReference "CodeEditTextView" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CodeEditApp/CodeEditTextView";
-			requirement = {
-				kind = exactVersion;
-				version = 0.6.8;
 			};
 		};
 		6C0F3A3A2A1D0D5000223D19 /* XCRemoteSwiftPackageReference "CodeEditKit" */ = {
@@ -4484,11 +4483,6 @@
 			package = 58F2EB1C292FB954004A9BDE /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
 		};
-		6C092EC52A4E803300489202 /* CodeEditTextView */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6C092EC42A4E803300489202 /* XCRemoteSwiftPackageReference "CodeEditTextView" */;
-			productName = CodeEditTextView;
-		};
 		6C0F3A3B2A1D0D5000223D19 /* CodeEditKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 6C0F3A3A2A1D0D5000223D19 /* XCRemoteSwiftPackageReference "CodeEditKit" */;
@@ -4537,6 +4531,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6CDEFC9429E22C2700B7C684 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
 			productName = Introspect;
+		};
+		6CE952DC2B29236C00C29C31 /* CodeEditSourceEditor */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CE952D92B2922F300C29C31 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */;
+			productName = CodeEditSourceEditor;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -351,7 +351,7 @@
 		6CE622692A2A174A0013085C /* InspectorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE622682A2A174A0013085C /* InspectorTab.swift */; };
 		6CE6226B2A2A1C730013085C /* UtilityAreaTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE6226A2A2A1C730013085C /* UtilityAreaTab.swift */; };
 		6CE6226E2A2A1CDE0013085C /* NavigatorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE6226D2A2A1CDE0013085C /* NavigatorTab.swift */; };
-		6CE952DD2B29236C00C29C31 /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6CE952DC2B29236C00C29C31 /* CodeEditSourceEditor */; };
+		6CE952E32B29433500C29C31 /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6CE952E22B29433500C29C31 /* CodeEditSourceEditor */; };
 		6CED16E42A3E660D000EC962 /* String+Lines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CED16E32A3E660D000EC962 /* String+Lines.swift */; };
 		6CFF967429BEBCC300182D6F /* FindCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFF967329BEBCC300182D6F /* FindCommands.swift */; };
 		6CFF967629BEBCD900182D6F /* FileCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFF967529BEBCD900182D6F /* FileCommands.swift */; };
@@ -994,7 +994,7 @@
 				6C2149412A1BB9AB00748382 /* LogStream in Frameworks */,
 				6C147C4529A329350089B630 /* OrderedCollections in Frameworks */,
 				6C6BD6F429CD142C00235D17 /* CollectionConcurrencyKit in Frameworks */,
-				6CE952DD2B29236C00C29C31 /* CodeEditSourceEditor in Frameworks */,
+				6CE952E32B29433500C29C31 /* CodeEditSourceEditor in Frameworks */,
 				5879828A292ED15F0085B254 /* SwiftTerm in Frameworks */,
 				6CDEFC9629E22C2700B7C684 /* Introspect in Frameworks */,
 				2816F594280CF50500DD548B /* CodeEditSymbols in Frameworks */,
@@ -2851,7 +2851,7 @@
 				6CDEFC9529E22C2700B7C684 /* Introspect */,
 				6C0F3A3B2A1D0D5000223D19 /* CodeEditKit */,
 				6C5BE5212A3D5666002DA0FC /* WindowManagement */,
-				6CE952DC2B29236C00C29C31 /* CodeEditSourceEditor */,
+				6CE952E22B29433500C29C31 /* CodeEditSourceEditor */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -2947,7 +2947,7 @@
 				6CDEFC9429E22C2700B7C684 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 				6C0F3A3A2A1D0D5000223D19 /* XCRemoteSwiftPackageReference "CodeEditKit" */,
 				6C5BE5202A3D5666002DA0FC /* XCRemoteSwiftPackageReference "SwiftUI-WindowManagement" */,
-				6CE952D92B2922F300C29C31 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */,
+				6CE952E12B29433500C29C31 /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */,
 			);
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
 			projectDirPath = "";
@@ -4356,13 +4356,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		6CE952D92B2922F300C29C31 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../CodeEditSourceEditor;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -4460,6 +4453,14 @@
 				minimumVersion = 0.2.3;
 			};
 		};
+		6CE952E12B29433500C29C31 /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.7.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -4532,9 +4533,9 @@
 			package = 6CDEFC9429E22C2700B7C684 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
 			productName = Introspect;
 		};
-		6CE952DC2B29236C00C29C31 /* CodeEditSourceEditor */ = {
+		6CE952E22B29433500C29C31 /* CodeEditSourceEditor */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6CE952D92B2922F300C29C31 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */;
+			package = 6CE952E12B29433500C29C31 /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */;
 			productName = CodeEditSourceEditor;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "codeeditsourceeditor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor.git",
+      "state" : {
+        "revision" : "e08a43ea07861e42d42f317899df69bf8f0a0a54",
+        "version" : "0.7.0"
+      }
+    },
+    {
       "identity" : "codeeditsymbols",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditSymbols",

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -39,10 +39,10 @@
     {
       "identity" : "codeedittextview",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditTextView",
+      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "6a04ca72975b25b28829e419a43cce5cabb97891",
-        "version" : "0.6.8"
+        "revision" : "c867fed329b2b4ce91a13742e20626f50cf233bb",
+        "version" : "0.7.0"
       }
     },
     {
@@ -172,15 +172,6 @@
       }
     },
     {
-      "identity" : "sttextview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzyzanowskim/STTextView.git",
-      "state" : {
-        "revision" : "1046965bd62dc05cf17beb4b4e901cdae851395e",
-        "version" : "0.8.7"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -257,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/TextFormation",
       "state" : {
-        "revision" : "b4987856bc860643ac2c9cdbc7d5f3e9ade68377",
-        "version" : "0.8.1"
+        "revision" : "f6faed6abd768ae95b70d10113d4008a7cac57a7",
+        "version" : "0.8.2"
       }
     },
     {

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import CodeEditSourceEditor
 import CodeEditSymbols
 
 final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
@@ -102,7 +103,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
                         return
                     }
                     if line > 0, let document = document as? CodeFileDocument {
-                        document.cursorPosition = (line, column > 0 ? column : 1)
+                        document.cursorPositions = [CursorPosition(line: line, column: column > 0 ? column : 1)]
                     }
                 }
         }

--- a/CodeEdit/Features/CodeFile/CodeFile.swift
+++ b/CodeEdit/Features/CodeFile/CodeFile.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftUI
 import UniformTypeIdentifiers
 import QuickLookUI
-import CodeEditTextView
+import CodeEditSourceEditor
 import CodeEditLanguages
 import Combine
 
@@ -70,7 +70,7 @@ final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem {
         fileURL
     }
 
-    @Published var cursorPosition = (1, 1)
+    @Published var cursorPositions = [CursorPosition]()
 
     private let isDocumentEditedSubject = PassthroughSubject<Bool, Never>()
 

--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import CodeEditSourceEditor
 import CodeEditTextView
 import CodeEditLanguages
 import Combine
@@ -98,7 +99,7 @@ struct CodeFileView: View {
     @EnvironmentObject private var editor: Editor
 
     var body: some View {
-        CodeEditTextView(
+        CodeEditSourceEditor(
             $codeFile.content,
             language: getLanguage(),
             theme: selectedTheme.editor.editorTheme,
@@ -107,7 +108,7 @@ struct CodeFileView: View {
             indentOption: (codeFile.indentOption ?? indentOption).textViewOption(),
             lineHeight: lineHeightMultiple,
             wrapLines: codeFile.wrapLines ?? wrapLinesToEditorWidth,
-            cursorPosition: $codeFile.cursorPosition,
+            cursorPositions: $codeFile.cursorPositions,
             useThemeBackground: useThemeBackground,
             contentInsets: edgeInsets.nsEdgeInsets,
             isEditable: isEditable,

--- a/CodeEdit/Features/Git/SourceControlManager.swift
+++ b/CodeEdit/Features/Git/SourceControlManager.swift
@@ -221,7 +221,7 @@ final class SourceControlManager: ObservableObject {
             do {
                 try await gitClient.discardChanges(for: file.url)
                 // TODO: Refresh content of active and unmodified document,
-                // requires CodeEditTextView changes
+                // requires CodeEditSourceEditor changes
             } catch {
                 await showAlertForError(title: "Failed to discard changes", error: error)
             }
@@ -234,7 +234,7 @@ final class SourceControlManager: ObservableObject {
             do {
                 try await gitClient.discardAllChanges()
                 // TODO: Refresh content of active and unmodified document,
-                // requires CodeEditTextView changes
+                // requires CodeEditSourceEditor changes
             } catch {
                 await showAlertForError(title: "Failed to discard changes", error: error)
             }

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/Theme.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/Theme.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import CodeEditTextView
+import CodeEditSourceEditor
 
 // swiftlint:disable file_length
 


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

- Updates CodeEditTextView to the new CodeEditSourceEditor repository, which includes a new text view.
- **Drastically** improves performance when opening and editing files (128ms opening time for `sqlite3.c`, fast editing no matter how large the file).
- Fixes stuttering when scrolling through files.
- Implements a new gutter view.
- Adds ability to open a file at either a line/column or at a selection range, and supports multiple cursors (related: #1504).
- Improves support for multiple-cursors.
- Adds a new API for managing, updating, and listening to editor text. In the future this should be used to update text for instance if the file's contents change.

### Related Issues

- Closes #1379
- Closes #1008 
- Fixes an issue with the URL scheme, there is no issue for this but it fixes the ability to open a file at a specific line and column.
- Related to #1385

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Fast scrolling, editing, loading of any size file. Files used are: (`sqlite3.c` 150k LOC, and the Russian/English dictionary 15MB)

https://github.com/CodeEditApp/CodeEdit/assets/35942988/cca6b656-ff92-4fd9-bdc6-7758ee0a4325

Opening a file from the command line opens to the correct line/column. Even updating an already opened file to the new cursor location.

https://github.com/CodeEditApp/CodeEdit/assets/35942988/9905c331-91d4-4bbb-bb56-abd7fe9e0b1d



