### PR TITLE
FIX: Git History Date bug

### DIFF
--- a/CodeEdit/Features/CodeEditUI/Views/ToolbarBranchPicker.swift
+++ b/CodeEdit/Features/CodeEditUI/Views/ToolbarBranchPicker.swift
@@ -35,8 +35,8 @@ struct ToolbarBranchPicker: View {
             if currentBranch != nil {
                 Image.branch
                     .font(.title3)
-                    .imageScale(.large)
-                    .foregroundColor(controlActive == .inactive ? inactiveColor : .primary)
+                    .imageScale(.medium)
+                    .foregroundColor(controlActive == .inactive ? inactiveColor : .gray)
             } else {
                 Image(systemName: "folder.fill.badge.gearshape")
                     .font(.title3)
@@ -57,9 +57,10 @@ struct ToolbarBranchPicker: View {
                     }, label: {
                         Text(currentBranch.name)
                             .font(.subheadline)
-                            .foregroundColor(controlActive == .inactive ? inactiveColor : .secondary)
+                            .foregroundColor(controlActive == .inactive ? inactiveColor : .gray)
                             .frame(height: 11)
                     })
+                    .menuIndicator(isHovering ? .visible : .hidden)
                     .buttonStyle(.borderless)
                     .padding(.leading, -3)
                 }

--- a/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
@@ -25,7 +25,8 @@ extension GitClient {
         if let branchName { branchNameString = "--first-parent \(branchName)" }
         if let maxCount { maxCountString = "-n \(maxCount)" }
         let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale.current
+        dateFormatter.locale = Locale(identifier: Locale.current.identifier)
+//        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
         let output = try await run(
             "log --pretty=%h¦%H¦%s¦%aN¦%ae¦%cn¦%ce¦%aD¦ \(maxCountString) \(branchNameString) \(fileLocalPath)"

--- a/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
@@ -25,9 +25,11 @@ extension GitClient {
         if let branchName { branchNameString = "--first-parent \(branchName)" }
         if let maxCount { maxCountString = "-n \(maxCount)" }
         let dateFormatter = DateFormatter()
+        
+        // Can't use `Locale.current`, since it'd give a nil date outside the US
         dateFormatter.locale = Locale(identifier: Locale.current.identifier)
-//        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
+        
         let output = try await run(
             "log --pretty=%h¦%H¦%s¦%aN¦%ae¦%cn¦%ce¦%aD¦ \(maxCountString) \(branchNameString) \(fileLocalPath)"
                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
@@ -25,11 +25,11 @@ extension GitClient {
         if let branchName { branchNameString = "--first-parent \(branchName)" }
         if let maxCount { maxCountString = "-n \(maxCount)" }
         let dateFormatter = DateFormatter()
-        
+
         // Can't use `Locale.current`, since it'd give a nil date outside the US
         dateFormatter.locale = Locale(identifier: Locale.current.identifier)
         dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
-        
+
         let output = try await run(
             "log --pretty=%h¦%H¦%s¦%aN¦%ae¦%cn¦%ce¦%aD¦ \(maxCountString) \(branchNameString) \(fileLocalPath)"
                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Views/SourceControlNavigatorView.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Views/SourceControlNavigatorView.swift
@@ -13,7 +13,7 @@ struct SourceControlNavigatorView: View {
     var body: some View {
         if let sourceControlManager = workspace.workspaceFileManager?.sourceControlManager {
             VStack(spacing: 0) {
-                SourcControlNavigatorTabs()
+                SourceControlNavigatorTabs()
                     .environmentObject(sourceControlManager)
                     .task {
                         do {
@@ -34,7 +34,7 @@ struct SourceControlNavigatorView: View {
     }
 }
 
-struct SourcControlNavigatorTabs: View {
+struct SourceControlNavigatorTabs: View {
     @EnvironmentObject var sourceControlManager: SourceControlManager
     @State private var selectedSection: Int = 0
 


### PR DESCRIPTION
- Correct date isn't displayed in this history tab

- Branch image was slightly to big, compared to Xcode

- Branch menu color was a bit off

- Branch menu indicator wasn't hidden

<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
The commit date in the history tab wasn't displayed correctly. Additionally, the git branch menu had a few issues, including discrepancies in color, indicator visibility, and branch symbol size.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

na

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
Before:
<img width="264" alt="Screenshot 2024-02-03 at 9 28 35 PM" src="https://github.com/CodeEditApp/CodeEdit/assets/83090745/a82bf7a5-8879-4752-af52-0885007934b7">
Now:
<img width="275" alt="Screenshot 2024-02-03 at 9 27 37 PM" src="https://github.com/CodeEditApp/CodeEdit/assets/83090745/007e0862-4b3a-4a25-b69b-6ad4ac7891d4">
Before:
<img width="157" alt="Screenshot 2024-02-03 at 9 03 34 PM" src="https://github.com/CodeEditApp/CodeEdit/assets/83090745/0770526e-3776-4889-b675-37cbaca938b0">
Now:
<img width="178" alt="Screenshot 2024-02-03 at 9 26 03 PM" src="https://github.com/CodeEditApp/CodeEdit/assets/83090745/eb5fc857-a230-45c2-b5c5-11179742dddb">
When hovering:
<img width="158" alt="Screenshot 2024-02-03 at 9 26 07 PM" src="https://github.com/CodeEditApp/CodeEdit/assets/83090745/fd3e2860-4678-4e28-b539-2ab16de0a9d0">
