### PR TITLE
Fix Editor Focus, Undo/Redo, Speed Up Cursor Labels

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -119,7 +119,7 @@
 		58798237292E30B90085B254 /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58798230292E30B90085B254 /* FeedbackView.swift */; };
 		58798238292E30B90085B254 /* FeedbackWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58798232292E30B90085B254 /* FeedbackWindowController.swift */; };
 		5879824F292E78D80085B254 /* CodeFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58798248292E78D80085B254 /* CodeFileView.swift */; };
-		58798250292E78D80085B254 /* CodeFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58798249292E78D80085B254 /* CodeFile.swift */; };
+		58798250292E78D80085B254 /* CodeFileDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58798249292E78D80085B254 /* CodeFileDocument.swift */; };
 		58798251292E78D80085B254 /* OtherFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5879824B292E78D80085B254 /* OtherFileView.swift */; };
 		58798252292E78D80085B254 /* ImageFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5879824D292E78D80085B254 /* ImageFileView.swift */; };
 		58798284292ED0FB0085B254 /* TerminalEmulatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58798280292ED0FB0085B254 /* TerminalEmulatorView.swift */; };
@@ -646,7 +646,7 @@
 		58798230292E30B90085B254 /* FeedbackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
 		58798232292E30B90085B254 /* FeedbackWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedbackWindowController.swift; sourceTree = "<group>"; };
 		58798248292E78D80085B254 /* CodeFileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeFileView.swift; sourceTree = "<group>"; };
-		58798249292E78D80085B254 /* CodeFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeFile.swift; sourceTree = "<group>"; };
+		58798249292E78D80085B254 /* CodeFileDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeFileDocument.swift; sourceTree = "<group>"; };
 		5879824B292E78D80085B254 /* OtherFileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OtherFileView.swift; sourceTree = "<group>"; };
 		5879824D292E78D80085B254 /* ImageFileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageFileView.swift; sourceTree = "<group>"; };
 		58798280292ED0FB0085B254 /* TerminalEmulatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TerminalEmulatorView.swift; sourceTree = "<group>"; };
@@ -1624,7 +1624,7 @@
 			children = (
 				5879824C292E78D80085B254 /* Image */,
 				5879824A292E78D80085B254 /* Other */,
-				58798249292E78D80085B254 /* CodeFile.swift */,
+				58798249292E78D80085B254 /* CodeFileDocument.swift */,
 				58798248292E78D80085B254 /* CodeFileView.swift */,
 				6C5B63DD29C76213005454BA /* WindowCodeFileView.swift */,
 			);
@@ -3438,7 +3438,7 @@
 				6C97EBCC2978760400302F95 /* AcknowledgementsWindowController.swift in Sources */,
 				284DC84F2978B7B400BF2770 /* ContributorsView.swift in Sources */,
 				B62AEDC92A2704F3009A9F52 /* UtilityAreaTabView.swift in Sources */,
