### PR TITLE
FIX: Source Navigator Icon Symbols affected by accent color

### DIFF
--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Changes/Views/SourceControlNavigatorChangedFileView.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Changes/Views/SourceControlNavigatorChangedFileView.swift
@@ -53,8 +53,9 @@ struct SourceControlNavigatorChangedFileView: View {
                     .truncationMode(.middle)
             }, icon: {
                 Image(systemName: changedFile.systemImage)
+                    .foregroundStyle(changedFile.iconColor)
             })
-            .accentColor(changedFile.iconColor)
+
             Spacer()
             Text(changedFile.gitStatus?.description ?? "")
                 .font(.system(size: 11, weight: .bold))

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/History/Views/CommitChangedFileListItemView.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/History/Views/CommitChangedFileListItemView.swift
@@ -34,8 +34,9 @@ struct CommitChangedFileListItemView: View {
                     .truncationMode(.middle)
             }, icon: {
                 Image(systemName: changedFile.systemImage)
+                    .foregroundStyle(changedFile.iconColor)
             })
-            .accentColor(changedFile.iconColor)
+
             Spacer()
             Text(changedFile.gitStatus?.description ?? "")
                 .font(.system(size: 11, weight: .bold))

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Repository/Views/SourceControlNavigatorRepositoryItem.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Repository/Views/SourceControlNavigatorRepositoryItem.swift
@@ -29,12 +29,13 @@ struct SourceControlNavigatorRepositoryItem: View {
                 if item.symbolImage != nil {
                     Image(symbol: item.symbolImage ?? "")
                         .opacity(controlActiveState == .inactive ? 0.5 : 1)
+                        .foregroundStyle(item.imageColor ?? .accentColor)
                 } else {
                     Image(systemName: item.systemImage ?? "")
                         .opacity(controlActiveState == .inactive ? 0.5 : 1)
+                        .foregroundStyle(item.imageColor ?? .accentColor)
                 }
             })
-            .accentColor(item.imageColor ?? .accentColor)
             .padding(.leading, 1)
             .padding(.vertical, -1)
         } else {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
Before, we were using .accentColor to set the color of file icons in the source navigator. However, this wasn't the intended behavior, so I've updated it to use .foregroundStyle on the icons instead.
<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

na

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
Before:
![Screenshot_2024-02-06_alle_15](https://github.com/CodeEditApp/CodeEdit/assets/83090745/5124500b-c1f9-4c9a-bdb8-20dd9eb89c28)
<img width="353" alt="Screenshot_2024-02-06_alle_16 15 37" src="https://github.com/CodeEditApp/CodeEdit/assets/83090745/e400cf60-fb0a-4dcf-b520-5efa90e2cd62">

Now:
<img width="353" alt="Screenshot_2024-02-06_alle_16 11 31" src="https://github.com/CodeEditApp/CodeEdit/assets/83090745/9f8e78da-8a67-4e6d-ad32-7a399605853c">
