### PR TITLE
Improved how bundled and user-defined themes are loaded in

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -438,24 +438,6 @@
 		B6C6A42A297716A500A3D28F /* EditorTabCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C6A429297716A500A3D28F /* EditorTabCloseButton.swift */; };
 		B6C6A42E29771A8D00A3D28F /* EditorTabButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C6A42D29771A8D00A3D28F /* EditorTabButtonStyle.swift */; };
 		B6C6A43029771F7100A3D28F /* EditorTabBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C6A42F29771F7100A3D28F /* EditorTabBackground.swift */; };
-		B6D26E6C2B686DE300B4C14F /* High Contrast (Light).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E5A2B686DE200B4C14F /* High Contrast (Light).cetheme */; };
-		B6D26E6D2B686DE300B4C14F /* Presentation (Light).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E5B2B686DE200B4C14F /* Presentation (Light).cetheme */; };
-		B6D26E6E2B686DE300B4C14F /* Solarized (Light).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E5C2B686DE200B4C14F /* Solarized (Light).cetheme */; };
-		B6D26E6F2B686DE300B4C14F /* Classic (Dark).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E5D2B686DE200B4C14F /* Classic (Dark).cetheme */; };
-		B6D26E702B686DE300B4C14F /* Midnight.cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E5E2B686DE200B4C14F /* Midnight.cetheme */; };
-		B6D26E712B686DE300B4C14F /* GitHub (Dark).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E5F2B686DE200B4C14F /* GitHub (Dark).cetheme */; };
-		B6D26E722B686DE300B4C14F /* Dusk.cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E602B686DE200B4C14F /* Dusk.cetheme */; };
-		B6D26E732B686DE300B4C14F /* Classic (Light).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E612B686DE200B4C14F /* Classic (Light).cetheme */; };
-		B6D26E742B686DE300B4C14F /* Presentation (Dark).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E622B686DE200B4C14F /* Presentation (Dark).cetheme */; };
-		B6D26E752B686DE300B4C14F /* Default (Dark).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E632B686DE300B4C14F /* Default (Dark).cetheme */; };
-		B6D26E762B686DE300B4C14F /* Low Key.cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E642B686DE300B4C14F /* Low Key.cetheme */; };
-		B6D26E772B686DE300B4C14F /* High Contrast (Dark).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E652B686DE300B4C14F /* High Contrast (Dark).cetheme */; };
-		B6D26E782B686DE300B4C14F /* GitHub (Light).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E662B686DE300B4C14F /* GitHub (Light).cetheme */; };
-		B6D26E792B686DE300B4C14F /* Basic.cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E672B686DE300B4C14F /* Basic.cetheme */; };
-		B6D26E7A2B686DE300B4C14F /* Sunset.cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E682B686DE300B4C14F /* Sunset.cetheme */; };
-		B6D26E7B2B686DE300B4C14F /* Default (Light).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E692B686DE300B4C14F /* Default (Light).cetheme */; };
-		B6D26E7C2B686DE300B4C14F /* Civic.cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E6A2B686DE300B4C14F /* Civic.cetheme */; };
-		B6D26E7D2B686DE300B4C14F /* Solarized (Dark).cetheme in Resources */ = {isa = PBXBuildFile; fileRef = B6D26E6B2B686DE300B4C14F /* Solarized (Dark).cetheme */; };
 		B6D7EA592971078500301FAC /* InspectorSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D7EA582971078500301FAC /* InspectorSection.swift */; };
 		B6D7EA5C297107DD00301FAC /* InspectorField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D7EA5B297107DD00301FAC /* InspectorField.swift */; };
 		B6E41C7029DD157F0088F9F4 /* AccountsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E41C6F29DD157F0088F9F4 /* AccountsSettingsView.swift */; };
@@ -480,6 +462,7 @@
 		B6F0517929D9E3C900D72287 /* SourceControlGitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F0517829D9E3C900D72287 /* SourceControlGitView.swift */; };
 		B6F0517B29D9E46400D72287 /* SourceControlSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F0517A29D9E46400D72287 /* SourceControlSettingsView.swift */; };
 		B6F0517D29D9E4B100D72287 /* TerminalSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F0517C29D9E4B100D72287 /* TerminalSettingsView.swift */; };
+		B6FF04782B6C08AC002C2C78 /* DefaultThemes in Resources */ = {isa = PBXBuildFile; fileRef = B6FF04772B6C08AC002C2C78 /* DefaultThemes */; };
 		D7012EE827E757850001E1EF /* FindNavigatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7012EE727E757850001E1EF /* FindNavigatorView.swift */; };
 		D7211D4327E066CE008F2ED7 /* Localized+Ex.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7211D4227E066CE008F2ED7 /* Localized+Ex.swift */; };
 		D7211D4727E06BFE008F2ED7 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D7211D4927E06BFE008F2ED7 /* Localizable.strings */; };
@@ -976,24 +959,6 @@
 		B6C6A429297716A500A3D28F /* EditorTabCloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabCloseButton.swift; sourceTree = "<group>"; };
 		B6C6A42D29771A8D00A3D28F /* EditorTabButtonStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorTabButtonStyle.swift; sourceTree = "<group>"; };
 		B6C6A42F29771F7100A3D28F /* EditorTabBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabBackground.swift; sourceTree = "<group>"; };
-		B6D26E5A2B686DE200B4C14F /* High Contrast (Light).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "High Contrast (Light).cetheme"; sourceTree = "<group>"; };
-		B6D26E5B2B686DE200B4C14F /* Presentation (Light).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Presentation (Light).cetheme"; sourceTree = "<group>"; };
-		B6D26E5C2B686DE200B4C14F /* Solarized (Light).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Solarized (Light).cetheme"; sourceTree = "<group>"; };
-		B6D26E5D2B686DE200B4C14F /* Classic (Dark).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Classic (Dark).cetheme"; sourceTree = "<group>"; };
-		B6D26E5E2B686DE200B4C14F /* Midnight.cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Midnight.cetheme; sourceTree = "<group>"; };
-		B6D26E5F2B686DE200B4C14F /* GitHub (Dark).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "GitHub (Dark).cetheme"; sourceTree = "<group>"; };
-		B6D26E602B686DE200B4C14F /* Dusk.cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Dusk.cetheme; sourceTree = "<group>"; };
-		B6D26E612B686DE200B4C14F /* Classic (Light).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Classic (Light).cetheme"; sourceTree = "<group>"; };
-		B6D26E622B686DE200B4C14F /* Presentation (Dark).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Presentation (Dark).cetheme"; sourceTree = "<group>"; };
-		B6D26E632B686DE300B4C14F /* Default (Dark).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Default (Dark).cetheme"; sourceTree = "<group>"; };
-		B6D26E642B686DE300B4C14F /* Low Key.cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Low Key.cetheme"; sourceTree = "<group>"; };
-		B6D26E652B686DE300B4C14F /* High Contrast (Dark).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "High Contrast (Dark).cetheme"; sourceTree = "<group>"; };
-		B6D26E662B686DE300B4C14F /* GitHub (Light).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "GitHub (Light).cetheme"; sourceTree = "<group>"; };
-		B6D26E672B686DE300B4C14F /* Basic.cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Basic.cetheme; sourceTree = "<group>"; };
-		B6D26E682B686DE300B4C14F /* Sunset.cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Sunset.cetheme; sourceTree = "<group>"; };
-		B6D26E692B686DE300B4C14F /* Default (Light).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Default (Light).cetheme"; sourceTree = "<group>"; };
-		B6D26E6A2B686DE300B4C14F /* Civic.cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Civic.cetheme; sourceTree = "<group>"; };
-		B6D26E6B2B686DE300B4C14F /* Solarized (Dark).cetheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Solarized (Dark).cetheme"; sourceTree = "<group>"; };
 		B6D7EA582971078500301FAC /* InspectorSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorSection.swift; sourceTree = "<group>"; };
 		B6D7EA5B297107DD00301FAC /* InspectorField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorField.swift; sourceTree = "<group>"; };
 		B6E41C6F29DD157F0088F9F4 /* AccountsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsSettingsView.swift; sourceTree = "<group>"; };
@@ -1018,6 +983,7 @@
 		B6F0517829D9E3C900D72287 /* SourceControlGitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlGitView.swift; sourceTree = "<group>"; };
 		B6F0517A29D9E46400D72287 /* SourceControlSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlSettingsView.swift; sourceTree = "<group>"; };
 		B6F0517C29D9E4B100D72287 /* TerminalSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSettingsView.swift; sourceTree = "<group>"; };
+		B6FF04772B6C08AC002C2C78 /* DefaultThemes */ = {isa = PBXFileReference; lastKnownFileType = folder; path = DefaultThemes; sourceTree = "<group>"; };
 		D7012EE727E757850001E1EF /* FindNavigatorView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = FindNavigatorView.swift; sourceTree = "<group>"; tabWidth = 4; };
 		D7211D4227E066CE008F2ED7 /* Localized+Ex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Localized+Ex.swift"; sourceTree = "<group>"; };
 		D7211D4827E06BFE008F2ED7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1176,31 +1142,6 @@
 				28052DFE29730E0B00F4F90A /* Release.xcconfig */,
 			);
 			path = Configs;
