### PR TITLE
Fix Editor Layout Setup

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
@@ -96,7 +96,9 @@ final class CEWorkspaceFileManager {
         if let file = flattenedFileItems[path] {
             return file
         } else if createIfNotFound {
-            let url = URL(fileURLWithPath: path, relativeTo: folderUrl)
+            guard let url = URL(string: path, relativeTo: folderUrl) else {
+                return nil
+            }
 
             // Drill down towards the file, indexing any directories needed. If file is not in the `folderURL` or
             // subdirectories, exit.

--- a/CodeEdit/Features/Editor/Models/EditorLayout.swift
+++ b/CodeEdit/Features/Editor/Models/EditorLayout.swift
@@ -44,6 +44,23 @@ enum EditorLayout: Equatable {
         }
     }
 
+    func find(editor id: UUID) -> Editor? {
+        switch self {
+        case .one(let editor):
+            if editor.id == id {
+                return editor
+            }
+        case .vertical(let splitViewData), .horizontal(let splitViewData):
+            for layout in splitViewData.editorLayouts {
+                if let editor = layout.find(editor: id) {
+                    return editor
+                }
+            }
+        }
+
+        return nil
+    }
+
     /// Forms a set of all files currently represented by tabs.
     func gatherOpenFiles() -> Set<CEWorkspaceFile> {
         switch self {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

Fixes the editor not correctly restoring state between window opens. The issue was twofold:
- There was a bug with CEWorkspaceFileManager where paths that were being queried with spaces and URL encoded would be _doubly_ url encoded (eg, `path/test%20docs` would resolve to `path/test%2520docs`) and not be able to be resolved.
- The saved active editor was not being used correctly. This was fixed by adding a `find` method to the editor layouts to correctly use the "fixed" version of the layout after it's been resolved by the file manager. 

The state restoration code also got some extra logging in case of errors and a couple extra checks.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

https://github.com/CodeEditApp/CodeEdit/assets/35942988/15112cb4-150d-4790-b3ed-d9fbe59409d2

