### PR TITLE
Fix Empty Editor State Bug

### DIFF
--- a/CodeEdit/Features/Editor/Models/EditorLayout+StateRestoration.swift
+++ b/CodeEdit/Features/Editor/Models/EditorLayout+StateRestoration.swift
@@ -21,6 +21,7 @@ extension EditorManager {
 
         guard !state.groups.isEmpty else {
             logger.warning("Empty Editor State found, restoring to clean editor state.")
+            initCleanState()
             return
         }
 

--- a/CodeEdit/Features/Editor/Models/EditorLayout.swift
+++ b/CodeEdit/Features/Editor/Models/EditorLayout.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum EditorLayout {
+enum EditorLayout: Equatable {
     case one(Editor)
     case vertical(SplitViewData)
     case horizontal(SplitViewData)
@@ -69,6 +69,30 @@ enum EditorLayout {
             } else {
                 data.flatten()
             }
+        }
+    }
+
+    var isEmpty: Bool {
+        switch self {
+        case .one:
+            return false
+        case .vertical(let splitViewData), .horizontal(let splitViewData):
+            return splitViewData.editorLayouts.allSatisfy { editorLayout in
+                editorLayout.isEmpty
+            }
+        }
+    }
+
+    static func == (lhs: EditorLayout, rhs: EditorLayout) -> Bool {
+        switch (lhs, rhs) {
+        case let (.one(lhs), .one(rhs)):
+            return lhs == rhs
+        case let (.vertical(lhs), .vertical(rhs)):
+            return lhs.editorLayouts == rhs.editorLayouts
+        case let (.horizontal(lhs), .horizontal(rhs)):
+            return lhs.editorLayouts == rhs.editorLayouts
+        default:
+            return false
         }
     }
 }

--- a/CodeEdit/Features/Editor/Models/EditorManager.swift
+++ b/CodeEdit/Features/Editor/Models/EditorManager.swift
@@ -46,7 +46,7 @@ class EditorManager: ObservableObject {
         self.isFocusingActiveEditor = false
         switchToActiveEditor()
     }
-    
+
     /// Initializes the editor manager's state to the "initial" state.
     ///
     /// Functionally identical to the initializer for this class.


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

If a workspace is closed via an application quit with a split editor, the editor will allow the user to close all editors when the app is re-opened. This leaves the workspace completely unresponsive with no active editor splits.

To fix, moved logic that should be in `EditorManager` into that class and cleaned up some files, then added a private state variable to `EditorTabBarLeadingAccessories` that tracks an "other" editor if it exists. It updates that state variable when the editor manager updates at all now instead of doing the check on a view update.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* N/A, discovered while implementing tests for the editor UI.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

`main` build, after quitting the app with a split open:

https://github.com/CodeEditApp/CodeEdit/assets/35942988/82632637-1ee9-4ee0-9f2e-f626709794d7

Fixed:

https://github.com/CodeEditApp/CodeEdit/assets/35942988/e119d857-85a0-45bc-ae1f-4ae6f5aa6e0b


