### PR TITLE
Open quickly overlay preview no longer clips the search bar

### DIFF
--- a/CodeEdit/Features/CodeEditUI/Views/OverlayView.swift
+++ b/CodeEdit/Features/CodeEditUI/Views/OverlayView.swift
@@ -119,6 +119,7 @@ struct OverlayView<RowView: View, PreviewView: View, Option: Identifiable & Hash
                         } else {
                             if let selection, let previewViewBuilder {
                                 previewViewBuilder(selection)
+                                    .clipped()
                                     .frame(maxWidth: .infinity)
                                     .transition(.move(edge: .trailing))
                             } else {


### PR DESCRIPTION
### Description

fixed the open quickly overlay preview line numbers background clipping the search bar

### Related Issues

* close #1538 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

see issue #1538 for a before video

https://github.com/CodeEditApp/CodeEdit/assets/128280019/5a9eb48f-d3ba-4a52-9450-d6fbd3ca10a1


