### PR TITLE
Fix toolbar tracking separator

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -143,6 +143,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
             .sidebarTrackingSeparator,
             .branchPicker,
             .flexibleSpace,
+            .itemListTrackingSeparator,
             .flexibleSpace,
             .toggleLastSidebarItem
         ]


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This PR fixes the wrong initial state of the tracking separator for the inspector toolbar.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #1634

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots
Before:
![image](https://github.com/CodeEditApp/CodeEdit/assets/62355975/401d44d2-4ee0-43d7-8fbb-a50017d969c5)
After:
![image](https://github.com/CodeEditApp/CodeEdit/assets/62355975/11ab26a0-b44b-4d98-8ca3-9f361b651dac)

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
