### PR TITLE
New split editor symbol

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -4732,7 +4732,7 @@
 			repositoryURL = "https://github.com/CodeEditApp/CodeEditSymbols";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.4;
+				version = 0.2.1;
 			};
 		};
 		287136B1292A407E00E9F5F4 /* XCRemoteSwiftPackageReference "SwiftLintPlugin" */ = {

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditSymbols",
       "state" : {
-        "revision" : "26cab264914f2648ab70ab6833eef331c2f3a38a",
-        "version" : "0.1.4"
+        "revision" : "8262a5de7504cba4fc7da033b24b7f679c634800",
+        "version" : "0.2.1"
       }
     },
     {

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarTrailingAccessories.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarTrailingAccessories.swift
@@ -45,7 +45,7 @@ struct EditorTabBarTrailingAccessories: View {
                 Button {
                     split(edge: .bottom)
                 } label: {
-                    Image(systemName: "square.split.1x2")
+                    Image(symbol: "square.split.horizontal.plus")
                 }
                 .help("Split Vertically")
 
@@ -53,7 +53,7 @@ struct EditorTabBarTrailingAccessories: View {
                 Button {
                     split(edge: .trailing)
                 } label: {
-                    Image(systemName: "square.split.2x1")
+                    Image(symbol: "square.split.vertical.plus")
                 }
                 .help("Split Horizontally")
 

--- a/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarBreakpointButton.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarBreakpointButton.swift
@@ -16,7 +16,7 @@ struct StatusBarBreakpointButton: View {
             model.isBreakpointEnabled.toggle()
         } label: {
             if model.isBreakpointEnabled {
-                Image.breakpoint_fill
+                Image.breakpointFill
                     .foregroundColor(.accentColor)
             } else {
                 Image.breakpoint


### PR DESCRIPTION
### Description

Split symbol now more closely resembles the one found in Xcode

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="1409" alt="Screenshot 2024-03-20 at 1 17 16 PM" src="https://github.com/CodeEditApp/CodeEdit/assets/806104/f1aeefe8-3ba7-4c37-a82c-17a6f10b0335">
