### PR TITLE
Added real-time cursor location to status bar

### DIFF
--- a/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorLocationLabel.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorLocationLabel.swift
@@ -6,20 +6,89 @@
 //
 
 import SwiftUI
+import CodeEditSourceEditor
 
 struct StatusBarCursorLocationLabel: View {
     @Environment(\.controlActiveState)
     private var controlActive
 
     @EnvironmentObject private var model: UtilityAreaViewModel
+    @EnvironmentObject private var editorManager: EditorManager
+
+    @State private var file: CEWorkspaceFile?
+    @State private var cursorPositions: [CursorPosition]?
+
+    func updateSource() {
+        file = editorManager.activeEditor.selectedTab
+    }
+
+    func getLines(_ range: NSRange) -> Int {
+        if let fileDocument = file?.fileDocument {
+            let selection = fileDocument.content[range] ?? ""
+            let lines = selection.components(separatedBy: "\n")
+
+            return lines.count
+        }
+
+        return 0
+    }
+
+    func getLabel(_ cursorPositions: [CursorPosition]) -> String {
+        if cursorPositions.isEmpty {
+            return ""
+        }
+
+        if cursorPositions.count > 1 {
+            return "\(cursorPositions.count) selected ranges"
+        }
+
+        if cursorPositions[0].range.length > 0 {
+            let lineCount = getLines(cursorPositions[0].range)
+
+            if lineCount > 1 {
+                return "\(lineCount) lines"
+            }
+
+            return "\(cursorPositions[0].range.length) characters"
+        }
+
+        return "Line: \(cursorPositions[0].line)  Col: \(cursorPositions[0].column)"
+    }
 
     var body: some View {
-        Text("Line: \(model.cursorLocation.line)  Col: \(model.cursorLocation.column)")
-            .font(model.toolbarFont)
-            .foregroundColor(foregroundColor)
-            .fixedSize()
-            .lineLimit(1)
-            .onHover { isHovering($0) }
+        Group {
+            if let currentFile = file, let fileDocument = currentFile.fileDocument {
+                Group {
+                    if let cursorPositions = cursorPositions {
+                        Text(getLabel(cursorPositions))
+                    } else {
+                        EmptyView()
+                    }
+                }
+                .onReceive(fileDocument.$cursorPositions) { val in
+                    cursorPositions = val
+                }
+            } else {
+                EmptyView()
+            }
+        }
+        .font(model.toolbarFont)
+        .foregroundColor(foregroundColor)
+        .fixedSize()
+        .lineLimit(1)
+        .onHover { isHovering($0) }
+        .onAppear {
+            updateSource()
+        }
+        .onReceive(editorManager.activeEditor.objectWillChange) { _ in
+            updateSource()
+        }
+        .onChange(of: editorManager.activeEditor) { _ in
+            updateSource()
+        }
+        .onChange(of: editorManager.activeEditor.selectedTab) { _ in
+            updateSource()
+        }
     }
 
     private var foregroundColor: Color {


### PR DESCRIPTION
### Description

The real-time cursor position, selected character count, and selected line count is now displayed in the status bar.

### Related Issues

* #1513

### Checklist

- [x] Add cursor location (line and column)
- [x] Add character count
- [x] Add line count
- [x] Add selected range count (could not test because multiple cursors currently doesn't work)
---
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/806104/6eb50f6d-ec31-46a9-9961-06144e617069

https://github.com/CodeEditApp/CodeEdit/assets/806104/1696e28a-feb7-4180-adf3-a1b253272d52

https://github.com/CodeEditApp/CodeEdit/assets/806104/7cec28e4-95c8-4791-ab66-c8d102aaef77

