### PR TITLE
Fixed commit changes file icons to support all symbols

### DIFF
--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/History/Views/CommitChangedFileListItemView.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/History/Views/CommitChangedFileListItemView.swift
@@ -33,7 +33,7 @@ struct CommitChangedFileListItemView: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
             }, icon: {
-                Image(systemName: changedFile.systemImage)
+                Image(nsImage: changedFile.nsIcon)
                     .foregroundStyle(changedFile.iconColor)
             })
 


### PR DESCRIPTION
### Description

Icons for changed files icons - Navigator Area › Source Control Navigator › History › Commit Details - were not showing CodeEditSymbols and only showed system symbols.

Fixed file icons to support custom CodeEdit symbols.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
