### PR TITLE
Fixed delay in synchronization of font size increment and decrement

### DIFF
--- a/CodeEdit/Features/Settings/Models/AppSettings.swift
+++ b/CodeEdit/Features/Settings/Models/AppSettings.swift
@@ -15,17 +15,6 @@ struct AppSettings<T>: DynamicProperty where T: Equatable {
 
     let keyPath: WritableKeyPath<SettingsData, T>
 
-    @available(*,
-                deprecated,
-                message: """
-Use init(_ keyPath:) instead, otherwise the view will be reevaluated on every settings change.
-"""
-    )
-    init() where T == SettingsData {
-        self.keyPath = \.self
-        self.settings = .init(\.settings)
-    }
-
     init(_ keyPath: WritableKeyPath<SettingsData, T>) {
         self.keyPath = keyPath
         let settingsKeyPath = (\EnvironmentValues.settings).appending(path: keyPath)

--- a/CodeEdit/Features/Settings/Models/AppSettings.swift
+++ b/CodeEdit/Features/Settings/Models/AppSettings.swift
@@ -28,13 +28,13 @@ Use init(_ keyPath:) instead, otherwise the view will be reevaluated on every se
 
     init(_ keyPath: WritableKeyPath<SettingsData, T>) {
         self.keyPath = keyPath
-        let newKeyPath = (\EnvironmentValues.settings).appending(path: keyPath)
-        self.settings = .init(newKeyPath)
+        let settingsKeyPath = (\EnvironmentValues.settings).appending(path: keyPath)
+        self.settings = Environment(settingsKeyPath)
     }
 
     var wrappedValue: T {
         get {
-            settings.wrappedValue
+            Settings.shared.preferences[keyPath: keyPath]
         }
         nonmutating set {
             Settings.shared.preferences[keyPath: keyPath] = newValue
@@ -42,8 +42,8 @@ Use init(_ keyPath:) instead, otherwise the view will be reevaluated on every se
     }
 
     var projectedValue: Binding<T> {
-        .init {
-            settings.wrappedValue
+        Binding {
+            Settings.shared.preferences[keyPath: keyPath]
         } set: {
             Settings.shared.preferences[keyPath: keyPath] = $0
         }

--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -47,20 +47,20 @@ struct ViewCommands: Commands {
 
             Menu("Font Size") {
                 Button("Increase") {
-                    if !(editorFontSize >= 288) {
+                    if editorFontSize < 288 {
                         editorFontSize += 1
                     }
-                    if !(terminalFontSize >= 288) {
+                    if terminalFontSize < 288 {
                         terminalFontSize += 1
                     }
                 }
                 .keyboardShortcut("+")
 
                 Button("Decrease") {
-                    if !(editorFontSize <= 1) {
+                    if editorFontSize > 1 {
                         editorFontSize -= 1
                     }
-                    if !(terminalFontSize <= 1) {
+                    if terminalFontSize > 1 {
                         terminalFontSize -= 1
                     }
                 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
This PR should fix #1396 but I am not sure.

My understanding is that, `editorFontSize` in `ViewCommands` is not updating after increase or decrease. For example, if `editorFontSize` value is 12, after increasing it will be 13 and it will be rendered but `editorFontSize` value in `ViewCommands` won't be updated so `editorFontSize` remain same (in this case 12 and its increased value always will be 13, so there will be no change to see) but it changed and it is 13, just `editorFontSize` did not get the updated value. The same goes for `terminalFontSize`.

To fix it, I tried some ways (using binding etc.) but only working way I found is returning `Settings.shared.preferences[keyPath: keyPath]` from getters instead of `settings.wrappedValue` in `AppSettings`. But *I am not sure* if it is the correct solution. However, there is no broken part I can see so it can be the solution.

I also improved readability of the code and removed deprecated code.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1396

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots
Font increase and decrease works


https://github.com/CodeEditApp/CodeEdit/assets/33904390/e485193d-e674-4294-ba45-94d6ca3727b2





<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
