### PR TITLE
fix(git): use `branch --show-current` to get current branch

### DIFF
--- a/CodeEdit/Features/Git/Client/GitClient+Branches.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+Branches.swift
@@ -31,7 +31,7 @@ extension GitClient {
 
     /// Get current branch
     func getCurrentBranch() async throws -> GitBranch? {
-        let branchName = try await run("rev-parse --abbrev-ref HEAD").trimmingCharacters(in: .whitespacesAndNewlines)
+        let branchName = try await run("branch --show-current").trimmingCharacters(in: .whitespacesAndNewlines)
         let components = try await run(
             "for-each-ref --format=\"%(refname)|%(upstream:short)\" refs/heads/\(branchName)"
         )


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Updates the `git` command used to get the current branch from:

```bash
git rev-parse --abbrev-ref HEAD
```

To be:

```bash
git branch --show-current
```

`git branch --show-current` is available since Git 2.22 which was released Mid 2019
(official release notes https://public-inbox.org/git/xmqq36klozfu.fsf@gitster-ct.c.googlers.com/).

macOS Ventura uses git version `2.39.3` so this should be safe for users from Ventura and up.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1594

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="260" alt="Screenshot 2024-03-02 at 1 12 55 PM" src="https://github.com/CodeEditApp/CodeEdit/assets/34756077/9d4d2907-6bc3-4bb4-8114-0921cf2e2574">
