### PR TITLE
Navigation style setting and file history navigation improvements

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -422,6 +422,8 @@
 		B65B10FE2B08B07D002852CF /* SourceControlNavigatorChangesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65B10FD2B08B07D002852CF /* SourceControlNavigatorChangesList.swift */; };
 		B65B11012B09D5D4002852CF /* GitClient+Pull.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65B11002B09D5D4002852CF /* GitClient+Pull.swift */; };
 		B65B11042B09DB1C002852CF /* GitClient+Fetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65B11032B09DB1C002852CF /* GitClient+Fetch.swift */; };
+		B664C3B02B965F6C00816B4E /* NavigationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B664C3AF2B965F6C00816B4E /* NavigationSettings.swift */; };
+		B664C3B32B96634F00816B4E /* NavigationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B664C3B22B96634F00816B4E /* NavigationSettingsView.swift */; };
 		B66A4E4529C8E86D004573B4 /* CommandsFixes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66A4E4429C8E86D004573B4 /* CommandsFixes.swift */; };
 		B66A4E4C29C9179B004573B4 /* CodeEditApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66A4E4B29C9179B004573B4 /* CodeEditApp.swift */; };
 		B66A4E4F29C917B8004573B4 /* WelcomeWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66A4E4E29C917B8004573B4 /* WelcomeWindow.swift */; };