-				58798250292E78D80085B254 /* CodeFile.swift in Sources */,
+				58798250292E78D80085B254 /* CodeFileDocument.swift in Sources */,
 				5878DAA5291AE76700DD95A3 /* QuickOpenView.swift in Sources */,
 				201169D72837B2E300F92B46 /* SourceControlNavigatorView.swift in Sources */,
 				B6F0517929D9E3C900D72287 /* SourceControlGitView.swift in Sources */,

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "c867fed329b2b4ce91a13742e20626f50cf233bb",
-        "version" : "0.7.0"
+        "revision" : "6abce20f1827a3665a5159195157f592352e38b4",
+        "version" : "0.7.1"
       }
     },
     {

--- a/CodeEdit/Features/CodeFile/CodeFileDocument.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileDocument.swift
@@ -154,7 +154,7 @@ final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem {
 
     class RangeTranslator: TextViewCoordinator {
         private weak var textViewController: TextViewController?
-        
+
         /// Returns the lines contained in the given range.
         /// - Parameter range: The range to use.
         /// - Returns: The number of lines contained by the given range. Or `0` if the text view could not be found,
@@ -166,7 +166,7 @@ final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem {
                   let textView = scrollView.documentView as? TextView,
                   // Find the lines at the beginning and end of the range
                   let startTextLine = textView.layoutManager.textLineForOffset(range.location),
-                  let endTextLine = textView.layoutManager.textLineForOffset(range.upperBound)else {
+                  let endTextLine = textView.layoutManager.textLineForOffset(range.upperBound) else {
                 return 0
             }
             return (endTextLine.index - startTextLine.index) + 1

--- a/CodeEdit/Features/CodeFile/CodeFileDocument.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileDocument.swift
@@ -11,6 +11,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 import QuickLookUI
 import CodeEditSourceEditor
+import CodeEditTextView
 import CodeEditLanguages
 import Combine
 
@@ -71,6 +72,8 @@ final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem {
     }
 
     @Published var cursorPositions = [CursorPosition]()
+
+    var rangeTranslator: RangeTranslator = RangeTranslator()
 
     private let isDocumentEditedSubject = PassthroughSubject<Bool, Never>()
 
@@ -147,5 +150,34 @@ final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem {
         }
 
         self.isDocumentEditedSubject.send(self.isDocumentEdited)
+    }
+
+    class RangeTranslator: TextViewCoordinator {
+        private weak var textViewController: TextViewController?
+        
+        /// Returns the lines contained in the given range.
+        /// - Parameter range: The range to use.
+        /// - Returns: The number of lines contained by the given range. Or `0` if the text view could not be found,
+        ///            or lines could not be found for the given range.
+        func linesInRange(_ range: NSRange) -> Int {
+            // TODO: textView should be public, workaround for now
+            guard let controller = textViewController,
+                  let scrollView = controller.view as? NSScrollView,
+                  let textView = scrollView.documentView as? TextView,
+                  // Find the lines at the beginning and end of the range
+                  let startTextLine = textView.layoutManager.textLineForOffset(range.location),
+                  let endTextLine = textView.layoutManager.textLineForOffset(range.upperBound)else {
+                return 0
+            }
+            return (endTextLine.index - startTextLine.index) + 1
+        }
+
+        func prepareCoordinator(controller: TextViewController) {
+            self.textViewController = controller
+        }
+
+        func destroy() {
+            self.textViewController = nil
+        }
     }
 }

--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -114,7 +114,8 @@ struct CodeFileView: View {
             isEditable: isEditable,
             letterSpacing: letterSpacing,
             bracketPairHighlight: bracketPairHighlight,
-            undoManager: undoManager
+            undoManager: undoManager,
+            coordinators: [codeFile.rangeTranslator]
         )
 
         .id(codeFile.fileURL)

--- a/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorLocationLabel.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorLocationLabel.swift
@@ -24,10 +24,7 @@ struct StatusBarCursorLocationLabel: View {
 
     func getLines(_ range: NSRange) -> Int {
         if let fileDocument = file?.fileDocument {
-            let selection = fileDocument.content[range] ?? ""
-            let lines = selection.components(separatedBy: "\n")
-
-            return lines.count
+            return fileDocument.rangeTranslator.linesInRange(range)
         }
 
         return 0


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

- Updates CETV to fix two bugs:
  - The editor did not return the correct view from hitTest, resulting in the editor not being able to receive firstResponder status.
  - The editor would not tell a new undo manager about itself, resulting in an undo manager that could not record undo/redo actions.
- Refactors @austincondiff's cursor labels to use the new `TextViewCoordinator` API to efficiently get the number of lines in ranges in the cursor label. The complexity of the calculation is no longer tied linearly to length (`O(log n)`).

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->
N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Finding the number of lines in a selection is instantaneous for any number of lines:

https://github.com/CodeEditApp/CodeEdit/assets/35942988/e4dce3d7-ce23-4405-b424-58d25f784ea8
