### PR TITLE
Git branch show track information

### DIFF
--- a/CodeEdit/Features/Git/Client/GitClient+Branches.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+Branches.swift
@@ -17,8 +17,6 @@ extension GitClient {
             .components(separatedBy: "\n")
             .filter { $0 != "" && !$0.contains("HEAD") }
             .compactMap { line in
-                let components = line.components(separatedBy: " ")
-                    .filter { !$0.isEmpty }
                 guard let branchPart = line.components(separatedBy: " ").first else { return nil }
                 let branchComponents = branchPart.components(separatedBy: "|")
                 let name = branchComponents[0]

--- a/CodeEdit/Features/Git/Client/GitClient+Branches.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+Branches.swift
@@ -11,20 +11,30 @@ extension GitClient {
     /// Get branches
     /// - Returns: Array of branches
     func getBranches() async throws -> [GitBranch] {
-        let command = "branch --format \"%(refname:short)|%(refname)|%(upstream:short)\" -a"
+        let command = "branch --format \"%(refname:short)|%(refname)|%(upstream:short) %(upstream:track)\" -a"
 
         return try await run(command)
             .components(separatedBy: "\n")
             .filter { $0 != "" && !$0.contains("HEAD") }
             .compactMap { line in
-                let components = line.components(separatedBy: "|")
-                let name = components[0]
-                let upstream = components[safe: 2]
+                let components = line.components(separatedBy: " ")
+                    .filter { !$0.isEmpty }
+                guard let branchPart = line.components(separatedBy: " ").first else { return nil }
+                let branchComponents = branchPart.components(separatedBy: "|")
+                let name = branchComponents[0]
+                let upstream = branchComponents[safe: 2]
+
+                let trackInfoString = line
+                    .dropFirst(branchPart.count)
+                    .trimmingCharacters(in: .whitespacesWithoutNewlines)
+                let trackInfo = parseBranchTrackInfo(from: trackInfoString)
 
                 return .init(
                     name: name,
-                    longName: components[safe: 1] ?? name,
-                    upstream: upstream?.isEmpty == true ? nil : upstream
+                    longName: branchComponents[safe: 1] ?? name,
+                    upstream: upstream?.isEmpty == true ? nil : upstream,
+                    ahead: trackInfo.ahead,
+                    behind: trackInfo.behind
                 )
             }
     }
@@ -32,18 +42,26 @@ extension GitClient {
     /// Get current branch
     func getCurrentBranch() async throws -> GitBranch? {
         let branchName = try await run("branch --show-current").trimmingCharacters(in: .whitespacesAndNewlines)
-        let components = try await run(
-            "for-each-ref --format=\"%(refname)|%(upstream:short)\" refs/heads/\(branchName)"
+        let output = try await run(
+            "for-each-ref --format=\"%(refname)|%(upstream:short) %(upstream:track)\" refs/heads/\(branchName)"
         )
             .trimmingCharacters(in: .whitespacesAndNewlines)
-            .components(separatedBy: "|")
 
-        let upstream = components[safe: 1]
+        guard let branchPart = output.components(separatedBy: " ").first else { return nil }
+        let branchComponents = branchPart.components(separatedBy: "|")
+        let upstream = branchComponents[safe: 1]
+
+        let trackInfoString = output
+            .dropFirst(branchPart.count)
+            .trimmingCharacters(in: .whitespacesWithoutNewlines)
+        let trackInfo = parseBranchTrackInfo(from: trackInfoString)
 
         return .init(
             name: branchName,
-            longName: components[0],
-            upstream: upstream?.isEmpty == true ? nil : upstream
+            longName: branchComponents[0],
+            upstream: upstream?.isEmpty == true ? nil : upstream,
+            ahead: trackInfo.ahead,
+            behind: trackInfo.behind
         )
     }
 
@@ -99,5 +117,36 @@ extension GitClient {
                 try await checkoutBranch(branch, forceLocal: true)
             }
         }
+    }
+
+    private func parseBranchTrackInfo(from infoString: String) -> (ahead: Int, behind: Int) {
+        let pattern = "\\[ahead (\\d+)(?:, behind (\\d+))?\\]|\\[behind (\\d+)\\]"
+        // Create a regular expression object
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            fatalError("Invalid regular expression pattern")
+        }
+        var ahead = 0
+        var behind = 0
+        // Match the input string with the regular expression
+        if let match = regex.firstMatch(
+            in: infoString,
+            options: [],
+            range: NSRange(location: 0, length: infoString.utf16.count)
+        ) {
+            // Extract the captured groups
+            if let aheadRange = Range(match.range(at: 1), in: infoString),
+               let aheadValue = Int(infoString[aheadRange]) {
+                ahead = aheadValue
+            }
+            if let behindRange = Range(match.range(at: 2), in: infoString),
+               let behindValue = Int(infoString[behindRange]) {
+                behind = behindValue
+            }
+            if let behindRange = Range(match.range(at: 3), in: infoString),
+               let behindValue = Int(infoString[behindRange]) {
+                behind = behindValue
+            }
+        }
+        return (ahead, behind)
     }
 }

--- a/CodeEdit/Features/Git/Client/Models/GitBranch.swift
+++ b/CodeEdit/Features/Git/Client/Models/GitBranch.swift
@@ -11,6 +11,8 @@ struct GitBranch: Hashable {
     let name: String
     let longName: String
     let upstream: String?
+    let ahead: Int
+    let behind: Int
 
     /// Is local branch
     var isLocal: Bool {

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Repository/Views/SourceControlNavigatorRepositoryItem.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Repository/Views/SourceControlNavigatorRepositoryItem.swift
@@ -25,6 +25,21 @@ struct SourceControlNavigatorRepositoryItem: View {
                         .foregroundStyle(.secondary)
                         .font(.system(size: 11))
                 }
+                Spacer()
+                HStack(spacing: 0) {
+                    if let ahead = item.branch?.ahead, ahead > 0 {
+                        Text("\(ahead)")
+                            .font(.system(size: 11))
+                        Image(systemName: "arrow.up")
+                            .imageScale(.small)
+                    }
+                    if let behind = item.branch?.behind, behind > 0 {
+                        Text("\(behind)")
+                            .font(.system(size: 11))
+                        Image(systemName: "arrow.down")
+                            .imageScale(.small)
+                    }
+                }
             }, icon: {
                 if item.symbolImage != nil {
                     Image(symbol: item.symbolImage ?? "")

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Repository/Views/SourceControlNavigatorRepositoryItem.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Repository/Views/SourceControlNavigatorRepositoryItem.swift
@@ -26,18 +26,22 @@ struct SourceControlNavigatorRepositoryItem: View {
                         .font(.system(size: 11))
                 }
                 Spacer()
-                HStack(spacing: 0) {
-                    if let ahead = item.branch?.ahead, ahead > 0 {
-                        Text("\(ahead)")
-                            .font(.system(size: 11))
-                        Image(systemName: "arrow.up")
-                            .imageScale(.small)
-                    }
+                HStack(spacing: 5) {
                     if let behind = item.branch?.behind, behind > 0 {
-                        Text("\(behind)")
-                            .font(.system(size: 11))
-                        Image(systemName: "arrow.down")
-                            .imageScale(.small)
+                        HStack(spacing: 0) {
+                            Image(systemName: "arrow.down")
+                                .imageScale(.small)
+                            Text("\(behind)")
+                                .font(.system(size: 11))
+                        }
+                    }
+                    if let ahead = item.branch?.ahead, ahead > 0 {
+                        HStack(spacing: 0) {
+                            Image(systemName: "arrow.up")
+                                .imageScale(.small)
+                            Text("\(ahead)")
+                                .font(.system(size: 11))
+                        }
                     }
                 }
             }, icon: {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description


A small improvement to show Git branch information.

Get branch upstream track info when getting branch list and current branch, and show the ahead/behind info in the repo tab.

<!--- REQUIRED: Describe what changed in detail -->


<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code


### Screenshots

<img width="473" alt="Screenshot 2024-03-21 at 19 34 27" src="https://github.com/CodeEditApp/CodeEdit/assets/103433299/879f8d8c-ef6c-4617-bdd1-2b40c5eab650">

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
