### PR TITLE
Adjusted titlebar spacing to be more accurate

### DIFF
--- a/CodeEdit/Features/CodeEditUI/Views/ToolbarBranchPicker.swift
+++ b/CodeEdit/Features/CodeEditUI/Views/ToolbarBranchPicker.swift
@@ -31,19 +31,19 @@ struct ToolbarBranchPicker: View {
     }
 
     var body: some View {
-        HStack(alignment: .center, spacing: 5) {
-            if currentBranch != nil {
-                Image.branch
-                    .font(.title3)
-                    .imageScale(.medium)
-                    .foregroundColor(controlActive == .inactive ? inactiveColor : .gray)
-            } else {
-                Image(systemName: "folder.fill.badge.gearshape")
-                    .font(.title3)
-                    .imageScale(.medium)
-                    .foregroundColor(controlActive == .inactive ? inactiveColor : .accentColor)
+        HStack(alignment: .center, spacing: 7) {
+            Group {
+                if currentBranch != nil {
+                    Image(symbol: "branch")
+                } else {
+                    Image(systemName: "folder.fill.badge.gearshape")
+                }
             }
-            VStack(alignment: .leading, spacing: 2) {
+            .foregroundColor(controlActive == .inactive ? inactiveColor : .secondary)
+            .font(.system(size: 14))
+            .imageScale(.medium)
+            .frame(width: 17, height: 17)
+            VStack(alignment: .leading, spacing: 0) {
                 Text(title)
                     .font(.headline)
                     .foregroundColor(controlActive == .inactive ? inactiveColor : .primary)
@@ -63,6 +63,7 @@ struct ToolbarBranchPicker: View {
                     .menuIndicator(isHovering ? .visible : .hidden)
                     .buttonStyle(.borderless)
                     .padding(.leading, -3)
+                    .padding(.bottom, 2)
                 }
             }
         }


### PR DESCRIPTION
### Description

Made a few small spacing adjustments to be more consistent with Xcode. Changes include:

- More space below branch picker
- Symbol is a little smaller
- More space between symbol and title

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1634

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="178" alt="image" src="https://github.com/CodeEditApp/CodeEdit/assets/806104/86a59a9a-6243-4813-b9e2-bd9f9feac574">

Top: Xcode
Middle: CodeEdit (before)
Bottom: CodeEdit (after)