@@ -970,6 +972,8 @@
 		B65B10FD2B08B07D002852CF /* SourceControlNavigatorChangesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceControlNavigatorChangesList.swift; sourceTree = "<group>"; };
 		B65B11002B09D5D4002852CF /* GitClient+Pull.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitClient+Pull.swift"; sourceTree = "<group>"; };
 		B65B11032B09DB1C002852CF /* GitClient+Fetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitClient+Fetch.swift"; sourceTree = "<group>"; };
+		B664C3AF2B965F6C00816B4E /* NavigationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSettings.swift; sourceTree = "<group>"; };
+		B664C3B22B96634F00816B4E /* NavigationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSettingsView.swift; sourceTree = "<group>"; };
 		B66A4E4429C8E86D004573B4 /* CommandsFixes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandsFixes.swift; sourceTree = "<group>"; };
 		B66A4E4B29C9179B004573B4 /* CodeEditApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeEditApp.swift; sourceTree = "<group>"; };
 		B66A4E4E29C917B8004573B4 /* WelcomeWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeWindow.swift; sourceTree = "<group>"; };
@@ -1277,13 +1281,13 @@
 		287776EA27E350A100D46668 /* NavigatorArea */ = {
 			isa = PBXGroup;
 			children = (
-				307AC4CB2ABABD9800163376 /* ViewModels */,
 				D7012EE627E757660001E1EF /* FindNavigator */,
 				581550CB29FBD30400684881 /* OutlineView */,
 				286471AC27ED52950039369D /* ProjectNavigator */,
 				201169D52837B29600F92B46 /* SourceControlNavigator */,
 				B67660682AA972D400CD56B0 /* Models */,
 				B67660692AA972DC00CD56B0 /* Views */,
+				307AC4CB2ABABD9800163376 /* ViewModels */,
 			);
 			path = NavigatorArea;
 			sourceTree = "<group>";
@@ -2553,16 +2557,17 @@
 		B61DA9DD29D929BF00BF4A43 /* Pages */ = {
 			isa = PBXGroup;
 			children = (
+				B664C3AD2B965F4500816B4E /* NavigationSettings */,
+				B61DA9E129D929F900BF4A43 /* GeneralSettings */,
+				B6E41C6E29DD15540088F9F4 /* AccountsSettings */,
+				58F2EAAE292FB2B0004A9BDE /* ThemeSettings */,
+				B6EA1FF329DA37D3001BF195 /* TextEditingSettings */,
 				5B698A082B262F8400DE9392 /* SearchSettings */,
 				6C5BE51A2A3D5419002DA0FC /* FeatureFlags */,
 				B6CF632629E5417C0085880A /* Keybindings */,
-				B6E41C6E29DD15540088F9F4 /* AccountsSettings */,
-				B6EA1FF329DA37D3001BF195 /* TextEditingSettings */,
 				B6F0516E29D9E35300D72287 /* LocationsSettings */,
 				B6F0516D29D9E34200D72287 /* SourceControlSettings */,
 				B6F0516C29D9E32700D72287 /* TerminalSettings */,
-				58F2EAAE292FB2B0004A9BDE /* ThemeSettings */,
-				B61DA9E129D929F900BF4A43 /* GeneralSettings */,
 			);
 			path = Pages;
 			sourceTree = "<group>";
@@ -2661,6 +2666,23 @@
 				B658FB3627DA9E1000EA4DBD /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		B664C3AD2B965F4500816B4E /* NavigationSettings */ = {
+			isa = PBXGroup;
+			children = (
+				B664C3AE2B965F5500816B4E /* Models */,
+				B664C3B22B96634F00816B4E /* NavigationSettingsView.swift */,
+			);
+			path = NavigationSettings;
+			sourceTree = "<group>";
+		};
+		B664C3AE2B965F5500816B4E /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				B664C3AF2B965F6C00816B4E /* NavigationSettings.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		B66DD19E2B3C0E0C0004FFEC /* History */ = {
@@ -3291,6 +3313,7 @@
 				587B9E9229301D8F00AC7927 /* BitBucketAccount.swift in Sources */,
 				DE513F52281B672D002260B9 /* EditorTabBarAccessory.swift in Sources */,
 				2813F93927ECC4C300E305E4 /* NavigatorAreaView.swift in Sources */,
+				B664C3B02B965F6C00816B4E /* NavigationSettings.swift in Sources */,
 				5B698A0F2B2636A700DE9392 /* SearchSettingsIgnoreGlobPatternItemView.swift in Sources */,
 				587B9E8A29301D8F00AC7927 /* GitHubIssue.swift in Sources */,
 				EC0870F72A455F6400EB8692 /* ProjectNavigatorViewController+NSMenuDelegate.swift in Sources */,
@@ -3339,6 +3362,7 @@
 				611192042B08CCED00D4459B /* SearchIndexer+ProgressiveSearch.swift in Sources */,
 				611192022B08CCDC00D4459B /* SearchIndexer+Search.swift in Sources */,
 				04BA7C272AE2E9F100584E1C /* GitClient+Push.swift in Sources */,
+				B664C3B32B96634F00816B4E /* NavigationSettingsView.swift in Sources */,
 				2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */,
 				D7012EE827E757850001E1EF /* FindNavigatorView.swift in Sources */,
 				58A5DF8029325B5A00D1BD5D /* GitClient.swift in Sources */,

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -4693,7 +4693,7 @@
 			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.7.1;
+				minimumVersion = 0.7.2;
 			};
 		};
 		6CDEFC9429E22C2700B7C684 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
       "state" : {
-        "revision" : "a72e6c9b5f38b00ea0b03da5e706e3c4d05c706e",
-        "version" : "0.7.1"
+        "revision" : "7360f00bf7ec8e93b4833357bd254bef7e5c943d",
+        "version" : "0.7.2"
       }
     },
     {

--- a/CodeEdit/Features/CodeEditUI/Views/SegmentedControl.swift
+++ b/CodeEdit/Features/CodeEditUI/Views/SegmentedControl.swift
@@ -31,7 +31,7 @@ struct SegmentedControl: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 4) {
             ForEach(options.indices, id: \.self) { index in
                 SegmentedControlItem(
                     label: options[index],

--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -97,6 +97,7 @@ final class Editor: ObservableObject, Identifiable {
     /// Closes the editor.
     func close() {
         parent?.closeEditor(with: id)
+        editorManager.updateCachedFlattenedEditors = true
     }
 
     /// Gets the editor layout.

--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -64,29 +64,34 @@ final class Editor: ObservableObject, Identifiable {
 
     init() {
         self.tabs = []
+        self.temporaryTab = nil
         self.parent = nil
     }
 
     init(
         files: OrderedSet<CEWorkspaceFile> = [],
         selectedTab: Tab? = nil,
+        temporaryTab: Tab? = nil,
         parent: SplitViewData? = nil
     ) {
         self.tabs = []
         self.parent = parent
         files.forEach { openTab(file: $0) }
         self.selectedTab = selectedTab ?? (files.isEmpty ? nil : Tab(file: files.first!))
+        self.temporaryTab = temporaryTab
     }
 
     init(
         files: OrderedSet<Tab> = [],
         selectedTab: Tab? = nil,
+        temporaryTab: Tab? = nil,
         parent: SplitViewData? = nil
     ) {
         self.tabs = []
         self.parent = parent
         files.forEach { openTab(file: $0.file) }
         self.selectedTab = selectedTab ?? tabs.first
+        self.temporaryTab = temporaryTab
     }
 
     /// Closes the editor.

--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -97,7 +97,6 @@ final class Editor: ObservableObject, Identifiable {
     /// Closes the editor.
     func close() {
         parent?.closeEditor(with: id)
-        editorManager.updateCachedFlattenedEditors = true
     }
 
     /// Gets the editor layout.

--- a/CodeEdit/Features/Editor/Models/EditorLayout.swift
+++ b/CodeEdit/Features/Editor/Models/EditorLayout.swift
@@ -90,7 +90,7 @@ enum EditorLayout: Equatable {
     }
 
     /// Gets flattened splitviews.
-    mutating func getFlattened(parent: SplitViewData) -> [Editor] {
+    func getFlattened(parent: SplitViewData) -> [Editor] {
         switch self {
         case .one(let editor):
             return [editor]

--- a/CodeEdit/Features/Editor/Models/EditorLayout.swift
+++ b/CodeEdit/Features/Editor/Models/EditorLayout.swift
@@ -89,6 +89,24 @@ enum EditorLayout: Equatable {
         }
     }
 
+    /// Gets flattened splitviews.
+    mutating func getFlattened(parent: SplitViewData) -> [Editor] {
+        switch self {
+        case .one(let editor):
+            return [editor]
+        case .horizontal(let data), .vertical(let data):
+            if data.editorLayouts.count == 1 {
+                let one = data.editorLayouts[0]
+                if case .one(let editor) = one {
+                    return [editor]
+                }
+                return []
+            } else {
+                return data.getFlattened()
+            }
+        }
+    }
+
     var isEmpty: Bool {
         switch self {
         case .one:

--- a/CodeEdit/Features/Editor/Models/EditorManager.swift
+++ b/CodeEdit/Features/Editor/Models/EditorManager.swift
@@ -37,7 +37,7 @@ class EditorManager: ObservableObject {
     var cancellable: AnyCancellable?
 
     // This caching mechanism is a temporary solution and is not optimized
-    var updateCachedFlattenedEditors: Bool = true
+    @Published var updateCachedFlattenedEditors: Bool = true
     var cachedFlettenedEditors: [Editor] = []
     var flattenedEditors: [Editor] {
         if updateCachedFlattenedEditors {
@@ -120,6 +120,7 @@ class EditorManager: ObservableObject {
 
         flatten()
         objectWillChange.send()
+        updateCachedFlattenedEditors = true
     }
 
     /// Set a new active editor.

--- a/CodeEdit/Features/Editor/Models/EditorManager.swift
+++ b/CodeEdit/Features/Editor/Models/EditorManager.swift
@@ -72,21 +72,22 @@ class EditorManager: ObservableObject {
 
     /// Flattens the splitviews.
     func flatten() {
-        if case .horizontal(let data) = editorLayout {
+        switch editorLayout {
+        case .horizontal(let data), .vertical(let data):
             data.flatten()
-        } else if case .vertical(let data) = editorLayout {
-            data.flatten()
+        default:
+            break
         }
     }
 
     /// Returns and array of flattened splitviews.
     func getFlattened() -> [Editor] {
-        if case .horizontal(let data) = editorLayout {
+        switch editorLayout {
+        case .horizontal(let data), .vertical(let data):
             return data.getFlattened()
-        } else if case .vertical(let data) = editorLayout {
-            return data.getFlattened()
+        default:
+            return []
         }
-        return []
     }
 
     /// Opens a new tab in a editor.

--- a/CodeEdit/Features/Editor/Models/EditorManager.swift
+++ b/CodeEdit/Features/Editor/Models/EditorManager.swift
@@ -36,6 +36,17 @@ class EditorManager: ObservableObject {
     var tabBarTabIdSubject = PassthroughSubject<String?, Never>()
     var cancellable: AnyCancellable?
 
+    // This caching mechanism is a temporary solution and is not optimized
+    var updateCachedFlattenedEditors: Bool = true
+    var cachedFlettenedEditors: [Editor] = []
+    var flattenedEditors: [Editor] {
+        if updateCachedFlattenedEditors {
+            cachedFlettenedEditors = self.getFlattened()
+            updateCachedFlattenedEditors = false
+        }
+        return cachedFlettenedEditors
+    }
+
     // MARK: - Init
 
     init() {
@@ -66,6 +77,16 @@ class EditorManager: ObservableObject {
         } else if case .vertical(let data) = editorLayout {
             data.flatten()
         }
+    }
+
+    /// Returns and array of flattened splitviews.
+    func getFlattened() -> [Editor] {
+        if case .horizontal(let data) = editorLayout {
+            return data.getFlattened()
+        } else if case .vertical(let data) = editorLayout {
+            return data.getFlattened()
+        }
+        return []
     }
 
     /// Opens a new tab in a editor.

--- a/CodeEdit/Features/Editor/PathBar/Views/EditorPathBarView.swift
+++ b/CodeEdit/Features/Editor/PathBar/Views/EditorPathBarView.swift
@@ -67,7 +67,7 @@ struct EditorPathBarView: View {
                 }
             }
         }
-        .padding(.horizontal, shouldShowTabBar ? file == nil ? 10 : 4 : 0)
+        .padding(.horizontal, shouldShowTabBar ? (file == nil ? 10 : 4) : 0)
         .safeAreaInset(edge: .leading, spacing: 0) {
             if !shouldShowTabBar {
                 EditorTabBarLeadingAccessories()

--- a/CodeEdit/Features/Editor/PathBar/Views/EditorPathBarView.swift
+++ b/CodeEdit/Features/Editor/PathBar/Views/EditorPathBarView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct EditorPathBarView: View {
     private let file: CEWorkspaceFile?
+    private let shouldShowTabBar: Bool
     private let tappedOpenFile: (CEWorkspaceFile) -> Void
 
     @Environment(\.colorScheme)
@@ -20,13 +21,15 @@ struct EditorPathBarView: View {
     @Environment(\.controlActiveState)
     private var activeState
 
-    static let height = 27.0
+    static let height = 28.0
 
     init(
         file: CEWorkspaceFile?,
+        shouldShowTabBar: Bool,
         tappedOpenFile: @escaping (CEWorkspaceFile) -> Void
     ) {
         self.file = file ?? nil
+        self.shouldShowTabBar = shouldShowTabBar
         self.tappedOpenFile = tappedOpenFile
     }
 
@@ -63,7 +66,17 @@ struct EditorPathBarView: View {
                     }
                 }
             }
-            .padding(.horizontal, 10)
+        }
+        .padding(.horizontal, shouldShowTabBar ? file == nil ? 10 : 4 : 0)
+        .safeAreaInset(edge: .leading, spacing: 0) {
+            if !shouldShowTabBar {
+                EditorTabBarLeadingAccessories()
+            }
+        }
+        .safeAreaInset(edge: .trailing, spacing: 0) {
+            if !shouldShowTabBar {
+                EditorTabBarTrailingAccessories()
+            }
         }
         .frame(height: Self.height, alignment: .center)
         .opacity(activeState == .inactive ? 0.8 : 1.0)

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarLeadingAccessories.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarLeadingAccessories.swift
@@ -136,9 +136,3 @@ struct EditorTabBarLeadingAccessories: View {
         }
     }
 }
-
-struct TabBarLeadingAccessories_Previews: PreviewProvider {
-    static var previews: some View {
-        EditorTabBarLeadingAccessories()
-    }
-}

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarLeadingAccessories.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarLeadingAccessories.swift
@@ -74,11 +74,9 @@ struct EditorTabBarLeadingAccessories: View {
                     }
                 } label: {
                     Image(systemName: "chevron.left")
-                        .controlSize(.regular)
-                        .opacity(
-                            editor.historyOffset == editor.history.count-1 || editor.history.isEmpty
-                            ? 0.5 : 1.0
-                        )
+                        .opacity(editor.historyOffset == editor.history.count-1 || editor.history.isEmpty ? 0.5 : 1)
+                        .frame(height: EditorTabBarView.height - 2)
+                        .padding(.horizontal, 4)
                 } primaryAction: {
                     editorManager.activeEditor = editor
                     editor.goBackInHistory()
@@ -103,8 +101,9 @@ struct EditorTabBarLeadingAccessories: View {
                     }
                 } label: {
                     Image(systemName: "chevron.right")
-                        .controlSize(.regular)
-                        .opacity(editor.historyOffset == 0 ? 0.5 : 1.0)
+                        .opacity(editor.historyOffset == 0 ? 0.5 : 1)
+                        .frame(height: EditorTabBarView.height - 2)
+                        .padding(.horizontal, 4)
                 } primaryAction: {
                     editorManager.activeEditor = editor
                     editor.goForwardInHistory()
@@ -112,11 +111,9 @@ struct EditorTabBarLeadingAccessories: View {
                 .disabled(editor.historyOffset == 0)
                 .help("Navigate forward")
             }
+            .buttonStyle(.icon)
             .controlSize(.small)
             .font(EditorTabBarAccessoryIcon.iconFont)
-            .frame(height: EditorTabBarView.height - 2)
-            .padding(.horizontal, 4)
-            .contentShape(Rectangle())
         }
         .foregroundColor(.secondary)
         .buttonStyle(.plain)

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarTrailingAccessories.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarTrailingAccessories.swift
@@ -69,7 +69,7 @@ struct EditorTabBarTrailingAccessories: View {
     func split(edge: Edge) {
         let newEditor: Editor
         if let tab = editor.selectedTab {
-            newEditor = .init(files: [tab])
+            newEditor = .init(files: [tab], temporaryTab: tab)
         } else {
             newEditor = .init()
         }

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarTrailingAccessories.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarTrailingAccessories.swift
@@ -74,6 +74,7 @@ struct EditorTabBarTrailingAccessories: View {
             newEditor = .init()
         }
         splitEditor(edge, newEditor)
+        editorManager.updateCachedFlattenedEditors = true
         editorManager.activeEditor = newEditor
     }
 }

--- a/CodeEdit/Features/Editor/Views/EditorView.swift
+++ b/CodeEdit/Features/Editor/Views/EditorView.swift
@@ -26,8 +26,10 @@ struct EditorView: View {
     // TODO: If ANY editor has permanent tabs, show tab bar, not just this editor (is this the most efficient place to do this check?)
     var shouldShowTabBar: Bool {
         return navigationStyle == .openInTabs
-        || (editor.temporaryTab == nil && !editor.tabs.isEmpty)
-        || (editor.temporaryTab != nil && editor.tabs.count > 1)
+        || editorManager.flattenedEditors.contains { editor in
+            (editor.temporaryTab == nil && !editor.tabs.isEmpty)
+            || (editor.temporaryTab != nil && editor.tabs.count > 1)
+        }
     }
 
     var editorInsetAmount: Double {
@@ -88,6 +90,9 @@ struct EditorView: View {
             if navigationStyle == .openInTabs {
                 editor.temporaryTab = nil
             }
+        }
+        .onChange(of: editorManager.flattenedEditors) { newValue in
+            print(newValue)
         }
     }
 }

--- a/CodeEdit/Features/Editor/Views/EditorView.swift
+++ b/CodeEdit/Features/Editor/Views/EditorView.swift
@@ -90,8 +90,10 @@ struct EditorView: View {
                 editor.temporaryTab = nil
             }
         }
-        .onChange(of: editorManager.flattenedEditors) { newValue in
-            print(newValue)
+        .onChange(of: navigationStyle) { newValue in
+            if newValue == .openInPlace && editor.tabs.count == 1 {
+                editor.temporaryTab = editor.tabs[0]
+            }
         }
     }
 }

--- a/CodeEdit/Features/Editor/Views/EditorView.swift
+++ b/CodeEdit/Features/Editor/Views/EditorView.swift
@@ -23,7 +23,6 @@ struct EditorView: View {
 
     @EnvironmentObject private var editorManager: EditorManager
 
-    // TODO: If ANY editor has permanent tabs, show tab bar, not just this editor (is this the most efficient place to do this check?)
     var shouldShowTabBar: Bool {
         return navigationStyle == .openInTabs
         || editorManager.flattenedEditors.contains { editor in

--- a/CodeEdit/Features/Editor/Views/EditorView.swift
+++ b/CodeEdit/Features/Editor/Views/EditorView.swift
@@ -23,21 +23,21 @@ struct EditorView: View {
 
     @EnvironmentObject private var editorManager: EditorManager
 
-    var shouldShowTabBar: Bool {
-        return navigationStyle == .openInTabs
-        || editorManager.flattenedEditors.contains { editor in
-            (editor.temporaryTab == nil && !editor.tabs.isEmpty)
-            || (editor.temporaryTab != nil && editor.tabs.count > 1)
-        }
-    }
-
-    var editorInsetAmount: Double {
-        let tabBarHeight = shouldShowTabBar ? (EditorTabBarView.height + 1) : 0
-        let pathBarHeight = showEditorPathBar ? (EditorPathBarView.height + 1) : 0
-        return tabBarHeight + pathBarHeight
-    }
-
     var body: some View {
+        var shouldShowTabBar: Bool {
+            return navigationStyle == .openInTabs
+            || editorManager.flattenedEditors.contains { editor in
+                (editor.temporaryTab == nil && !editor.tabs.isEmpty)
+                || (editor.temporaryTab != nil && editor.tabs.count > 1)
+            }
+        }
+
+        var editorInsetAmount: Double {
+            let tabBarHeight = shouldShowTabBar ? (EditorTabBarView.height + 1) : 0
+            let pathBarHeight = showEditorPathBar ? (EditorPathBarView.height + 1) : 0
+            return tabBarHeight + pathBarHeight
+        }
+
         VStack {
             if let selected = editor.selectedTab {
                 WorkspaceCodeFileView(

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
@@ -29,6 +29,7 @@ final class ProjectNavigatorViewController: NSViewController {
     var workspace: WorkspaceDocument?
 
     var iconColor: SettingsData.FileIconStyle = .color
+
     var fileExtensionsVisibility: SettingsData.FileExtensionsVisibility = .showAll
     var shownFileExtensions: SettingsData.FileExtensions = .default
     var hiddenFileExtensions: SettingsData.FileExtensions = .default
@@ -119,7 +120,7 @@ final class ProjectNavigatorViewController: NSViewController {
             } else {
                 outlineView.expandItem(item)
             }
-        } else {
+        } else if Settings[\.navigation].navigationStyle == .openInTabs {
             workspace?.editorManager.activeEditor.openTab(file: item, asTemporary: false)
         }
     }

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Views/SourceControlNavigatorView.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Views/SourceControlNavigatorView.swift
@@ -46,7 +46,7 @@ struct SourceControlNavigatorTabs: View {
                 prominent: true
             )
             .frame(maxWidth: .infinity)
-            .frame(height: 26)
+            .frame(height: 27)
             .padding(.horizontal, 8)
             .task {
                 do {

--- a/CodeEdit/Features/Settings/Models/SettingsData.swift
+++ b/CodeEdit/Features/Settings/Models/SettingsData.swift
@@ -30,6 +30,9 @@ struct SettingsData: Codable, Hashable {
     var accounts: AccountsSettings = .init()
 
     /// The global settings for themes
+    var navigation: NavigationSettings = .init()
+
+    /// The global settings for themes
     var theme: ThemeSettings = .init()
 
     /// The global settings for text editing
@@ -58,6 +61,7 @@ struct SettingsData: Codable, Hashable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.general = try container.decodeIfPresent(GeneralSettings.self, forKey: .general) ?? .init()
         self.accounts = try container.decodeIfPresent(AccountsSettings.self, forKey: .accounts) ?? .init()
+        self.navigation = try container.decodeIfPresent(NavigationSettings.self, forKey: .navigation) ?? .init()
         self.theme = try container.decodeIfPresent(ThemeSettings.self, forKey: .theme) ?? .init()
         self.terminal = try container.decodeIfPresent(TerminalSettings.self, forKey: .terminal) ?? .init()
         self.textEditing = try container.decodeIfPresent(TextEditingSettings.self, forKey: .textEditing) ?? .init()
@@ -82,6 +86,8 @@ struct SettingsData: Codable, Hashable {
             general.searchKeys.forEach { settings.append(.init(name, isSetting: true, settingName: $0)) }
         case .accounts:
             accounts.searchKeys.forEach { settings.append(.init(name, isSetting: true, settingName: $0)) }
+        case .navigation:
+            navigation.searchKeys.forEach { settings.append(.init(name, isSetting: true, settingName: $0)) }
         case .theme:
             theme.searchKeys.forEach { settings.append(.init(name, isSetting: true, settingName: $0)) }
         case .textEditing:
@@ -97,7 +103,6 @@ struct SettingsData: Codable, Hashable {
         case .featureFlags:
             featureFlags.searchKeys.forEach { settings.append(.init(name, isSetting: true, settingName: $0)) }
         case .behavior: return [.init(name, settingName: "Error")]
-        case .navigation: return [.init(name, settingName: "Error")]
         case .components: return [.init(name, settingName: "Error")]
         case .keybindings: return [.init(name, settingName: "Error")]
         case .advanced: return [.init(name, settingName: "Error")]

--- a/CodeEdit/Features/Settings/Pages/NavigationSettings/Models/NavigationSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/NavigationSettings/Models/NavigationSettings.swift
@@ -1,0 +1,8 @@
+//
+//  NavigationSettings.swift
+//  CodeEdit
+//
+//  Created by Austin Condiff on 3/4/24.
+//
+
+import Foundation

--- a/CodeEdit/Features/Settings/Pages/NavigationSettings/Models/NavigationSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/NavigationSettings/Models/NavigationSettings.swift
@@ -6,3 +6,37 @@
 //
 
 import Foundation
+
+extension SettingsData {
+
+    /// The global settings for the terminal emulator
+    struct NavigationSettings: Codable, Hashable, SearchableSettingsPage {
+
+        /// The search keys
+        var searchKeys: [String] {
+            [
+                "Navigation Style",
+            ]
+            .map { NSLocalizedString($0, comment: "") }
+        }
+
+        /// Navigation style used
+        var navigationStyle: NavigationStyle = .openInTabs
+
+        /// Default initializer
+        init() {}
+
+        /// Explicit decoder init for setting default values when key is not present in `JSON`
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.navigationStyle = try container.decodeIfPresent(
+                NavigationStyle.self, forKey: .navigationStyle
+            ) ?? .openInTabs
+        }
+    }
+
+    enum NavigationStyle: String, Codable, Hashable {
+        case openInTabs
+        case openInPlace
+    }
+}

--- a/CodeEdit/Features/Settings/Pages/NavigationSettings/NavigationSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/NavigationSettings/NavigationSettingsView.swift
@@ -1,0 +1,18 @@
+//
+//  NavigationSettingsView.swift
+//  CodeEdit
+//
+//  Created by Austin Condiff on 3/4/24.
+//
+
+import SwiftUI
+
+struct NavigationSettingsView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    NavigationSettingsView()
+}

--- a/CodeEdit/Features/Settings/Pages/NavigationSettings/NavigationSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/NavigationSettings/NavigationSettingsView.swift
@@ -8,11 +8,25 @@
 import SwiftUI
 
 struct NavigationSettingsView: View {
+    @AppSettings(\.navigation)
+    var settings
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        SettingsForm {
+            Section {
+                navigationStyle
+            }
+        }
     }
 }
 
-#Preview {
-    NavigationSettingsView()
+private extension NavigationSettingsView {
+    private var navigationStyle: some View {
+        Picker("Navigation Style", selection: $settings.navigationStyle) {
+            Text("Open in Tabs")
+                .tag(SettingsData.NavigationStyle.openInTabs)
+            Text("Open in Place")
+                .tag(SettingsData.NavigationStyle.openInPlace)
+        }
+    }
 }

--- a/CodeEdit/Features/Settings/SettingsView.swift
+++ b/CodeEdit/Features/Settings/SettingsView.swift
@@ -38,6 +38,13 @@ struct SettingsView: View {
         ),
         .init(
             SettingsPage(
+                .navigation,
+                baseColor: .green,
+                icon: .system("arrow.triangle.turn.up.right.diamond.fill")
+            )
+        ),
+        .init(
+            SettingsPage(
                 .theme,
                 baseColor: .pink,
                 icon: .system("paintbrush.fill")
@@ -152,6 +159,8 @@ struct SettingsView: View {
                     GeneralSettingsView().environmentObject(updater)
                 case .accounts:
                     AccountsSettingsView()
+                case .navigation:
+                    NavigationSettingsView()
                 case .theme:
                     ThemeSettingsView()
                 case .textEditing:

--- a/CodeEdit/Features/SplitView/Model/SplitViewData.swift
+++ b/CodeEdit/Features/SplitView/Model/SplitViewData.swift
@@ -85,4 +85,13 @@ final class SplitViewData: ObservableObject {
             editorLayouts[index].flatten(parent: self)
         }
     }
+
+    /// Gets flattened splitviews.
+    func getFlattened() -> [Editor] {
+        var arr: [Editor] = []
+        for index in editorLayouts.indices {
+            arr += editorLayouts[index].getFlattened(parent: self)
+        }
+        return arr
+    }
 }


### PR DESCRIPTION
### Description

The new Navigation Style setting allows users to open a single file instead of multiple files in an editor. When this is set, the tab bar is hidden when there is only a single temporary tab.

When splitting an editor, the new editors only tab (copied from the previous editor) will now be a temporary tab (previously not temporary). This is so that when using a "open in place" navigation style, the tabs will remain hidden when splitting an editor.

If going back or forward in history to a file for a tab that was previously closed, we now open it as a temporary tab. Again this will prevent the tab bar from unnecessarily showing up in certain edge-cases.

We are also now invalidating history when opening file with project navigator so user cannot go forward.

### Related Issues

* closes #1602

### Checklist
- [x] Add Navigation Style setting
- [x] Hide tab bar if only one temporary tab exists in an editor when navigation style is set to open in place 
- [x] Add navigation controls to path bar when tab bar is hidden
- [x] Adjust editor top safe area [^1]
- [x] Prevent double clicking file to make it a permanent tab
- [x] Prevent file edit or save from making the tab permanent
- [x] If only one tab in an editor exists when changing Navigation Style to Open in Place, convert it to a temporary tab
- [x] If any open editor splits contain a non-temporary tab, show the tab bar for all editors. [^2]
- [x] When splitting an editor, open the new editors only tab as a temporary tab
- [x] Navigating through the file history to a previously closed tab should reopen it as a temporary tab
- [x] Invalidate history when opening file with project navigator so user cannot go forward 
---
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/806104/38611ec1-ef8b-4bcf-85e9-d0285e1fac7b

[^1]: CodeEditTextView will need work to fix a bug revealed by this work, see below video (@thecoolwinter)
    https://github.com/CodeEditApp/CodeEdit/assets/806104/f1a57323-98a7-4bdb-baaa-aa39ddf4e166
[^2]: I might need to iterate over all editor splits to determine this. See TODO in code. (@Wouter01 any ideas?)