-			sourceTree = "<group>";
-		};
-		28069DA527F5BD320016BC47 /* DefaultThemes */ = {
-			isa = PBXGroup;
-			children = (
-				B6D26E672B686DE300B4C14F /* Basic.cetheme */,
-				B6D26E6A2B686DE300B4C14F /* Civic.cetheme */,
-				B6D26E5D2B686DE200B4C14F /* Classic (Dark).cetheme */,
-				B6D26E612B686DE200B4C14F /* Classic (Light).cetheme */,
-				B6D26E632B686DE300B4C14F /* Default (Dark).cetheme */,
-				B6D26E692B686DE300B4C14F /* Default (Light).cetheme */,
-				B6D26E602B686DE200B4C14F /* Dusk.cetheme */,
-				B6D26E5F2B686DE200B4C14F /* GitHub (Dark).cetheme */,
-				B6D26E662B686DE300B4C14F /* GitHub (Light).cetheme */,
-				B6D26E652B686DE300B4C14F /* High Contrast (Dark).cetheme */,
-				B6D26E5A2B686DE200B4C14F /* High Contrast (Light).cetheme */,
-				B6D26E642B686DE300B4C14F /* Low Key.cetheme */,
-				B6D26E5E2B686DE200B4C14F /* Midnight.cetheme */,
-				B6D26E622B686DE200B4C14F /* Presentation (Dark).cetheme */,
-				B6D26E5B2B686DE200B4C14F /* Presentation (Light).cetheme */,
-				B6D26E6B2B686DE300B4C14F /* Solarized (Dark).cetheme */,
-				B6D26E5C2B686DE200B4C14F /* Solarized (Light).cetheme */,
-				B6D26E682B686DE300B4C14F /* Sunset.cetheme */,
-			);
-			path = DefaultThemes;
 			sourceTree = "<group>";
 		};
 		2806E8FE2979587A000040F4 /* Model */ = {
@@ -2538,6 +2479,7 @@
 				B658FB2E27DA9E0F00EA4DBD /* CodeEdit */,
 				587B60F329340A8000D5CD8F /* CodeEditTests */,
 				28052E0129730F2F00F4F90A /* Configs */,
+				B6FF04772B6C08AC002C2C78 /* DefaultThemes */,
 				58F2EACE292FB2B0004A9BDE /* Documentation.docc */,
 				2BE487ED28245162003F3F64 /* OpenWithCodeEdit */,
 				284DC8502978BA2600BF2770 /* .all-contributorsrc */,
@@ -2563,7 +2505,6 @@
 		B658FB2E27DA9E0F00EA4DBD /* CodeEdit */ = {
 			isa = PBXGroup;
 			children = (
-				28069DA527F5BD320016BC47 /* DefaultThemes */,
 				5831E3C52933E6CB00D5A6D2 /* Features */,
 				D7211D4427E066D4008F2ED7 /* Localization */,
 				B658FB3527DA9E1000EA4DBD /* Preview Content */,
@@ -3082,32 +3023,15 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6D26E732B686DE300B4C14F /* Classic (Light).cetheme in Resources */,
-				B6D26E6F2B686DE300B4C14F /* Classic (Dark).cetheme in Resources */,
-				B6D26E712B686DE300B4C14F /* GitHub (Dark).cetheme in Resources */,
-				B6D26E752B686DE300B4C14F /* Default (Dark).cetheme in Resources */,
-				B6D26E792B686DE300B4C14F /* Basic.cetheme in Resources */,
-				B6D26E7B2B686DE300B4C14F /* Default (Light).cetheme in Resources */,
-				B6D26E7D2B686DE300B4C14F /* Solarized (Dark).cetheme in Resources */,
-				B6D26E6E2B686DE300B4C14F /* Solarized (Light).cetheme in Resources */,
+				B6FF04782B6C08AC002C2C78 /* DefaultThemes in Resources */,
 				283BDCBD2972EEBD002AFF81 /* Package.resolved in Resources */,
-				B6D26E6C2B686DE300B4C14F /* High Contrast (Light).cetheme in Resources */,
 				B658FB3727DA9E1000EA4DBD /* Preview Assets.xcassets in Resources */,
 				3E0196732A3921AC002648D8 /* codeedit_shell_integration.zsh in Resources */,
-				B6D26E6D2B686DE300B4C14F /* Presentation (Light).cetheme in Resources */,
-				B6D26E742B686DE300B4C14F /* Presentation (Dark).cetheme in Resources */,
-				B6D26E702B686DE300B4C14F /* Midnight.cetheme in Resources */,
 				58A5DFA529339F6400D1BD5D /* default_keybindings.json in Resources */,
-				B6D26E782B686DE300B4C14F /* GitHub (Light).cetheme in Resources */,
 				3E01967A2A392B45002648D8 /* codeedit_shell_integration.bash in Resources */,
 				D7211D4727E06BFE008F2ED7 /* Localizable.strings in Resources */,
-				B6D26E7A2B686DE300B4C14F /* Sunset.cetheme in Resources */,
-				B6D26E762B686DE300B4C14F /* Low Key.cetheme in Resources */,
-				B6D26E7C2B686DE300B4C14F /* Civic.cetheme in Resources */,
-				B6D26E722B686DE300B4C14F /* Dusk.cetheme in Resources */,
 				284DC8512978BA2600BF2770 /* .all-contributorsrc in Resources */,
 				B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */,
-				B6D26E772B686DE300B4C14F /* High Contrast (Dark).cetheme in Resources */,
 				6C6BD6FC29CD152400235D17 /* codeedit.extension.appextensionpoint in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel.swift
@@ -149,12 +149,20 @@ final class ThemeModel: ObservableObject {
             }
 
             // get all URLs in users themes folder that end with `.cetheme`
-            let userDefinedThemeFilenames = try filemanager.contentsOfDirectory(atPath: themesURL.path).filter { $0.contains(".cetheme") }
-            let userDefinedThemeURLs = userDefinedThemeFilenames.map { themesURL.appendingPathComponent($0) }
+            let userDefinedThemeFilenames = try filemanager.contentsOfDirectory(atPath: themesURL.path).filter {
+                $0.contains(".cetheme")
+            }
+            let userDefinedThemeURLs = userDefinedThemeFilenames.map {
+                themesURL.appendingPathComponent($0)
+            }
 
             // get all bundled theme URLs
-            let bundledThemeFilenames = try filemanager.contentsOfDirectory(atPath: bundledThemesURL.path).filter { $0.contains(".cetheme") }
-            let bundledThemeURLs = bundledThemeFilenames.map { bundledThemesURL.appendingPathComponent($0) }
+            let bundledThemeFilenames = try filemanager.contentsOfDirectory(atPath: bundledThemesURL.path).filter {
+                $0.contains(".cetheme")
+            }
+            let bundledThemeURLs = bundledThemeFilenames.map {
+                bundledThemesURL.appendingPathComponent($0)
+            }
 
             // combine user theme URLs with bundled theme URLs
             let themeURLs = userDefinedThemeURLs + bundledThemeURLs

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingThemeRow.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingThemeRow.swift
@@ -23,7 +23,7 @@ struct ThemeSettingsThemeRow: View {
                 .font(.system(size: 10.5, weight: .bold))
             VStack(alignment: .leading) {
                 Text(theme.displayName)
-                Text("CodeEdit")
+                Text(theme.author)
                     .foregroundColor(.secondary)
                     .font(.footnote)
             }

--- a/DefaultThemes/Basic.cetheme
+++ b/DefaultThemes/Basic.cetheme
@@ -1,125 +1,125 @@
 {
-  "name": "Dusk",
-  "displayName": "Dusk",
-  "description": "Xcode dark theme.",
+  "name": "basic",
+  "displayName": "Basic",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
   "distributionURL": "https://github.com/CodeEditApp/CodeEdit",
-  "type": "dark",
+  "type": "light",
   "editor": {
     "background": {
-      "color": "#282B35"
+      "color": "#FFFFFF"
     },
     "selection": {
-      "color": "#67675C"
+      "color": "#B2D7FF"
     },
     "insertionPoint": {
-      "color": "#FFFFFF"
+      "color": "#000000"
     },
     "lineHighlight": {
-      "color": "#3B3B3C"
+      "color": "#F5F5F6"
     },
     "invisibles": {
-      "color": "#5F5F5F"
+      "color": "#D6D6D6"
     },
     "text": {
-      "color": "#FFFFFF"
+      "color": "#000000"
     },
     "comments": {
-      "color": "#41B645"
+      "color": "#008F00"
     },
     "strings": {
-      "color": "#DB2C38"
+      "color": "#B4261A"
     },
     "characters": {
-      "color": "#786DC4"
+      "color": "#000000"
     },
     "numbers": {
-      "color": "#786DC4"
+      "color": "#000000"
     },
     "keywords": {
-      "color": "#B21889"
+      "color": "#0433FF"
     },
     "attributes": {
-      "color": "#55747C"
+      "color": "#000000"
     },
     "types": {
-      "color": "#5DD8FF"
+      "color": "#02638C"
     },
     "variables": {
-      "color": "#41A1C0"
+      "color": "#057CB0"
     },
     "commands": {
-      "color": "#83C057"
+      "color": "#3495AF"
     },
     "values": {
-      "color": "#00A0BE"
+      "color": "#3495AF"
     }
   },
   "terminal": {
     "background": {
-      "color": "#282B35"
+      "color": "#FFFFFF"
     },
     "selection": {
-      "color": "#67675C"
+      "color": "#B2D7FF"
     },
     "cursor": {
-      "color": "#FFFFFF"
+      "color": "#000000"
     },
     "text": {
-      "color": "#FFFFFF"
+      "color": "#000000"
     },
     "boldText": {
-      "color": "#D9D9D9"
+      "color": "#000000"
     },
     "black": {
-      "color": "#1F2024"
+      "color": "#000000"
     },
     "red": {
-      "color": "#FF3B30"
+      "color": "#990000"
     },
     "green": {
-      "color": "#28CD41"
+      "color": "#00A600"
     },
     "yellow": {
-      "color": "#FFCC00"
+      "color": "#999900"
     },
     "blue": {
-      "color": "#007AFF"
+      "color": "#0000B2"
     },
     "magenta": {
-      "color": "#AF52DE"
+      "color": "#B200B2"
     },
     "cyan": {
-      "color": "#59ADC4"
+      "color": "#00A6B2"
     },
     "white": {
-      "color": "#D9D9D9"
+      "color": "#BFBFBF"
     },
     "brightBlack": {
-      "color": "#8E8E93"
+      "color": "#666666"
     },
     "brightRed": {
-      "color": "#FF3B30"
+      "color": "#E50000"
     },
     "brightGreen": {
-      "color": "#28CD41"
+      "color": "#00D900"
     },
     "brightYellow": {
-      "color": "#FFFF00"
+      "color": "#E5E500"
     },
     "brightBlue": {
-      "color": "#007AFF"
+      "color": "#0000FF"
     },
     "brightMagenta": {
-      "color": "#AF52DE"
+      "color": "#E500E5"
     },
     "brightCyan": {
-      "color": "#55BEF0"
+      "color": "#00E5E5"
     },
     "brightWhite": {
-      "color": "#FFFFFF"
+      "color": "#E5E5E5"
     }
   }
 }

--- a/DefaultThemes/Civic.cetheme
+++ b/DefaultThemes/Civic.cetheme
@@ -1,7 +1,7 @@
 {
-  "name": "Classic (Dark)",
-  "displayName": "Classic (Dark)",
-  "description": "Xcode dark theme.",
+  "name": "civic",
+  "displayName": "Civic",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
@@ -9,40 +9,40 @@
   "type": "dark",
   "editor": {
     "background": {
-      "color": "#292A30"
+      "color": "#292B36"
     },
     "selection": {
-      "color": "#646F83"
+      "color": "#445261"
     },
     "insertionPoint": {
       "color": "#FFFFFF"
     },
     "lineHighlight": {
-      "color": "#2F3239"
+      "color": "#353749"
     },
     "invisibles": {
-      "color": "#53606E"
+      "color": "#5F5F5F"
     },
     "text": {
-      "color": "#FFFFFF"
+      "color": "#E7E8EB"
     },
     "comments": {
-      "color": "#84B360"
+      "color": "#51C34F"
     },
     "strings": {
-      "color": "#FF8170"
+      "color": "#DE3A3C"
     },
     "characters": {
-      "color": "#D9C97C"
+      "color": "#8783BE"
     },
     "numbers": {
-      "color": "#D9C97C"
+      "color": "#00AAA3"
     },
     "keywords": {
-      "color": "#FF7AB2"
+      "color": "#E12DA0"
     },
     "attributes": {
-      "color": "#CC9768"
+      "color": "#68878F"
     },
     "types": {
       "color": "#6BDFFF"
@@ -51,75 +51,75 @@
       "color": "#4EB0CC"
     },
     "commands": {
-      "color": "#78C2B3"
+      "color": "#18B5B1"
     },
     "values": {
-      "color": "#B281EB"
+      "color": "#29A09F"
     }
   },
   "terminal": {
     "background": {
-      "color": "#292A30"
+      "color": "#292B36"
     },
     "selection": {
-      "color": "#646F83"
+      "color": "#445261"
     },
     "cursor": {
       "color": "#FFFFFF"
     },
     "text": {
-      "color": "#FFFFFF"
+      "color": "#E7E8EB"
     },
     "boldText": {
-      "color": "#FFFFFF"
+      "color": "#E7E8EB"
     },
     "black": {
-      "color": "#1F1F24"
+      "color": "#000000"
     },
     "red": {
-      "color": "#FF8170"
+      "color": "#DE3A3C"
     },
     "green": {
-      "color": "#84B360"
+      "color": "#51C34F"
     },
     "yellow": {
-      "color": "#D9C97C"
+      "color": "#8783BE"
     },
     "blue": {
       "color": "#4EB0CC"
     },
     "magenta": {
-      "color": "#B281EB"
+      "color": "#E12DA0"
     },
     "cyan": {
-      "color": "#78C2B3"
+      "color": "#29A09F"
     },
     "white": {
-      "color": "#BFBFBF"
+      "color": "#E7E8EB"
     },
     "brightBlack": {
-      "color": "#1F1F24"
+      "color": "#666666"
     },
     "brightRed": {
-      "color": "#FF8170"
+      "color": "#DE3A3C"
     },
     "brightGreen": {
-      "color": "#84B360"
+      "color": "#51C34F"
     },
     "brightYellow": {
-      "color": "#D9C97C"
+      "color": "#8783BE"
     },
     "brightBlue": {
       "color": "#4EB0CC"
     },
     "brightMagenta": {
-      "color": "#B281EB"
+      "color": "#E500E5"
     },
     "brightCyan": {
-      "color": "#78C2B3"
+      "color": "#29A09F"
     },
     "brightWhite": {
-      "color": "#E5E5E5"
+      "color": "#E7E8EB"
     }
   }
 }

--- a/DefaultThemes/Classic (Dark).cetheme
+++ b/DefaultThemes/Classic (Dark).cetheme
@@ -1,125 +1,125 @@
 {
-  "name": "Presentation (Light)",
-  "displayName": "Presentation (Light)",
-  "description": "Xcode light theme.",
+  "name": "classic.dark",
+  "displayName": "Classic (Dark)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
   "distributionURL": "https://github.com/CodeEditApp/CodeEdit",
-  "type": "light",
+  "type": "dark",
   "editor": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#292A30"
     },
     "selection": {
-      "color": "#D1E3FF"
+      "color": "#646F83"
     },
     "insertionPoint": {
-      "color": "#007AFF"
+      "color": "#FFFFFF"
     },
     "lineHighlight": {
-      "color": "#ECF5FF"
+      "color": "#2F3239"
     },
     "invisibles": {
-      "color": "#D6D6D6"
+      "color": "#53606E"
     },
     "text": {
-      "color": "#000000"
+      "color": "#FFFFFF"
     },
     "comments": {
-      "color": "#56606B"
+      "color": "#84B360"
     },
     "strings": {
-      "color": "#BA0011"
+      "color": "#FF8170"
     },
     "characters": {
-      "color": "#000BFF"
+      "color": "#D9C97C"
     },
     "numbers": {
-      "color": "#000BFF"
+      "color": "#D9C97C"
     },
     "keywords": {
-      "color": "#B40062"
+      "color": "#FF7AB2"
     },
     "attributes": {
-      "color": "#836C28"
+      "color": "#CC9768"
     },
     "types": {
-      "color": "#004975"
+      "color": "#6BDFFF"
     },
     "variables": {
-      "color": "#0F68A0"
+      "color": "#4EB0CC"
     },
     "commands": {
-      "color": "#3B7F89"
+      "color": "#78C2B3"
     },
     "values": {
-      "color": "#5C2699"
+      "color": "#B281EB"
     }
   },
   "terminal": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#292A30"
     },
     "selection": {
-      "color": "#D1E3FF"
+      "color": "#646F83"
     },
     "cursor": {
-      "color": "#000000"
+      "color": "#FFFFFF"
     },
     "text": {
-      "color": "#000000"
+      "color": "#FFFFFF"
     },
     "boldText": {
-      "color": "#262626"
+      "color": "#FFFFFF"
     },
     "black": {
-      "color": "#1F2024"
+      "color": "#1F1F24"
     },
     "red": {
-      "color": "#FF3B30"
+      "color": "#FF8170"
     },
     "green": {
-      "color": "#28CD41"
+      "color": "#84B360"
     },
     "yellow": {
-      "color": "#FFCC00"
+      "color": "#D9C97C"
     },
     "blue": {
-      "color": "#007AFF"
+      "color": "#4EB0CC"
     },
     "magenta": {
-      "color": "#AF52DE"
+      "color": "#B281EB"
     },
     "cyan": {
-      "color": "#59ADC4"
+      "color": "#78C2B3"
     },
     "white": {
-      "color": "#D9D9D9"
+      "color": "#BFBFBF"
     },
     "brightBlack": {
-      "color": "#8E8E93"
+      "color": "#1F1F24"
     },
     "brightRed": {
-      "color": "#FF3B30"
+      "color": "#FF8170"
     },
     "brightGreen": {
-      "color": "#28CD41"
+      "color": "#84B360"
     },
     "brightYellow": {
-      "color": "#FFCC00"
+      "color": "#D9C97C"
     },
     "brightBlue": {
-      "color": "#007AFF"
+      "color": "#4EB0CC"
     },
     "brightMagenta": {
-      "color": "#AF52DE"
+      "color": "#B281EB"
     },
     "brightCyan": {
-      "color": "#55BEF0"
+      "color": "#78C2B3"
     },
     "brightWhite": {
-      "color": "#FFFFFF"
+      "color": "#E5E5E5"
     }
   }
 }

--- a/DefaultThemes/Classic (Light).cetheme
+++ b/DefaultThemes/Classic (Light).cetheme
@@ -1,7 +1,7 @@
 {
-  "name": "Basic",
-  "displayName": "Basic",
-  "description": "Xcode Basic theme.",
+  "name": "classic.light",
+  "displayName": "Classic (Light)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
@@ -18,7 +18,7 @@
       "color": "#000000"
     },
     "lineHighlight": {
-      "color": "#F5F5F6"
+      "color": "#ECF5FF"
     },
     "invisibles": {
       "color": "#D6D6D6"
@@ -27,34 +27,34 @@
       "color": "#000000"
     },
     "comments": {
-      "color": "#008F00"
+      "color": "#2D8504"
     },
     "strings": {
-      "color": "#A31515"
+      "color": "#D12F1B"
     },
     "characters": {
-      "color": "#000000"
+      "color": "#272AD8"
     },
     "numbers": {
-      "color": "#000000"
+      "color": "#272AD8"
     },
     "keywords": {
-      "color": "#0433FF"
+      "color": "#AD3DA4"
     },
     "attributes": {
-      "color": "#000000"
+      "color": "#947100"
     },
     "types": {
-      "color": "#02638C"
+      "color": "#03638C"
     },
     "variables": {
-      "color": "#0F68A0"
+      "color": "#057CB0"
     },
     "commands": {
-      "color": "#0F68A0"
+      "color": "#3F8087"
     },
     "values": {
-      "color": "#2B839F"
+      "color": "#804FB8"
     }
   },
   "terminal": {
@@ -71,55 +71,55 @@
       "color": "#000000"
     },
     "boldText": {
-      "color": "#000000"
+      "color": "#262626"
     },
     "black": {
-      "color": "#000000"
+      "color": "#1F2024"
     },
     "red": {
-      "color": "#990000"
+      "color": "#FF3B30"
     },
     "green": {
-      "color": "#00A600"
+      "color": "#28CD41"
     },
     "yellow": {
-      "color": "#999900"
+      "color": "#FFCC00"
     },
     "blue": {
-      "color": "#0000B2"
+      "color": "#007AFF"
     },
     "magenta": {
-      "color": "#B200B2"
+      "color": "#AF52DE"
     },
     "cyan": {
-      "color": "#00A6B2"
+      "color": "#59ADC4"
     },
     "white": {
-      "color": "#BFBFBF"
+      "color": "#D9D9D9"
     },
     "brightBlack": {
-      "color": "#666666"
+      "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#E50000"
+      "color": "#FF3B30"
     },
     "brightGreen": {
-      "color": "#00D900"
+      "color": "#28CD41"
     },
     "brightYellow": {
-      "color": "#E5E500"
+      "color": "#FFCC00"
     },
     "brightBlue": {
-      "color": "#0000FF"
+      "color": "#007AFF"
     },
     "brightMagenta": {
-      "color": "#E500E5"
+      "color": "#AF52DE"
     },
     "brightCyan": {
-      "color": "#00E5E5"
+      "color": "#55BEF0"
     },
     "brightWhite": {
-      "color": "#E5E5E5"
+      "color": "#FFFFFF"
     }
   }
 }

--- a/DefaultThemes/Default (Dark).cetheme
+++ b/DefaultThemes/Default (Dark).cetheme
@@ -1,7 +1,7 @@
 {
-  "name": "Solarized (Dark)",
-  "displayName": "Solarized (Dark)",
-  "description": "Solarized dark theme.",
+  "name": "default.dark",
+  "displayName": "Default (Dark)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
@@ -9,117 +9,117 @@
   "type": "dark",
   "editor": {
     "background": {
-      "color": "#002B36"
+      "color": "#292A30"
     },
     "selection": {
-      "color": "#586E75"
+      "color": "#646F83"
     },
     "insertionPoint": {
-      "color": "#839496"
+      "color": "#007AFF"
     },
     "lineHighlight": {
-      "color": "#073642"
+      "color": "#2F3239"
     },
     "invisibles": {
-      "color": "#073642"
+      "color": "#53606E"
     },
     "text": {
-      "color": "#839496"
+      "color": "#FFFFFF"
     },
     "comments": {
-      "color": "#586E75"
+      "color": "#7F8C98"
     },
     "strings": {
-      "color": "#2AA198"
+      "color": "#FF8170"
     },
     "characters": {
-      "color": "#DC322F"
+      "color": "#D9C97C"
     },
     "numbers": {
-      "color": "#DC322F"
+      "color": "#D9C97C"
     },
     "keywords": {
-      "color": "#859900"
+      "color": "#FF7AB2"
     },
     "attributes": {
-      "color": "#6C71C4"
+      "color": "#CC9768"
     },
     "types": {
-      "color": "#268BD2"
+      "color": "#6BDFFF"
     },
     "variables": {
-      "color": "#B58900"
+      "color": "#4EB0CC"
     },
     "commands": {
-      "color": "#CB4B16"
+      "color": "#78C2B3"
     },
     "values": {
-      "color": "#D33682"
+      "color": "#B281EB"
     }
   },
   "terminal": {
     "background": {
-      "color": "#002B36"
+      "color": "#292A30"
     },
     "selection": {
-      "color": "#586E75"
+      "color": "#646F83"
     },
     "cursor": {
-      "color": "#839496"
+      "color": "#FFFFFF"
     },
     "text": {
-      "color": "#839496"
+      "color": "#FFFFFF"
     },
     "boldText": {
-      "color": "#839496"
+      "color": "#D9D9D9"
     },
     "black": {
-      "color": "#073642"
+      "color": "#1F2024"
     },
     "red": {
-      "color": "#DC322F"
+      "color": "#FF8170"
     },
     "green": {
-      "color": "#859900"
+      "color": "#78C2B3"
     },
     "yellow": {
-      "color": "#B58900"
+      "color": "#D9C97C"
     },
     "blue": {
-      "color": "#268BD2"
+      "color": "#B281EB"
     },
     "magenta": {
-      "color": "#D33682"
+      "color": "#FF7AB2"
     },
     "cyan": {
-      "color": "#2AA198"
+      "color": "#4EB0CC"
     },
     "white": {
-      "color": "#EEE8D5"
+      "color": "#D9D9D9"
     },
     "brightBlack": {
-      "color": "#002B36"
+      "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#CB4B16"
+      "color": "#FF8170"
     },
     "brightGreen": {
-      "color": "#586E75"
+      "color": "#78C2B3"
     },
     "brightYellow": {
-      "color": "#657B83"
+      "color": "#D9C97C"
     },
     "brightBlue": {
-      "color": "#839496"
+      "color": "#B281EB"
     },
     "brightMagenta": {
-      "color": "#6C71C4"
+      "color": "#FF7AB2"
     },
     "brightCyan": {
-      "color": "#93A1A1"
+      "color": "#4EB0CC"
     },
     "brightWhite": {
-      "color": "#FDF6E3"
+      "color": "#FFFFFF"
     }
   }
 }

--- a/DefaultThemes/Default (Light).cetheme
+++ b/DefaultThemes/Default (Light).cetheme
@@ -1,125 +1,125 @@
 {
-  "name": "Civic",
-  "displayName": "Civic",
-  "description": "Xcode dark theme.",
+  "name": "default.light",
+  "displayName": "Default (Light)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
   "distributionURL": "https://github.com/CodeEditApp/CodeEdit",
-  "type": "dark",
+  "type": "light",
   "editor": {
     "background": {
-      "color": "#292B36"
-    },
-    "selection": {
-      "color": "#445261"
-    },
-    "insertionPoint": {
       "color": "#FFFFFF"
     },
+    "selection": {
+      "color": "#B2D7FF"
+    },
+    "insertionPoint": {
+      "color": "#007AFF"
+    },
     "lineHighlight": {
-      "color": "#353749"
+      "color": "#ECF5FF"
     },
     "invisibles": {
-      "color": "#5F5F5F"
+      "color": "#D6D6D6"
     },
     "text": {
-      "color": "#E7E8EB"
+      "color": "#000000"
     },
     "comments": {
-      "color": "#51C34F"
+      "color": "#707F8C"
     },
     "strings": {
-      "color": "#DE3A3C"
+      "color": "#D12F1B"
     },
     "characters": {
-      "color": "#8783BE"
+      "color": "#272AD8"
     },
     "numbers": {
-      "color": "#00AAA3"
+      "color": "#272AD8"
     },
     "keywords": {
-      "color": "#E12DA0"
+      "color": "#AD3DA4"
     },
     "attributes": {
-      "color": "#68878F"
+      "color": "#947100"
     },
     "types": {
-      "color": "#6BDFFF"
+      "color": "#02638C"
     },
     "variables": {
-      "color": "#4EB0CC"
+      "color": "#057CB0"
     },
     "commands": {
-      "color": "#18B5B1"
+      "color": "#3F8087"
     },
     "values": {
-      "color": "#29A09F"
+      "color": "#804FB8"
     }
   },
   "terminal": {
     "background": {
-      "color": "#292B36"
-    },
-    "selection": {
-      "color": "#445261"
-    },
-    "cursor": {
       "color": "#FFFFFF"
     },
-    "text": {
-      "color": "#E7E8EB"
+    "selection": {
+      "color": "#B2D7FF"
     },
-    "boldText": {
-      "color": "#E7E8EB"
-    },
-    "black": {
+    "cursor": {
       "color": "#000000"
     },
+    "text": {
+      "color": "#000000"
+    },
+    "boldText": {
+      "color": "#262626"
+    },
+    "black": {
+      "color": "#1F2024"
+    },
     "red": {
-      "color": "#DE3A3C"
+      "color": "#D12F1B"
     },
     "green": {
-      "color": "#51C34F"
+      "color": "#3F8087"
     },
     "yellow": {
-      "color": "#8783BE"
+      "color": "#947100"
     },
     "blue": {
-      "color": "#4EB0CC"
+      "color": "#272AD8"
     },
     "magenta": {
-      "color": "#E12DA0"
+      "color": "#804FB8"
     },
     "cyan": {
-      "color": "#29A09F"
+      "color": "#02638C"
     },
     "white": {
-      "color": "#E7E8EB"
+      "color": "#D9D9D9"
     },
     "brightBlack": {
-      "color": "#666666"
+      "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#DE3A3C"
+      "color": "#D12F1B"
     },
     "brightGreen": {
-      "color": "#51C34F"
+      "color": "#3F8087"
     },
     "brightYellow": {
-      "color": "#8783BE"
+      "color": "#947100"
     },
     "brightBlue": {
-      "color": "#4EB0CC"
+      "color": "#272AD8"
     },
     "brightMagenta": {
-      "color": "#E500E5"
+      "color": "#804FB8"
     },
     "brightCyan": {
-      "color": "#29A09F"
+      "color": "#02638C"
     },
     "brightWhite": {
-      "color": "#E7E8EB"
+      "color": "#FFFFFF"
     }
   }
 }

--- a/DefaultThemes/Dusk.cetheme
+++ b/DefaultThemes/Dusk.cetheme
@@ -1,7 +1,7 @@
 {
-  "name": "Presentation (Dark)",
-  "displayName": "Presentation (Dark)",
-  "description": "Xcode dark theme.",
+  "name": "dusk",
+  "displayName": "Dusk",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
@@ -9,16 +9,16 @@
   "type": "dark",
   "editor": {
     "background": {
-      "color": "#202025"
+      "color": "#282B35"
     },
     "selection": {
-      "color": "#646F83"
+      "color": "#67675C"
     },
     "insertionPoint": {
-      "color": "#007AFF"
+      "color": "#FFFFFF"
     },
     "lineHighlight": {
-      "color": "#444551"
+      "color": "#3B3B3C"
     },
     "invisibles": {
       "color": "#5F5F5F"
@@ -27,42 +27,42 @@
       "color": "#FFFFFF"
     },
     "comments": {
-      "color": "#6C7987"
+      "color": "#4DBF56"
     },
     "strings": {
-      "color": "#FC4651"
+      "color": "#E44448"
     },
     "characters": {
-      "color": "#FFE76D"
+      "color": "#8B84CF"
     },
     "numbers": {
-      "color": "#FFE76D"
+      "color": "#8B84CF"
     },
     "keywords": {
-      "color": "#F2248C"
+      "color": "#C2349B"
     },
     "attributes": {
-      "color": "#E09D65"
+      "color": "#67878F"
     },
     "types": {
-      "color": "#66DAFF"
+      "color": "#6BDFFF"
     },
     "variables": {
-      "color": "#35B0D8"
+      "color": "#4EB0CC"
     },
     "commands": {
-      "color": "#56D0B3"
+      "color": "#93C86A"
     },
     "values": {
-      "color": "#AB64FF"
+      "color": "#00AFCA"
     }
   },
   "terminal": {
     "background": {
-      "color": "#202025"
+      "color": "#282B35"
     },
     "selection": {
-      "color": "#646F83"
+      "color": "#67675C"
     },
     "cursor": {
       "color": "#FFFFFF"
@@ -77,22 +77,22 @@
       "color": "#1F2024"
     },
     "red": {
-      "color": "#FF3B30"
+      "color": "#E44448"
     },
     "green": {
-      "color": "#28CD41"
+      "color": "#93C86A"
     },
     "yellow": {
       "color": "#FFCC00"
     },
     "blue": {
-      "color": "#007AFF"
+      "color": "#8B84CF"
     },
     "magenta": {
-      "color": "#AF52DE"
+      "color": "#C2349B"
     },
     "cyan": {
-      "color": "#59ADC4"
+      "color": "#4EB0CC"
     },
     "white": {
       "color": "#D9D9D9"
@@ -101,22 +101,22 @@
       "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#FF3B30"
+      "color": "#E44448"
     },
     "brightGreen": {
-      "color": "#28CD41"
+      "color": "#93C86A"
     },
     "brightYellow": {
-      "color": "#FFFF00"
+      "color": "#FFCC00"
     },
     "brightBlue": {
-      "color": "#007AFF"
+      "color": "#8B84CF"
     },
     "brightMagenta": {
-      "color": "#AF52DE"
+      "color": "#C2349B"
     },
     "brightCyan": {
-      "color": "#55BEF0"
+      "color": "#4EB0CC"
     },
     "brightWhite": {
       "color": "#FFFFFF"

--- a/DefaultThemes/GitHub (Dark).cetheme
+++ b/DefaultThemes/GitHub (Dark).cetheme
@@ -1,98 +1,98 @@
 {
-  "name": "Default (Light)",
-  "displayName": "Default (Light)",
-  "description": "Xcode light theme.",
+  "name": "github.dark",
+  "displayName": "GitHub (Dark)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
   "distributionURL": "https://github.com/CodeEditApp/CodeEdit",
-  "type": "light",
+  "type": "dark",
   "editor": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#0D1117"
     },
     "selection": {
-      "color": "#B2D7FF"
+      "color": "#1E4273"
     },
     "insertionPoint": {
-      "color": "#007AFF"
+      "color": "#C9D1D9"
     },
     "lineHighlight": {
-      "color": "#ECF5FF"
+      "color": "#23252B"
     },
     "invisibles": {
-      "color": "#D6D6D6"
+      "color": "#424D5B"
     },
     "text": {
-      "color": "#000000"
+      "color": "#C9D1D9"
     },
     "comments": {
-      "color": "#5D6C79"
+      "color": "#8B949E"
     },
     "strings": {
-      "color": "#C41A16"
+      "color": "#A5D6FF"
     },
     "characters": {
-      "color": "#1C00CF"
+      "color": "#79C0FF"
     },
     "numbers": {
-      "color": "#1C00CF"
+      "color": "#79C0FF"
     },
     "keywords": {
-      "color": "#9B2393"
+      "color": "#FF7B72"
     },
     "attributes": {
-      "color": "#815F03"
+      "color": "#79C0FF"
     },
     "types": {
-      "color": "#0B4F79"
+      "color": "#79C0FF"
     },
     "variables": {
-      "color": "#326D74"
+      "color": "#D2A8FF"
     },
     "commands": {
-      "color": "#6C36A9"
+      "color": "#D2A8FF"
     },
     "values": {
-      "color": "#6C36A9"
+      "color": "#79C0FF"
     }
   },
   "terminal": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#0D1117"
     },
     "selection": {
-      "color": "#B2D7FF"
+      "color": "#1E4273"
     },
     "cursor": {
-      "color": "#000000"
+      "color": "#C9D1D9"
     },
     "text": {
-      "color": "#000000"
+      "color": "#C9D1D9"
     },
     "boldText": {
-      "color": "#262626"
+      "color": "#C9D1D9"
     },
     "black": {
       "color": "#1F2024"
     },
     "red": {
-      "color": "#FF3B30"
+      "color": "#FF7B72"
     },
     "green": {
-      "color": "#28CD41"
+      "color": "#7EE787"
     },
     "yellow": {
-      "color": "#FFCC00"
+      "color": "#F2CC60"
     },
     "blue": {
-      "color": "#007AFF"
+      "color": "#79C0FF"
     },
     "magenta": {
-      "color": "#AF52DE"
+      "color": "#D2A8FF"
     },
     "cyan": {
-      "color": "#59ADC4"
+      "color": "#79C0FF"
     },
     "white": {
       "color": "#D9D9D9"
@@ -101,22 +101,22 @@
       "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#FF3B30"
+      "color": "#FF7B72"
     },
     "brightGreen": {
-      "color": "#28CD41"
+      "color": "#7EE787"
     },
     "brightYellow": {
-      "color": "#FFCC00"
+      "color": "#F2CC60"
     },
     "brightBlue": {
-      "color": "#007AFF"
+      "color": "#79C0FF"
     },
     "brightMagenta": {
-      "color": "#AF52DE"
+      "color": "#D2A8FF"
     },
     "brightCyan": {
-      "color": "#55BEF0"
+      "color": "#79C0FF"
     },
     "brightWhite": {
       "color": "#FFFFFF"

--- a/DefaultThemes/GitHub (Light).cetheme
+++ b/DefaultThemes/GitHub (Light).cetheme
@@ -1,98 +1,98 @@
 {
-  "name": "Midnight",
-  "displayName": "Midnight",
-  "description": "Midnight theme.",
+  "name": "github.light",
+  "displayName": "GitHub (Light)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
   "distributionURL": "https://github.com/CodeEditApp/CodeEdit",
-  "type": "dark",
+  "type": "light",
   "editor": {
     "background": {
-      "color": "#000000"
+      "color": "#FFFFFF"
     },
     "selection": {
-      "color": "#5D5952"
+      "color": "#B4D6F5"
     },
     "insertionPoint": {
-      "color": "#FFFFFF"
+      "color": "#24292F"
     },
     "lineHighlight": {
-      "color": "#232121"
+      "color": "#E8F2FF"
     },
     "invisibles": {
-      "color": "#424242"
+      "color": "#CCCCCC"
     },
     "text": {
-      "color": "#FFFFFF"
+      "color": "#24292F"
     },
     "comments": {
-      "color": "#41CC45"
+      "color": "#6E7781"
     },
     "strings": {
-      "color": "#FF2C38"
+      "color": "#0A3069"
     },
     "characters": {
-      "color": "#786DFF"
+      "color": "#0550AE"
     },
     "numbers": {
-      "color": "#786DFF"
+      "color": "#0550AE"
     },
     "keywords": {
-      "color": "#D31895"
+      "color": "#CF222E"
     },
     "attributes": {
-      "color": "#2D449B"
+      "color": "#0550AE"
     },
     "types": {
-      "color": "#5DD8FF"
+      "color": "#0550AE"
     },
     "variables": {
-      "color": "#41A1C0"
+      "color": "#8250DF"
     },
     "commands": {
-      "color": "#23FF83"
+      "color": "#8250df"
     },
     "values": {
-      "color": "#00A0FF"
+      "color": "#0550AE"
     }
   },
   "terminal": {
     "background": {
-      "color": "#000000"
-    },
-    "selection": {
-      "color": "#5D5952"
-    },
-    "cursor": {
       "color": "#FFFFFF"
     },
+    "selection": {
+      "color": "#B4D6F5"
+    },
+    "cursor": {
+      "color": "#24292F"
+    },
     "text": {
-      "color": "#D9D9D9"
+      "color": "#24292f"
     },
     "boldText": {
-      "color": "#D9D9D9"
+      "color": "#24292F"
     },
     "black": {
       "color": "#1F2024"
     },
     "red": {
-      "color": "#FF3B30"
+      "color": "#CF222E"
     },
     "green": {
-      "color": "#28CD41"
+      "color": "#7EE787"
     },
     "yellow": {
-      "color": "#FFCC00"
+      "color": "#F2CC60"
     },
     "blue": {
-      "color": "#007AFF"
+      "color": "#79C0FF"
     },
     "magenta": {
-      "color": "#AF52DE"
+      "color": "#8250DF"
     },
     "cyan": {
-      "color": "#59ADC4"
+      "color": "#0550AE"
     },
     "white": {
       "color": "#D9D9D9"
@@ -101,22 +101,22 @@
       "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#FF3B30"
+      "color": "#CF222E"
     },
     "brightGreen": {
-      "color": "#28CD41"
+      "color": "#116329"
     },
     "brightYellow": {
-      "color": "#FFFF00"
+      "color": "#B38300"
     },
     "brightBlue": {
-      "color": "#007AFF"
+      "color": "#79C0FF"
     },
     "brightMagenta": {
-      "color": "#AF52DE"
+      "color": "#8250DF"
     },
     "brightCyan": {
-      "color": "#55BEF0"
+      "color": "#0550AE"
     },
     "brightWhite": {
       "color": "#FFFFFF"

--- a/DefaultThemes/High Contrast (Dark).cetheme
+++ b/DefaultThemes/High Contrast (Dark).cetheme
@@ -1,98 +1,98 @@
 {
-  "name": "GitHub (Light)",
-  "displayName": "GitHub (Light)",
-  "description": "GitHub light theme.",
+  "name": "high.contrast.dark",
+  "displayName": "High Contrast (Dark)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
   "distributionURL": "https://github.com/CodeEditApp/CodeEdit",
-  "type": "light",
+  "type": "dark",
   "editor": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#1F1F24"
     },
     "selection": {
-      "color": "#B4D6F5"
+      "color": "#434D5D"
     },
     "insertionPoint": {
-      "color": "#24292F"
+      "color": "#FFFFFF"
     },
     "lineHighlight": {
-      "color": "#E8F2FF"
+      "color": "#2F3139"
     },
     "invisibles": {
-      "color": "#CCCCCC"
+      "color": "#53606E"
     },
     "text": {
-      "color": "#24292F"
+      "color": "#FFFFFF"
     },
     "comments": {
-      "color": "#6E7781"
+      "color": "#8DBF67"
     },
     "strings": {
-      "color": "#0A3069"
+      "color": "#FF8A7A"
     },
     "characters": {
-      "color": "#0550AE"
+      "color": "#D9C668"
     },
     "numbers": {
-      "color": "#0550AE"
+      "color": "#D9C668"
     },
     "keywords": {
-      "color": "#CF222E"
+      "color": "#FF85B8"
     },
     "attributes": {
-      "color": "#0550AE"
+      "color": "#E8B68B"
     },
     "types": {
-      "color": "#0550AE"
+      "color": "#6BDFFF"
     },
     "variables": {
-      "color": "#8250DF"
+      "color": "#4EC4E6"
     },
     "commands": {
-      "color": "#8250df"
+      "color": "#83C9BC"
     },
     "values": {
-      "color": "#0550AE"
+      "color": "#CDA1FF"
     }
   },
   "terminal": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#1F1F24"
     },
     "selection": {
-      "color": "#B4D6F5"
+      "color": "#646F83"
     },
     "cursor": {
-      "color": "#24292F"
+      "color": "#FFFFFF"
     },
     "text": {
-      "color": "#24292f"
+      "color": "#FFFFFF"
     },
     "boldText": {
-      "color": "#24292F"
+      "color": "#D9D9D9"
     },
     "black": {
       "color": "#1F2024"
     },
     "red": {
-      "color": "#CF222E"
+      "color": "#FF8A7A"
     },
     "green": {
-      "color": "#7EE787"
+      "color": "#8DBF67"
     },
     "yellow": {
-      "color": "#F2CC60"
+      "color": "#FFCC00"
     },
     "blue": {
-      "color": "#79C0FF"
+      "color": "#4EC4E6"
     },
     "magenta": {
-      "color": "#8250DF"
+      "color": "#FF85B8"
     },
     "cyan": {
-      "color": "#0550AE"
+      "color": "#6BDFFF"
     },
     "white": {
       "color": "#D9D9D9"
@@ -101,22 +101,22 @@
       "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#CF222E"
+      "color": "#FF8A7A"
     },
     "brightGreen": {
-      "color": "#116329"
+      "color": "#8DBF67"
     },
     "brightYellow": {
-      "color": "#B38300"
+      "color": "#FFCC00"
     },
     "brightBlue": {
-      "color": "#79C0FF"
+      "color": "#CDA1FF"
     },
     "brightMagenta": {
-      "color": "#8250DF"
+      "color": "#FF85B8"
     },
     "brightCyan": {
-      "color": "#0550AE"
+      "color": "#4EC4E6"
     },
     "brightWhite": {
       "color": "#FFFFFF"

--- a/DefaultThemes/High Contrast (Light).cetheme
+++ b/DefaultThemes/High Contrast (Light).cetheme
@@ -1,7 +1,7 @@
 {
-  "name": "Sunset",
-  "displayName": "Sunset",
-  "description": "Solarized light theme.",
+  "name": "high.contrast.light",
+  "displayName": "High Contrast (Light)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
@@ -9,117 +9,117 @@
   "type": "light",
   "editor": {
     "background": {
-      "color": "#FFFCEA"
+      "color": "#FFFFFF"
     },
     "selection": {
-      "color": "#FBE4AC"
+      "color": "#B2D7FF"
     },
     "insertionPoint": {
       "color": "#000000"
     },
     "lineHighlight": {
-      "color": "#FEF6DB"
+      "color": "#ECF5FF"
     },
     "invisibles": {
-      "color": "#DACFB3"
+      "color": "#D6D6D6"
     },
     "text": {
       "color": "#000000"
     },
     "comments": {
-      "color": "#C3741C"
+      "color": "#1F6300"
     },
     "strings": {
-      "color": "#DF0700"
+      "color": "#AD1805"
     },
     "characters": {
-      "color": "#294277"
+      "color": "#272AD8"
     },
     "numbers": {
-      "color": "#294277"
+      "color": "#272AD8"
     },
     "keywords": {
-      "color": "#294277"
+      "color": "#9C2191"
     },
     "attributes": {
-      "color": "#2C329D"
+      "color": "#6E5400"
     },
     "types": {
-      "color": "#0B4F79"
+      "color": "#003F73"
     },
     "variables": {
-      "color": "#0F68A0"
+      "color": "#0058A1"
     },
     "commands": {
-      "color": "#476A97"
+      "color": "#294B4E"
     },
     "values": {
-      "color": "#476A97"
+      "color": "#330090"
     }
   },
   "terminal": {
     "background": {
-      "color": "#FFFCEA"
+      "color": "#FFFFFF"
     },
     "selection": {
-      "color": "#FBE4AC"
+      "color": "#B2D7FF"
     },
-    "insertionPoint": {
+    "cursor": {
       "color": "#000000"
     },
     "text": {
-      "color": "#657B83"
+      "color": "#000000"
     },
     "boldText": {
-      "color": "#586E75"
+      "color": "#262626"
     },
     "black": {
-      "color": "#073642"
+      "color": "#1F2024"
     },
     "red": {
-      "color": "#DC322F"
+      "color": "#AD1805"
     },
     "green": {
-      "color": "#859900"
+      "color": "#1F6300"
     },
     "yellow": {
-      "color": "#B58900"
+      "color": "#6E5400"
     },
     "blue": {
-      "color": "#268BD2"
+      "color": "#272AD8"
     },
     "magenta": {
-      "color": "#D33682"
+      "color": "#9C2191"
     },
     "cyan": {
-      "color": "#2AA198"
+      "color": "#0058A1"
     },
     "white": {
-      "color": "#EEE8D5"
+      "color": "#D9D9D9"
     },
     "brightBlack": {
-      "color": "#002B36"
+      "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#CB4B16"
+      "color": "#AD1805"
     },
     "brightGreen": {
-      "color": "#586E75"
+      "color": "#1F6300"
     },
     "brightYellow": {
-      "color": "#657B83"
+      "color": "#6E5400"
     },
     "brightBlue": {
-      "color": "#839496"
+      "color": "#272AD8"
     },
     "brightMagenta": {
-      "color": "#6C71C4"
+      "color": "#9C2191"
     },
     "brightCyan": {
-      "color": "#93A1A1"
+      "color": "#0058A1"
     },
     "brightWhite": {
-      "color": "#FDF6E3"
+      "color": "#FFFFFF"
     }
   }
 }

--- a/DefaultThemes/Low Key.cetheme
+++ b/DefaultThemes/Low Key.cetheme
@@ -1,98 +1,98 @@
 {
-  "name": "Default (Dark)",
-  "displayName": "Default (Dark)",
-  "description": "Xcode dark theme.",
+  "name": "low.key",
+  "displayName": "Low Key",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
   "distributionURL": "https://github.com/CodeEditApp/CodeEdit",
-  "type": "dark",
+  "type": "light",
   "editor": {
     "background": {
-      "color": "#292A30"
-    },
-    "selection": {
-      "color": "#646F83"
-    },
-    "insertionPoint": {
-      "color": "#007AFF"
-    },
-    "lineHighlight": {
-      "color": "#2F3239"
-    },
-    "invisibles": {
-      "color": "#53606E"
-    },
-    "text": {
       "color": "#FFFFFF"
     },
+    "selection": {
+      "color": "#D8DDDA"
+    },
+    "insertionPoint": {
+      "color": "#000000"
+    },
+    "lineHighlight": {
+      "color": "#F5F7F6"
+    },
+    "invisibles": {
+      "color": "#C0C0C0"
+    },
+    "text": {
+      "color": "#000000"
+    },
     "comments": {
-      "color": "#6C7986"
+      "color": "#546348"
     },
     "strings": {
-      "color": "#FC6A5D"
+      "color": "#843E64"
     },
     "characters": {
-      "color": "#D0BF69"
+      "color": "#323E7D"
     },
     "numbers": {
-      "color": "#D0BF69"
+      "color": "#323E7D"
     },
     "keywords": {
-      "color": "#FC5FA3"
+      "color": "#323E7D"
     },
     "attributes": {
-      "color": "#BF8555"
+      "color": "#255E22"
     },
     "types": {
-      "color": "#5DD8FF"
+      "color": "#02638C"
     },
     "variables": {
-      "color": "#41A1C0"
+      "color": "#0F68A0"
     },
     "commands": {
-      "color": "#67B7A4"
+      "color": "#587EA8"
     },
     "values": {
-      "color": "#A167E6"
+      "color": "#587EA8"
     }
   },
   "terminal": {
     "background": {
-      "color": "#292A30"
+      "color": "#FFFFFF"
     },
     "selection": {
-      "color": "#646F83"
+      "color": "#D8DDDA"
     },
     "cursor": {
-      "color": "#FFFFFF"
+      "color": "#000000"
     },
     "text": {
-      "color": "#FFFFFF"
+      "color": "#000000"
     },
     "boldText": {
-      "color": "#D9D9D9"
+      "color": "#000000"
     },
     "black": {
       "color": "#1F2024"
     },
     "red": {
-      "color": "#FF3B30"
+      "color": "#843E64"
     },
     "green": {
-      "color": "#28CD41"
+      "color": "#255E22"
     },
     "yellow": {
-      "color": "#FFCC00"
+      "color": "#546348"
     },
     "blue": {
-      "color": "#007AFF"
+      "color": "#587EA8"
     },
     "magenta": {
-      "color": "#AF52DE"
+      "color": "#323E7D"
     },
     "cyan": {
-      "color": "#59ADC4"
+      "color": "#02638C"
     },
     "white": {
       "color": "#D9D9D9"
@@ -101,22 +101,22 @@
       "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#FF3B30"
+      "color": "#843E64"
     },
     "brightGreen": {
-      "color": "#28CD41"
+      "color": "#255E22"
     },
     "brightYellow": {
-      "color": "#FFFF00"
+      "color": "#546348"
     },
     "brightBlue": {
-      "color": "#007AFF"
+      "color": "#587EA8"
     },
     "brightMagenta": {
-      "color": "#AF52DE"
+      "color": "#323E7D"
     },
     "brightCyan": {
-      "color": "#55BEF0"
+      "color": "#02638C"
     },
     "brightWhite": {
       "color": "#FFFFFF"

--- a/DefaultThemes/Midnight.cetheme
+++ b/DefaultThemes/Midnight.cetheme
@@ -1,7 +1,7 @@
 {
-  "name": "High Contrast (Dark)",
-  "displayName": "High Contrast (Dark)",
-  "description": "Xcode dark theme.",
+  "name": "midnight",
+  "displayName": "Midnight",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
@@ -9,66 +9,66 @@
   "type": "dark",
   "editor": {
     "background": {
-      "color": "#1F1F24"
+      "color": "#000000"
     },
     "selection": {
-      "color": "#434D5D"
+      "color": "#5D5952"
     },
     "insertionPoint": {
       "color": "#FFFFFF"
     },
     "lineHighlight": {
-      "color": "#2F3139"
+      "color": "#232121"
     },
     "invisibles": {
-      "color": "#53606E"
+      "color": "#424242"
     },
     "text": {
       "color": "#FFFFFF"
     },
     "comments": {
-      "color": "#8DBF67"
+      "color": "#4BD157"
     },
     "strings": {
-      "color": "#FF8A7A"
+      "color": "#FF4647"
     },
     "characters": {
-      "color": "#D9C668"
+      "color": "#8B87FF"
     },
     "numbers": {
-      "color": "#D9C668"
+      "color": "#8B87FF"
     },
     "keywords": {
-      "color": "#FF85B8"
+      "color": "#DE38A6"
     },
     "attributes": {
-      "color": "#E8B68B"
+      "color": "#3B5AAB"
     },
     "types": {
       "color": "#6BDFFF"
     },
     "variables": {
-      "color": "#4EC4E6"
+      "color": "#4EB0CC"
     },
     "commands": {
-      "color": "#83C9BC"
+      "color": "#09FA95"
     },
     "values": {
-      "color": "#CDA1FF"
+      "color": "#00B1FF"
     }
   },
   "terminal": {
     "background": {
-      "color": "#1F1F24"
+      "color": "#000000"
     },
     "selection": {
-      "color": "#646F83"
+      "color": "#5D5952"
     },
     "cursor": {
       "color": "#FFFFFF"
     },
     "text": {
-      "color": "#FFFFFF"
+      "color": "#D9D9D9"
     },
     "boldText": {
       "color": "#D9D9D9"
@@ -77,22 +77,22 @@
       "color": "#1F2024"
     },
     "red": {
-      "color": "#FF3B30"
+      "color": "#FF4647"
     },
     "green": {
-      "color": "#28CD41"
+      "color": "#4BD157"
     },
     "yellow": {
-      "color": "#FFCC00"
+      "color": "#EB905A"
     },
     "blue": {
-      "color": "#007AFF"
+      "color": "#00B1FF"
     },
     "magenta": {
-      "color": "#AF52DE"
+      "color": "#DE38A6"
     },
     "cyan": {
-      "color": "#59ADC4"
+      "color": "#6BDFFF"
     },
     "white": {
       "color": "#D9D9D9"
@@ -101,22 +101,22 @@
       "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#FF3B30"
+      "color": "#FF4647"
     },
     "brightGreen": {
-      "color": "#28CD41"
+      "color": "#4BD157"
     },
     "brightYellow": {
-      "color": "#FFFF00"
+      "color": "#EB905A"
     },
     "brightBlue": {
-      "color": "#007AFF"
+      "color": "#00B1FF"
     },
     "brightMagenta": {
-      "color": "#AF52DE"
+      "color": "#DE38A6"
     },
     "brightCyan": {
-      "color": "#55BEF0"
+      "color": "#6BDFFF"
     },
     "brightWhite": {
       "color": "#FFFFFF"

--- a/DefaultThemes/Presentation (Dark).cetheme
+++ b/DefaultThemes/Presentation (Dark).cetheme
@@ -1,98 +1,98 @@
 {
-  "name": "High Contrast (Light)",
-  "displayName": "High Contrast (Light)",
-  "description": "Xcode light theme.",
+  "name": "presentation.dark",
+  "displayName": "Presentation (Dark)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
   "distributionURL": "https://github.com/CodeEditApp/CodeEdit",
-  "type": "light",
+  "type": "dark",
   "editor": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#202025"
     },
     "selection": {
-      "color": "#B2D7FF"
+      "color": "#646F83"
     },
     "insertionPoint": {
-      "color": "#000000"
+      "color": "#007AFF"
     },
     "lineHighlight": {
-      "color": "#ECF5FF"
+      "color": "#444551"
     },
     "invisibles": {
-      "color": "#D6D6D6"
+      "color": "#5F5F5F"
     },
     "text": {
-      "color": "#000000"
+      "color": "#FFFFFF"
     },
     "comments": {
-      "color": "#1F6300"
+      "color": "#7F8C99"
     },
     "strings": {
-      "color": "#AD1805"
+      "color": "#FF5F63"
     },
     "characters": {
-      "color": "#272AD8"
+      "color": "#FFEA80"
     },
     "numbers": {
-      "color": "#272AD8"
+      "color": "#FFEA80"
     },
     "keywords": {
-      "color": "#9C2191"
+      "color": "#F7439D"
     },
     "attributes": {
-      "color": "#6E5400"
+      "color": "#E7AD78"
     },
     "types": {
-      "color": "#003F73"
+      "color": "#75E1FF"
     },
     "variables": {
-      "color": "#0058A1"
+      "color": "#3EBDE0"
     },
     "commands": {
-      "color": "#294B4E"
+      "color": "#64D7C0"
     },
     "values": {
-      "color": "#330090"
+      "color": "#BB81FF"
     }
   },
   "terminal": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#202025"
     },
     "selection": {
-      "color": "#B2D7FF"
+      "color": "#646F83"
     },
     "cursor": {
-      "color": "#000000"
+      "color": "#FFFFFF"
     },
     "text": {
-      "color": "#000000"
+      "color": "#FFFFFF"
     },
     "boldText": {
-      "color": "#262626"
+      "color": "#D9D9D9"
     },
     "black": {
       "color": "#1F2024"
     },
     "red": {
-      "color": "#FF3B30"
+      "color": "#FF5F63"
     },
     "green": {
-      "color": "#28CD41"
+      "color": "#64D7C0"
     },
     "yellow": {
-      "color": "#FFCC00"
+      "color": "#FFEA80"
     },
     "blue": {
-      "color": "#007AFF"
+      "color": "#3EBDE0"
     },
     "magenta": {
-      "color": "#AF52DE"
+      "color": "#F7439D"
     },
     "cyan": {
-      "color": "#59ADC4"
+      "color": "#75E1FF"
     },
     "white": {
       "color": "#D9D9D9"
@@ -101,22 +101,22 @@
       "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#FF3B30"
+      "color": "#FF5F63"
     },
     "brightGreen": {
-      "color": "#28CD41"
+      "color": "#64D7C0"
     },
     "brightYellow": {
-      "color": "#FFCC00"
+      "color": "#FFEA80"
     },
     "brightBlue": {
-      "color": "#007AFF"
+      "color": "#3EBDE0"
     },
     "brightMagenta": {
-      "color": "#AF52DE"
+      "color": "#F7439D"
     },
     "brightCyan": {
-      "color": "#55BEF0"
+      "color": "#75E1FF"
     },
     "brightWhite": {
       "color": "#FFFFFF"

--- a/DefaultThemes/Presentation (Light).cetheme
+++ b/DefaultThemes/Presentation (Light).cetheme
@@ -1,7 +1,7 @@
 {
-  "name": "Solarized (Light)",
-  "displayName": "Solarized (Light)",
-  "description": "Solarized light theme.",
+  "name": "presentation.light",
+  "displayName": "Presentation (Light)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
@@ -9,117 +9,117 @@
   "type": "light",
   "editor": {
     "background": {
-      "color": "#FDF6E3"
+      "color": "#FFFFFF"
     },
     "selection": {
-      "color": "#93A1A1"
+      "color": "#D1E3FF"
     },
     "insertionPoint": {
-      "color": "#657B83"
+      "color": "#007AFF"
     },
     "lineHighlight": {
-      "color": "#EEE8D5"
+      "color": "#ECF5FF"
     },
     "invisibles": {
-      "color": "#EEE8D5"
+      "color": "#D6D6D6"
     },
     "text": {
-      "color": "#657B83"
+      "color": "#000000"
     },
     "comments": {
-      "color": "#93A1A1"
+      "color": "#69737E"
     },
     "strings": {
-      "color": "#2AA198"
+      "color": "#C91B13"
     },
     "characters": {
-      "color": "#DC322F"
+      "color": "#0435FF"
     },
     "numbers": {
-      "color": "#DC322F"
+      "color": "#0435FF"
     },
     "keywords": {
-      "color": "#859900"
+      "color": "#C32275"
     },
     "attributes": {
-      "color": "#6C71C4"
+      "color": "#967E34"
     },
     "types": {
-      "color": "#268BD2"
+      "color": "#005C88"
     },
     "variables": {
-      "color": "#B58900"
+      "color": "#057CB0"
     },
     "commands": {
-      "color": "#CB4B16"
+      "color": "#49919B"
     },
     "values": {
-      "color": "#D33682"
+      "color": "#703DAA"
     }
   },
   "terminal": {
     "background": {
-      "color": "#FDF6E3"
+      "color": "#FFFFFF"
     },
     "selection": {
-      "color": "#93A1A1"
+      "color": "#D1E3FF"
     },
     "cursor": {
-      "color": "#657B83"
+      "color": "#000000"
     },
     "text": {
-      "color": "#657B83"
+      "color": "#000000"
     },
     "boldText": {
-      "color": "#586E75"
+      "color": "#262626"
     },
     "black": {
-      "color": "#073642"
+      "color": "#1F2024"
     },
     "red": {
-      "color": "#DC322F"
+      "color": "#C91B13"
     },
     "green": {
-      "color": "#859900"
+      "color": "#005C88"
     },
     "yellow": {
-      "color": "#B58900"
+      "color": "#967E34"
     },
     "blue": {
-      "color": "#268BD2"
+      "color": "#0435FF"
     },
     "magenta": {
-      "color": "#D33682"
+      "color": "#C32275"
     },
     "cyan": {
-      "color": "#2AA198"
+      "color": "#49919B"
     },
     "white": {
-      "color": "#EEE8D5"
+      "color": "#D9D9D9"
     },
     "brightBlack": {
-      "color": "#002B36"
+      "color": "#8E8E93"
     },
     "brightRed": {
-      "color": "#CB4B16"
+      "color": "#C91B13"
     },
     "brightGreen": {
-      "color": "#586E75"
+      "color": "#005C88"
     },
     "brightYellow": {
-      "color": "#657B83"
+      "color": "#967E34"
     },
     "brightBlue": {
-      "color": "#839496"
+      "color": "#0435FF"
     },
     "brightMagenta": {
-      "color": "#6C71C4"
+      "color": "#C32275"
     },
     "brightCyan": {
-      "color": "#93A1A1"
+      "color": "#49919B"
     },
     "brightWhite": {
-      "color": "#FDF6E3"
+      "color": "#FFFFFF"
     }
   }
 }

--- a/DefaultThemes/Solarized (Dark).cetheme
+++ b/DefaultThemes/Solarized (Dark).cetheme
@@ -1,7 +1,7 @@
 {
-  "name": "GitHub (Dark)",
-  "displayName": "GitHub (Dark)",
-  "description": "GitHub dark theme.",
+  "name": "solarized.dark",
+  "displayName": "Solarized (Dark)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
@@ -9,117 +9,117 @@
   "type": "dark",
   "editor": {
     "background": {
-      "color": "#0D1117"
+      "color": "#002B36"
     },
     "selection": {
-      "color": "#1E4273"
+      "color": "#586E75"
     },
     "insertionPoint": {
-      "color": "#C9D1D9"
+      "color": "#839496"
     },
     "lineHighlight": {
-      "color": "#23252B"
+      "color": "#073642"
     },
     "invisibles": {
-      "color": "#424D5B"
+      "color": "#073642"
     },
     "text": {
-      "color": "#C9D1D9"
+      "color": "#839496"
     },
     "comments": {
-      "color": "#8B949E"
+      "color": "#586E75"
     },
     "strings": {
-      "color": "#A5D6FF"
+      "color": "#2AA198"
     },
     "characters": {
-      "color": "#79C0FF"
+      "color": "#DC322F"
     },
     "numbers": {
-      "color": "#79C0FF"
+      "color": "#DC322F"
     },
     "keywords": {
-      "color": "#FF7B72"
+      "color": "#859900"
     },
     "attributes": {
-      "color": "#79C0FF"
+      "color": "#6C71C4"
     },
     "types": {
-      "color": "#79C0FF"
+      "color": "#268BD2"
     },
     "variables": {
-      "color": "#D2A8FF"
+      "color": "#B58900"
     },
     "commands": {
-      "color": "#D2A8FF"
+      "color": "#CB4B16"
     },
     "values": {
-      "color": "#79C0FF"
+      "color": "#D33682"
     }
   },
   "terminal": {
     "background": {
-      "color": "#0D1117"
+      "color": "#002B36"
     },
     "selection": {
-      "color": "#1E4273"
+      "color": "#586E75"
     },
     "cursor": {
-      "color": "#C9D1D9"
+      "color": "#839496"
     },
     "text": {
-      "color": "#C9D1D9"
+      "color": "#839496"
     },
     "boldText": {
-      "color": "#C9D1D9"
+      "color": "#839496"
     },
     "black": {
-      "color": "#1F2024"
+      "color": "#073642"
     },
     "red": {
-      "color": "#FF7B72"
+      "color": "#DC322F"
     },
     "green": {
-      "color": "#7EE787"
+      "color": "#859900"
     },
     "yellow": {
-      "color": "#F2CC60"
+      "color": "#B58900"
     },
     "blue": {
-      "color": "#79C0FF"
+      "color": "#268BD2"
     },
     "magenta": {
-      "color": "#D2A8FF"
+      "color": "#D33682"
     },
     "cyan": {
-      "color": "#79C0FF"
+      "color": "#2AA198"
     },
     "white": {
-      "color": "#D9D9D9"
+      "color": "#EEE8D5"
     },
     "brightBlack": {
-      "color": "#8E8E93"
+      "color": "#002B36"
     },
     "brightRed": {
-      "color": "#FF7B72"
+      "color": "#CB4B16"
     },
     "brightGreen": {
-      "color": "#7EE787"
+      "color": "#586E75"
     },
     "brightYellow": {
-      "color": "#F2CC60"
+      "color": "#657B83"
     },
     "brightBlue": {
-      "color": "#79C0FF"
+      "color": "#839496"
     },
     "brightMagenta": {
-      "color": "#D2A8FF"
+      "color": "#6C71C4"
     },
     "brightCyan": {
-      "color": "#79C0FF"
+      "color": "#93A1A1"
     },
     "brightWhite": {
-      "color": "#FFFFFF"
+      "color": "#FDF6E3"
     }
   }
 }

--- a/DefaultThemes/Solarized (Light).cetheme
+++ b/DefaultThemes/Solarized (Light).cetheme
@@ -1,7 +1,7 @@
 {
-  "name": "Low Key",
-  "displayName": "Low Key",
-  "description": "Xcode dark theme.",
+  "name": "solarized.light",
+  "displayName": "Solarized (Light)",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
@@ -9,117 +9,117 @@
   "type": "light",
   "editor": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#FDF6E3"
     },
     "selection": {
-      "color": "#D8DDDA"
+      "color": "#93A1A1"
     },
     "insertionPoint": {
-      "color": "#000000"
+      "color": "#657B83"
     },
     "lineHighlight": {
-      "color": "#F5F7F6"
+      "color": "#EEE8D5"
     },
     "invisibles": {
-      "color": "#C0C0C0"
+      "color": "#EEE8D5"
     },
     "text": {
-      "color": "#000000"
+      "color": "#657B83"
     },
     "comments": {
-      "color": "#435138"
+      "color": "#93A1A1"
     },
     "strings": {
-      "color": "#702C51"
+      "color": "#2AA198"
     },
     "characters": {
-      "color": "#262C6A"
+      "color": "#DC322F"
     },
     "numbers": {
-      "color": "#262C6A"
+      "color": "#DC322F"
     },
     "keywords": {
-      "color": "#262C6A"
+      "color": "#859900"
     },
     "attributes": {
-      "color": "#1E4D1A"
+      "color": "#6C71C4"
     },
     "types": {
-      "color": "#0B4F79"
+      "color": "#268BD2"
     },
     "variables": {
-      "color": "#0F68A0"
+      "color": "#B58900"
     },
     "commands": {
-      "color": "#476A97"
+      "color": "#CB4B16"
     },
     "values": {
-      "color": "#476A97"
+      "color": "#D33682"
     }
   },
   "terminal": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#FDF6E3"
     },
     "selection": {
-      "color": "#D8DDDA"
+      "color": "#93A1A1"
     },
     "cursor": {
-      "color": "#000000"
+      "color": "#657B83"
     },
     "text": {
-      "color": "#000000"
+      "color": "#657B83"
     },
     "boldText": {
-      "color": "#000000"
+      "color": "#586E75"
     },
     "black": {
-      "color": "#1F2024"
+      "color": "#073642"
     },
     "red": {
-      "color": "#FF3B30"
+      "color": "#DC322F"
     },
     "green": {
-      "color": "#28CD41"
+      "color": "#859900"
     },
     "yellow": {
-      "color": "#FFCC00"
+      "color": "#B58900"
     },
     "blue": {
-      "color": "#007AFF"
+      "color": "#268BD2"
     },
     "magenta": {
-      "color": "#AF52DE"
+      "color": "#D33682"
     },
     "cyan": {
-      "color": "#59ADC4"
+      "color": "#2AA198"
     },
     "white": {
-      "color": "#D9D9D9"
+      "color": "#EEE8D5"
     },
     "brightBlack": {
-      "color": "#8E8E93"
+      "color": "#002B36"
     },
     "brightRed": {
-      "color": "#FF3B30"
+      "color": "#CB4B16"
     },
     "brightGreen": {
-      "color": "#28CD41"
+      "color": "#586E75"
     },
     "brightYellow": {
-      "color": "#FFFF00"
+      "color": "#657B83"
     },
     "brightBlue": {
-      "color": "#007AFF"
+      "color": "#839496"
     },
     "brightMagenta": {
-      "color": "#AF52DE"
+      "color": "#6C71C4"
     },
     "brightCyan": {
-      "color": "#55BEF0"
+      "color": "#93A1A1"
     },
     "brightWhite": {
-      "color": "#FFFFFF"
+      "color": "#FDF6E3"
     }
   }
 }

--- a/DefaultThemes/Sunset.cetheme
+++ b/DefaultThemes/Sunset.cetheme
@@ -1,7 +1,7 @@
 {
-  "name": "Classic (Light)",
-  "displayName": "Classic (Light)",
-  "description": "Xcode light theme.",
+  "name": "sunset",
+  "displayName": "Sunset",
+  "description": "CodeEdit bundled theme.",
   "author": "CodeEdit",
   "version": "0.0.1",
   "license": "MIT",
@@ -9,114 +9,114 @@
   "type": "light",
   "editor": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#FFFCEA"
     },
     "selection": {
-      "color": "#B2D7FF"
+      "color": "#FBE4AC"
     },
     "insertionPoint": {
       "color": "#000000"
     },
     "lineHighlight": {
-      "color": "#ECF5FF"
+      "color": "#FEF6DB"
     },
     "invisibles": {
-      "color": "#D6D6D6"
+      "color": "#DACFB3"
     },
     "text": {
       "color": "#000000"
     },
     "comments": {
-      "color": "#267507"
+      "color": "#CF8724"
     },
     "strings": {
-      "color": "#C41A16"
+      "color": "#E82300"
     },
     "characters": {
-      "color": "#1C00CF"
+      "color": "#35568A"
     },
     "numbers": {
-      "color": "#1C00CF"
+      "color": "#35568A"
     },
     "keywords": {
-      "color": "#9B2393"
+      "color": "#35568A"
     },
     "attributes": {
-      "color": "#815F03"
+      "color": "#3A48AD"
     },
     "types": {
-      "color": "#0B4F79"
+      "color": "#02638C"
     },
     "variables": {
-      "color": "#0F68A0"
+      "color": "#057CB0"
     },
     "commands": {
-      "color": "#326D74"
+      "color": "#587EA8"
     },
     "values": {
-      "color": "#6C36A9"
+      "color": "#587EA8"
     }
   },
   "terminal": {
     "background": {
-      "color": "#FFFFFF"
+      "color": "#FFFCEA"
     },
     "selection": {
-      "color": "#B2D7FF"
+      "color": "#FBE4AC"
     },
-    "cursor": {
+    "insertionPoint": {
       "color": "#000000"
     },
     "text": {
       "color": "#000000"
     },
     "boldText": {
-      "color": "#262626"
+      "color": "#000000"
     },
     "black": {
-      "color": "#1F2024"
+      "color": "#000000"
     },
     "red": {
-      "color": "#FF3B30"
+      "color": "#E82300"
     },
     "green": {
-      "color": "#28CD41"
+      "color": "#02638C"
     },
     "yellow": {
-      "color": "#FFCC00"
+      "color": "#CF8724"
     },
     "blue": {
-      "color": "#007AFF"
+      "color": "#35568A"
     },
     "magenta": {
-      "color": "#AF52DE"
+      "color": "#3A48AD"
     },
     "cyan": {
-      "color": "#59ADC4"
+      "color": "#587EA8"
     },
     "white": {
-      "color": "#D9D9D9"
+      "color": "#FFFFFF"
     },
     "brightBlack": {
-      "color": "#8E8E93"
+      "color": "#000000"
     },
     "brightRed": {
-      "color": "#FF3B30"
+      "color": "#E82300"
     },
     "brightGreen": {
-      "color": "#28CD41"
+      "color": "#02638C"
     },
     "brightYellow": {
-      "color": "#FFCC00"
+      "color": "#CF8724"
     },
     "brightBlue": {
-      "color": "#007AFF"
+      "color": "#35568A"
     },
     "brightMagenta": {
-      "color": "#AF52DE"
+      "color": "#3A48AD"
     },
     "brightCyan": {
-      "color": "#55BEF0"
+      "color": "#587EA8"
     },
     "brightWhite": {
       "color": "#FFFFFF"


### PR DESCRIPTION
### Description

We currently pull themes from two places...
- /Applications/CodeEdit.app/Resources/DefaultThemes
- ~/Library/Application Support/CodeEdit/themes

Bundled themes are no longer copied to user themes folder and read in directly. 

We are also correcting some theme colors to sRGB color space.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

TBD