### PR TITLE
Git fetch improvement

### DIFF
--- a/CodeEdit/Features/Git/SourceControlManager.swift
+++ b/CodeEdit/Features/Git/SourceControlManager.swift
@@ -294,11 +294,9 @@ final class SourceControlManager: ObservableObject {
 
     /// Validate repository
     func validate() async throws {
-        Task {
-            let isGitRepository = try await gitClient.validate()
-            await MainActor.run {
-                self.isGitRepository = isGitRepository
-            }
+        let isGitRepository = await gitClient.validate()
+        await MainActor.run {
+            self.isGitRepository = isGitRepository
         }
     }
 

--- a/CodeEdit/Features/Git/SourceControlManager.swift
+++ b/CodeEdit/Features/Git/SourceControlManager.swift
@@ -18,9 +18,6 @@ final class SourceControlManager: ObservableObject {
     let editorManager: EditorManager
     weak var fileManager: CEWorkspaceFileManager?
 
-    // Timer for periodic fetch
-    private var fetchTimer: Timer?
-
     /// A list of changed files
     @Published var changedFiles: [CEWorkspaceFile] = []
 
@@ -116,27 +113,10 @@ final class SourceControlManager: ObservableObject {
         fileManager.notifyObservers(updatedItems: updatedStatusFor)
     }
 
-    /// Start periodic fetch with a specified interval
-    func startPeriodicFetch(interval: TimeInterval) {
-        fetchTimer?.invalidate() // Invalidate any existing timer
-        fetch()
-        fetchTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
-            self?.fetch()
-        }
-    }
-
     /// Fetch from remote
-    func fetch() {
-        Task {
-            try await gitClient.fetchFromRemote()
-            await self.refreshNumberOfUnsyncedCommits()
-        }
-    }
-
-    /// Stops the periodic fetch
-    func stopPeriodicFetch() {
-        fetchTimer?.invalidate()
-        fetchTimer = nil
+    func fetch() async throws {
+        try await gitClient.fetchFromRemote()
+        await self.refreshNumberOfUnsyncedCommits()
     }
 
     /// Refresh current branch

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Views/SourceControlNavigatorView.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Views/SourceControlNavigatorView.swift
@@ -15,11 +15,15 @@ struct SourceControlNavigatorView: View {
             VStack(spacing: 0) {
                 SourcControlNavigatorTabs()
                     .environmentObject(sourceControlManager)
-                    .onAppear {
-                        sourceControlManager.startPeriodicFetch(interval: 10)
-                    }
-                    .onDisappear {
-                        sourceControlManager.stopPeriodicFetch()
+                    .task {
+                        do {
+                            while true {
+                                try await sourceControlManager.fetch()
+                                try await Task.sleep(for: .seconds(10))
+                            }
+                        } catch {
+                            // TODO: if source fetching fails, display message
+                        }
                     }
             }
             .safeAreaInset(edge: .bottom, spacing: 0) {


### PR DESCRIPTION
### Description

A small improvement for git fetching.

Previously, a timer was used to fetch the repo when the source control sidebar pane is active. This timer launches a new task, but doesn't keep track of it. When a fetch takes more than 10 seconds, the timer will start fetching again, but the previous fetch won't stop. Moreover, Task implicitly captures self, which is problematic in this case.

The periodic refresh function has been removed. Instead, a task is created in the view, and will repeatedly call the fetch method. The task gets cancelled when the view disappears.

When the fetch fails, an error message should be displayed. This wasn't handled previously, and isn't now, but a todo has been added and the try has been moved in a do block, instead of failing silently. (I'm assuming the error should be displayed in some kind of notification panel, which doesn't exist atm)

Additionally, an unneeded task has been removed.

### Related Issues
None

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code