### PR TITLE
Font Improvement

### DIFF
--- a/CodeEdit/Features/CodeFile/CodeFileView.swift
+++ b/CodeEdit/Features/CodeFile/CodeFileView.swift
@@ -52,8 +52,6 @@ struct CodeFileView: View {
 
     private let isEditable: Bool
 
-    private let systemFont: NSFont = .monospacedSystemFont(ofSize: 11, weight: .medium)
-
     private let undoManager = CEUndoManager()
 
     init(codeFile: CodeFileDocument, textViewCoordinators: [TextViewCoordinator] = [], isEditable: Bool = true) {
@@ -85,9 +83,7 @@ struct CodeFileView: View {
 
     @State private var selectedTheme = ThemeModel.shared.selectedTheme ?? ThemeModel.shared.themes.first!
 
-    @State private var font: NSFont = {
-        return Settings[\.textEditing].font.current()
-    }()
+    @State private var font: NSFont = Settings[\.textEditing].font.current
 
     @State private var bracketPairHighlight: BracketPairHighlight? = {
         let theme = ThemeModel.shared.selectedTheme ?? ThemeModel.shared.themes.first!
@@ -150,11 +146,8 @@ struct CodeFileView: View {
             guard let theme = newValue else { return }
             self.selectedTheme = theme
         }
-        .onChange(of: settingsFont) { newValue in
-            font = NSFont(
-                name: settingsFont.name,
-                size: CGFloat(newValue.size)
-            ) ?? systemFont.withSize(CGFloat(newValue.size))
+        .onChange(of: settingsFont) { newFontSetting in
+            font = newFontSetting.current
         }
         .onChange(of: bracketHighlight) { _ in
             bracketPairHighlight = getBracketPairHighlight()

--- a/CodeEdit/Features/Settings/Pages/TerminalSettings/Models/TerminalSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TerminalSettings/Models/TerminalSettings.swift
@@ -5,6 +5,7 @@
 //  Created by Nanashi Li on 2022/04/08.
 //
 
+import AppKit.NSFont
 import Foundation
 
 extension SettingsData {
@@ -89,9 +90,6 @@ extension SettingsData {
     }
 
     struct TerminalFont: Codable, Hashable {
-        /// Indicates whether or not to use a custom font
-        var customFont: Bool = false
-
         /// The font size for the custom font
         var size: Double = 12
 
@@ -104,9 +102,16 @@ extension SettingsData {
         /// Explicit decoder init for setting default values when key is not present in `JSON`
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.customFont = try container.decodeIfPresent(Bool.self, forKey: .customFont) ?? false
-            self.size = try container.decodeIfPresent(Double.self, forKey: .size) ?? 11
-            self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? "SF Mono"
+            self.size = try container.decodeIfPresent(Double.self, forKey: .size) ?? size
+            self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? name
+        }
+
+        /// Returns an NSFont representation of the current configuration.
+        ///
+        /// Returns the custom font, if enabled and able to be instantiated.
+        /// Otherwise returns a default system font monospaced.
+        var current: NSFont {
+            return NSFont(name: name, size: size) ?? NSFont.monospacedSystemFont(ofSize: size, weight: .medium)
         }
     }
 }

--- a/CodeEdit/Features/Settings/Pages/TerminalSettings/Models/TerminalSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TerminalSettings/Models/TerminalSettings.swift
@@ -5,7 +5,7 @@
 //  Created by Nanashi Li on 2022/04/08.
 //
 
-import AppKit.NSFont
+import AppKit
 import Foundation
 
 extension SettingsData {

--- a/CodeEdit/Features/Settings/Pages/TerminalSettings/TerminalSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TerminalSettings/TerminalSettingsView.swift
@@ -70,9 +70,6 @@ private extension TerminalSettingsView {
 
     @ViewBuilder private var fontSelector: some View {
         MonospacedFontPicker(title: "Font", selectedFontName: $settings.font.name)
-            .onChange(of: settings.font.name) { fontName in
-                settings.font.customFont = fontName != "SF Mono"
-            }
     }
 
     private var fontSizeSelector: some View {

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
@@ -5,7 +5,7 @@
 //  Created by Nanashi Li on 2022/04/08.
 //
 
-import AppKit
+import AppKit.NSFont
 import Foundation
 
 extension SettingsData {
@@ -161,9 +161,6 @@ extension SettingsData {
     }
 
     struct EditorFont: Codable, Hashable {
-        /// Indicates whether or not to use a custom font
-        var customFont: Bool = false
-
         /// The font size for the font
         var size: Double = 12
 
@@ -176,21 +173,16 @@ extension SettingsData {
         /// Explicit decoder init for setting default values when key is not present in `JSON`
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.customFont = try container.decodeIfPresent(Bool.self, forKey: .customFont) ?? false
-            self.size = try container.decodeIfPresent(Double.self, forKey: .size) ?? 11
-            self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? "SF Mono"
+            self.size = try container.decodeIfPresent(Double.self, forKey: .size) ?? size
+            self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? name
         }
 
         /// Returns an NSFont representation of the current configuration.
         ///
         /// Returns the custom font, if enabled and able to be instantiated.
         /// Otherwise returns a default system font monospaced.
-        func current() -> NSFont {
-            guard customFont,
-                  let customFont = NSFont(name: name, size: size) else {
-                return NSFont.monospacedSystemFont(ofSize: size, weight: .medium)
-            }
-            return customFont
+        var current: NSFont {
+            return NSFont(name: name, size: size) ?? NSFont.monospacedSystemFont(ofSize: size, weight: .medium)
         }
     }
 }

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
@@ -5,7 +5,7 @@
 //  Created by Nanashi Li on 2022/04/08.
 //
 
-import AppKit.NSFont
+import AppKit
 import Foundation
 
 extension SettingsData {

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -39,9 +39,6 @@ struct TextEditingSettingsView: View {
 private extension TextEditingSettingsView {
     @ViewBuilder private var fontSelector: some View {
         MonospacedFontPicker(title: "Font", selectedFontName: $textEditing.font.name)
-            .onChange(of: textEditing.font.name) { fontName in
-                textEditing.font.customFont = fontName != "SF Mono"
-            }
     }
 
     @ViewBuilder private var fontSizeSelector: some View {

--- a/CodeEdit/Features/Settings/Views/MonospacedFontPicker.swift
+++ b/CodeEdit/Features/Settings/Views/MonospacedFontPicker.swift
@@ -49,6 +49,7 @@ struct MonospacedFontPicker: View {
                 Menu {
                     ForEach(otherFontFamilyNames, id: \.self) { fontFamilyName in
                         Button {
+                            pushIntoRecentFonts(fontFamilyName)
                             selectedFontName = fontFamilyName
                         } label: {
                             Text(fontFamilyName)

--- a/CodeEdit/Features/Settings/Views/MonospacedFontPicker.swift
+++ b/CodeEdit/Features/Settings/Views/MonospacedFontPicker.swift
@@ -20,59 +20,12 @@ struct MonospacedFontPicker: View {
         self.recentFonts = UserDefaults.standard.stringArray(forKey: "recentFonts") ?? []
     }
 
-    private func pushIntoRecentFonts(_ newItem: String) {
-        recentFonts.removeAll(where: { $0 == newItem })
-        recentFonts.insert(newItem, at: 0)
-        if recentFonts.count > 3 {
-            recentFonts.removeLast()
-        }
-        UserDefaults.standard.set(recentFonts, forKey: "recentFonts")
-    }
-
-    nonisolated func getFonts() async {
-        let availableFontFamilies = NSFontManager.shared.availableFontFamilies
-
-        self.monospacedFontFamilyNames = availableFontFamilies.filter { fontName in
-            // exclude the font if it is in recentFonts to prevent ForEach conflict
-            if recentFonts.contains(fontName) {
-                return false
-            }
-
-            // exclude default font
-            if fontName == "SF Mono" {
-                return false
-            }
-
-            // include the font which is fixedPitch
-            // include the font which numberOfGlyphs is greater than 26
-            if let font = NSFont(name: fontName, size: 14) {
-                return font.isFixedPitch && font.numberOfGlyphs > 26
-            } else {
-                return false
-            }
-        }
-
-        self.otherFontFamilyNames = availableFontFamilies.filter { fontName in
-            // exclude the font if it is in recentFonts to prevent ForEach conflict
-            if recentFonts.contains(fontName) {
-                return false
-            }
-
-            // include the font which is NOT fixedPitch
-            // include the font which numberOfGlyphs is greater than 26
-            if let font = NSFont(name: fontName, size: 14) {
-                return !font.isFixedPitch && font.numberOfGlyphs > 26
-            } else {
-                return false
-            }
-        }
-    }
-
     var body: some View {
-        return Picker(selection: $selectedFontName, label: Text(title)) {
+        Picker(selection: $selectedFontName, label: Text(title)) {
             Text("System Font")
                 .font(Font(NSFont.monospacedSystemFont(ofSize: 13.5, weight: .medium)))
                 .tag("SF Mono")
+
             if !recentFonts.isEmpty {
                 Divider()
                 ForEach(recentFonts, id: \.self) { fontFamilyName in
@@ -81,6 +34,7 @@ struct MonospacedFontPicker: View {
                         .tag(fontFamilyName) // to prevent picker invalid and does not have an associated tag error.
                 }
             }
+
             if !monospacedFontFamilyNames.isEmpty {
                 Divider()
                 ForEach(monospacedFontFamilyNames, id: \.self) { fontFamilyName in
@@ -89,14 +43,21 @@ struct MonospacedFontPicker: View {
                         .tag(fontFamilyName)
                 }
             }
+
             if !otherFontFamilyNames.isEmpty {
                 Divider()
-                Picker(selection: $selectedFontName, label: Text("Other fonts...")) {
+                Menu {
                     ForEach(otherFontFamilyNames, id: \.self) { fontFamilyName in
-                        Text(fontFamilyName)
-                            .font(.custom(fontFamilyName, size: 13.5))
-                            .tag(fontFamilyName)
+                        Button {
+                            selectedFontName = fontFamilyName
+                        } label: {
+                            Text(fontFamilyName)
+                                .font(.custom(fontFamilyName, size: 13.5))
+                        }
+                        .tag(fontFamilyName)
                     }
+                } label: {
+                    Text("Other fonts...")
                 }
             }
         }
@@ -113,4 +74,76 @@ struct MonospacedFontPicker: View {
             await getFonts()
         }
     }
+}
+
+extension MonospacedFontPicker {
+    private func pushIntoRecentFonts(_ newItem: String) {
+        recentFonts.removeAll(where: { $0 == newItem })
+        recentFonts.insert(newItem, at: 0)
+        if recentFonts.count > 3 {
+            recentFonts.removeLast()
+        }
+        UserDefaults.standard.set(recentFonts, forKey: "recentFonts")
+    }
+
+    private func getFonts() async {
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                let monospacedFontFamilyNames = getMonospacedFamilyNames()
+                await MainActor.run {
+                    self.monospacedFontFamilyNames = monospacedFontFamilyNames
+                }
+            }
+
+            group.addTask {
+                let otherFontFamilyNames = getOtherFontFamilyNames()
+                await MainActor.run {
+                    self.otherFontFamilyNames = otherFontFamilyNames
+                }
+            }
+        }
+    }
+
+    private func getMonospacedFamilyNames() -> [String] {
+        let availableFontFamilies = NSFontManager.shared.availableFontFamilies
+
+        return availableFontFamilies.filter { fontFamilyName in
+            // exclude the font if it is in recentFonts to prevent ForEach conflict
+            if recentFonts.contains(fontFamilyName) {
+               return false
+            }
+
+            // exclude default font
+            if fontFamilyName == "SF Mono" {
+               return false
+            }
+
+            // include the font which is fixedPitch
+            // include the font which numberOfGlyphs is greater than 26
+            if let font = NSFont(name: fontFamilyName, size: 14) {
+               return font.isFixedPitch && font.numberOfGlyphs > 26
+            } else {
+               return false
+            }
+        }
+   }
+
+   private func getOtherFontFamilyNames() -> [String] {
+       let availableFontFamilies = NSFontManager.shared.availableFontFamilies
+
+       return availableFontFamilies.filter { fontFamilyName in
+           // exclude the font if it is in recentFonts to prevent ForEach conflict
+           if recentFonts.contains(fontFamilyName) {
+               return false
+           }
+
+           // include the font which is NOT fixedPitch
+           // include the font which numberOfGlyphs is greater than 26
+           if let font = NSFont(name: fontFamilyName, size: 14) {
+               return !font.isFixedPitch && font.numberOfGlyphs > 26
+           } else {
+               return false
+           }
+       }
+   }
 }

--- a/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
+++ b/CodeEdit/Features/TerminalEmulator/TerminalEmulatorView.swift
@@ -27,26 +27,12 @@ struct TerminalEmulatorView: NSViewRepresentable {
 
     @State var terminal: LocalProcessTerminalView
 
-    private let systemFont: NSFont = .monospacedSystemFont(ofSize: 11, weight: .medium)
-
     private var font: NSFont {
         if terminalSettings.useTextEditorFont {
-            if !fontSettings.customFont {
-                return systemFont.withSize(CGFloat(fontSettings.size))
-            }
-            return NSFont(
-                name: fontSettings.name,
-                size: CGFloat(fontSettings.size)
-            ) ?? systemFont
+            return fontSettings.current
+        } else {
+            return terminalSettings.font.current
         }
-
-        if !terminalSettings.font.customFont {
-            return systemFont.withSize(CGFloat(terminalSettings.font.size))
-        }
-        return NSFont(
-            name: terminalSettings.font.name,
-            size: CGFloat(terminalSettings.font.size)
-        ) ?? systemFont
     }
 
     private var url: URL


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

This PR contains a few fixes, changes and improvements on font settings. Firstly, it fixes #1428 issue, and to do that I removed `customFont` property because I think it is unnecessary, easy forgettable and prone to mistakes (as seen in the issue) and I added `current` computed property to get `NSFont` directly instead of construct it manually. So, the code in `TerminalEmulatorView` is simpler and more understandable now and I also removed `systemFont` property in it because it should not be there in my opinion.
Secondly, I made similar changes on text editing font settings due to similar reasons.
Lastly, I made some improvements on `MonospaceFontPicker` because it gives main thread warning. However, there is noticeable delay on it when first click but I couldn't resolve it.

I think these three changes related so I did't separate them.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #1428

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Now my terminal has the correct font
<img width="1544" alt="screenshot" src="https://github.com/CodeEditApp/CodeEdit/assets/33904390/7c250628-9464-47e3-a2d5-face45b4dac5">

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
