### PR TITLE
Updated Xcode themes

### DIFF
--- a/CodeEdit/DefaultThemes/codeedit-xcode-dark.json
+++ b/CodeEdit/DefaultThemes/codeedit-xcode-dark.json
@@ -9,52 +9,52 @@
     "description" : "Xcode dark theme.",
     "editor" : {
         "strings" : {
-            "color" : "#FC6A5D"
+            "color" : "#FF8A7A"
         },
         "comments" : {
-            "color" : "#73A74E"
+            "color" : "#8DBF67"
         },
         "numbers" : {
-            "color" : "#D0BF69"
+            "color" : "#D9C668"
         },
         "commands" : {
-            "color" : "#67B7A4"
+            "color" : "#83C9BC"
         },
         "lineHighlight" : {
-            "color" : "#23252B"
+            "color" : "#2F3139"
         },
         "values" : {
-            "color" : "#A167E6"
+            "color" : "#CDA1FF"
         },
         "background" : {
-            "color" : "#1F1F24"
+            "color" : "#201E24"
         },
         "keywords" : {
-            "color" : "#FF7AB3"
+            "color" : "#FF85B8"
         },
         "text" : {
-            "color" : "#D9D9D9"
+            "color" : "#FFFFFF"
         },
         "insertionPoint" : {
-            "color" : "#D9D9D9"
+            "color" : "#FFFFFF"
         },
         "selection" : {
-            "color" : "#515B70"
+            "color" : "#434D5D"
         },
         "types" : {
-            "color" : "#5DD8FF"
+            "color" : "#6BDFFF"
         },
         "variables" : {
-            "color" : "#41A1C0"
+            "color" : "#4EC4E6"
         },
         "attributes" : {
-            "color" : "#D0A8FF"
+            "color" : "#E8B68B"
         },
         "characters" : {
-            "color" : "#D0BF69"
+            "color" : "#D9C668"
         },
         "invisibles" : {
-            "color" : "#424D5B"
+            "color" : "#53606E"
         }
     },
     "terminal" : {
@@ -83,13 +83,13 @@
             "color" : "#28CD41"
         },
         "background" : {
-            "color" : "#1F2024"
+            "color" : "#1F1F24"
         },
         "cursor" : {
-            "color" : "#D9D9D9"
+            "color" : "#FFFFFF"
         },
         "selection" : {
-            "color" : "#515B70"
+            "color" : "#646F83"
         },
         "magenta" : {
             "color" : "#AF52DE"
@@ -98,7 +98,7 @@
             "color" : "#1F2024"
         },
         "text" : {
-            "color" : "#D9D9D9"
+            "color" : "#FFFFFF"
         },
         "brightWhite" : {
             "color" : "#FFFFFF"

--- a/CodeEdit/DefaultThemes/codeedit-xcode-light.json
+++ b/CodeEdit/DefaultThemes/codeedit-xcode-light.json
@@ -9,52 +9,52 @@
     "description" : "Xcode light theme.",
     "editor" : {
         "strings" : {
-            "color" : "#C41A16"
+            "color" : "#AD1805"
         },
         "comments" : {
-            "color" : "#267507"
+            "color" : "#1F6300"
         },
         "numbers" : {
-            "color" : "#1C00CF"
+            "color" : "#272AD8"
         },
         "commands" : {
-            "color" : "#326D74"
+            "color" : "#294B4E"
         },
         "lineHighlight" : {
-            "color" : "#E8F2FF"
+            "color" : "#ECF5FF"
         },
         "values" : {
-            "color" : "#6C36A9"
+            "color" : "#330090"
         },
         "background" : {
             "color" : "#FFFFFF"
         },
         "keywords" : {
-            "color" : "#9B2393"
+            "color" : "#9C2191"
         },
         "text" : {
-            "color" : "#262626"
+            "color" : "#000000"
         },
         "insertionPoint" : {
-            "color" : "#262626"
+            "color" : "#000000"
         },
         "selection" : {
-            "color" : "#A4CDFF"
+            "color" : "#B2D7FF"
         },
         "types" : {
-            "color" : "#0B4F79"
+            "color" : "#003F73"
         },
         "variables" : {
-            "color" : "#0F68A0"
+            "color" : "#0058A1"
         },
         "attributes" : {
-            "color" : "#3900A0"
+            "color" : "#6E5400"
         },
         "characters" : {
-            "color" : "#1C00CF"
+            "color" : "#272AD8"
         },
         "invisibles" : {
-            "color" : "#CCCCCC"
+            "color" : "#D6D6D6"
         }
     },
     "terminal" : {
@@ -86,10 +86,10 @@
             "color" : "#FFFFFF"
         },
         "cursor" : {
-            "color" : "#262626"
+            "color" : "#000000"
         },
         "selection" : {
-            "color" : "#A4CDFF"
+            "color" : "#B2D7FF"
         },
         "magenta" : {
             "color" : "#AF52DE"
@@ -98,7 +98,7 @@
             "color" : "#1F2024"
         },
         "text" : {
-            "color" : "#262626"
+            "color" : "#000000"
         },
         "brightWhite" : {
             "color" : "#FFFFFF"


### PR DESCRIPTION
### Description

Updated the Xcode themes' hex values to the equivalent GenericRGB colors used by default by Xcode.

### Related Issues

* #1461

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Before

<img width="1232" alt="Screenshot 2024-01-16 at 13 10 15" src="https://private-user-images.githubusercontent.com/806104/296794825-5a92bda0-3952-489e-b4ef-86392823c560.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDU0ODAzOTksIm5iZiI6MTcwNTQ4MDA5OSwicGF0aCI6Ii84MDYxMDQvMjk2Nzk0ODI1LTVhOTJiZGEwLTM5NTItNDg5ZS1iNGVmLTg2MzkyODIzYzU2MC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwMTE3JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDExN1QwODI4MTlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT05ZjI1OWYyOGM0ZjBiYmJlNTNmZGIzMWNmYTA2MTVkY2MyNWM1YzY2NWE3NDYxZDU1ODQwYTg5ODA1Yjg4NDQwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.2l7fc5uSUKjF9RXgUdvl81phTA9iovZuziWm_MLW5qo">

After

<img width="1232" alt="Screenshot 2024-01-16 at 13 10 15" src="https://github.com/CodeEditApp/CodeEdit/assets/1909987/c1360058-3399-441f-a4f9-4aef416f7734">
