### PR TITLE
Alternate Cursor Location Description

### DIFF
--- a/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorLocationLabel.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorLocationLabel.swift
@@ -9,8 +9,8 @@ import SwiftUI
 import CodeEditSourceEditor
 
 struct StatusBarCursorLocationLabel: View {
-    @Environment(\.controlActiveState)
-    private var controlActive
+    @Environment(\.controlActiveState) private var controlActive
+    @Environment(\.modifierKeys) private var modifierKeys
 
     @EnvironmentObject private var model: UtilityAreaViewModel
     @EnvironmentObject private var editorManager: EditorManager
@@ -38,11 +38,18 @@ struct StatusBarCursorLocationLabel: View {
             return ""
         }
 
+        // More than one selection, display the number of selections.
         if cursorPositions.count > 1 {
             return "\(cursorPositions.count) selected ranges"
         }
 
+        // If the selection is more than just a cursor, return the length.
         if cursorPositions[0].range.length > 0 {
+            // When the option key is pressed display the character range.
+            if modifierKeys.contains(.option) {
+                return "Char: \(cursorPositions[0].range.location) Len: \(cursorPositions[0].range.length)"
+            }
+
             let lineCount = getLines(cursorPositions[0].range)
 
             if lineCount > 1 {
@@ -52,6 +59,12 @@ struct StatusBarCursorLocationLabel: View {
             return "\(cursorPositions[0].range.length) characters"
         }
 
+        // When the option key is pressed display the character offset.
+        if modifierKeys.contains(.option) {
+            return "Char: \(cursorPositions[0].range.location) Len: 0"
+        }
+
+        // When there's a single cursor, display the line and column.
         return "Line: \(cursorPositions[0].line)  Col: \(cursorPositions[0].column)"
     }
 
@@ -77,6 +90,7 @@ struct StatusBarCursorLocationLabel: View {
         .fixedSize()
         .lineLimit(1)
         .onHover { isHovering($0) }
+        
         .onAppear {
             updateSource()
         }

--- a/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorLocationLabel.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorLocationLabel.swift
@@ -9,8 +9,10 @@ import SwiftUI
 import CodeEditSourceEditor
 
 struct StatusBarCursorLocationLabel: View {
-    @Environment(\.controlActiveState) private var controlActive
-    @Environment(\.modifierKeys) private var modifierKeys
+    @Environment(\.controlActiveState)
+    private var controlActive
+    @Environment(\.modifierKeys)
+    private var modifierKeys
 
     @EnvironmentObject private var model: UtilityAreaViewModel
     @EnvironmentObject private var editorManager: EditorManager
@@ -90,7 +92,6 @@ struct StatusBarCursorLocationLabel: View {
         .fixedSize()
         .lineLimit(1)
         .onHover { isHovering($0) }
-
         .onAppear {
             updateSource()
         }

--- a/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorLocationLabel.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorLocationLabel.swift
@@ -90,7 +90,7 @@ struct StatusBarCursorLocationLabel: View {
         .fixedSize()
         .lineLimit(1)
         .onHover { isHovering($0) }
-        
+
         .onAppear {
             updateSource()
         }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Adds an alternate cursor location label that appears when holding the option ⌥ key.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

https://github.com/CodeEditApp/CodeEdit/assets/35942988/2c641d70-8cd0-4a1a-9d0f-21bf890225da

