### PR TITLE
keyboard shortcut for tab switching

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		58F2EB1E292FB954004A9BDE /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 58F2EB1D292FB954004A9BDE /* Sparkle */; };
 		58FD7608291EA1CB0051D6E4 /* QuickActionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD7605291EA1CB0051D6E4 /* QuickActionsViewModel.swift */; };
 		58FD7609291EA1CB0051D6E4 /* QuickActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD7607291EA1CB0051D6E4 /* QuickActionsView.swift */; };
+		5994B6DA2BD6B408006A4C5F /* EditorTabSwitchExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5994B6D92BD6B408006A4C5F /* EditorTabSwitchExtension.swift */; };
 		5B241BF32B6DDBFF0016E616 /* IgnorePatternListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B241BF22B6DDBFF0016E616 /* IgnorePatternListItemView.swift */; };
 		5B698A0A2B262FA000DE9392 /* SearchSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B698A092B262FA000DE9392 /* SearchSettingsView.swift */; };
 		5B698A0D2B26327800DE9392 /* SearchSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B698A0C2B26327800DE9392 /* SearchSettings.swift */; };
@@ -810,6 +811,7 @@
 		58F2EAE1292FB2B0004A9BDE /* SoftwareUpdater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SoftwareUpdater.swift; sourceTree = "<group>"; };
 		58FD7605291EA1CB0051D6E4 /* QuickActionsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickActionsViewModel.swift; sourceTree = "<group>"; };
 		58FD7607291EA1CB0051D6E4 /* QuickActionsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickActionsView.swift; sourceTree = "<group>"; };
+		5994B6D92BD6B408006A4C5F /* EditorTabSwitchExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabSwitchExtension.swift; sourceTree = "<group>"; };
 		5B241BF22B6DDBFF0016E616 /* IgnorePatternListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnorePatternListItemView.swift; sourceTree = "<group>"; };
 		5B698A092B262FA000DE9392 /* SearchSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSettingsView.swift; sourceTree = "<group>"; };
 		5B698A0C2B26327800DE9392 /* SearchSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSettings.swift; sourceTree = "<group>"; };
@@ -2752,6 +2754,7 @@
 				6CA1AE942B46950000378EAB /* EditorInstance.swift */,
 				6CC9E4B129B5669900C97388 /* Environment+ActiveEditor.swift */,
 				6C092ED92A53A58600489202 /* EditorLayout+StateRestoration.swift */,
+				5994B6D92BD6B408006A4C5F /* EditorTabSwitchExtension.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3475,6 +3478,7 @@
 				581550CF29FBD30400684881 /* StandardTableViewCell.swift in Sources */,
 				B62AEDB82A1FE2DC009A9F52 /* UtilityAreaOutputView.swift in Sources */,
 				B67DB0FC2AFDF71F002DC647 /* IconToggleStyle.swift in Sources */,
+				5994B6DA2BD6B408006A4C5F /* EditorTabSwitchExtension.swift in Sources */,
 				587B9E5C29301D8F00AC7927 /* Parameters.swift in Sources */,
 				61538B932B11201900A88846 /* String+Character.swift in Sources */,
 				613DF55E2B08DD5D00E9D902 /* FileHelper.swift in Sources */,

--- a/CodeEdit/Features/Editor/Models/EditorTabSwitchExtension.swift
+++ b/CodeEdit/Features/Editor/Models/EditorTabSwitchExtension.swift
@@ -1,0 +1,32 @@
+//
+//  EditorTabSwitchExtension.swift
+//  CodeEdit
+//
+//  Created by Roscoe Rubin-Rottenberg on 4/22/24.
+//
+
+import Foundation
+
+extension Editor {
+    func selectNextTab() {
+        guard let currentTab = selectedTab, let currentIndex = tabs.firstIndex(of: currentTab) else { return }
+        let nextIndex = tabs.index(after: currentIndex)
+        if nextIndex < tabs.endIndex {
+            selectedTab = tabs[nextIndex]
+        } else {
+            // Wrap around to the first tab if it's the last one
+            selectedTab = tabs.first
+        }
+    }
+
+    func selectPreviousTab() {
+        guard let currentTab = selectedTab, let currentIndex = tabs.firstIndex(of: currentTab) else { return }
+        let previousIndex = tabs.index(before: currentIndex)
+        if previousIndex >= tabs.startIndex {
+            selectedTab = tabs[previousIndex]
+        } else {
+            // Wrap around to the last tab if it's the first one
+            selectedTab = tabs.last
+        }
+    }
+}

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Views/EditorTabs.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Views/EditorTabs.swift
@@ -273,17 +273,6 @@ struct EditorTabs: View {
             }
         }
     }
-    private func selectNextTab() {
-        guard let currentIndex = openedTabs.firstIndex(of: editor.selectedTab?.file.id ?? "") else { return }
-        let nextIndex = (currentIndex + 1) % openedTabs.count // Wraps around to the first tab if it's the last one
-        editor.selectedTab = editor.tabs.first { $0.file.id == openedTabs[nextIndex] }
-    }
-
-    private func selectPreviousTab() {
-        guard let currentIndex = openedTabs.firstIndex(of: editor.selectedTab?.file.id ?? ""), !openedTabs.isEmpty else { return }
-        let previousIndex = (currentIndex - 1 + openedTabs.count) % openedTabs.count // Wraps around to the last tab if it's the first one
-        editor.selectedTab = editor.tabs.first { $0.file.id == openedTabs[previousIndex] }
-    }
 
     // swiftlint:enable function_body_length cyclomatic_complexity
 
@@ -398,17 +387,6 @@ struct EditorTabs: View {
                         EditorTabBarNativeInactiveBackground()
                     }
                 }
-                // keyboard shortcuts to go to next and previous tabs
-                Button(action: selectNextTab) {
-                    EmptyView()
-                }
-                .hidden()
-                .keyboardShortcut("]", modifiers: [.command, .shift])
-                Button(action: selectPreviousTab) {
-                    EmptyView()
-                }
-                .hidden()
-                .keyboardShortcut("[", modifiers: [.command, .shift])
             }
             .background {
                 if tabBarStyle == .native {
@@ -436,7 +414,6 @@ struct EditorTabs: View {
                 }
             }
         }
-        
     }
 
     private struct EditorTabOnDropDelegate: DropDelegate {

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Views/EditorTabs.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Views/EditorTabs.swift
@@ -114,6 +114,8 @@ struct EditorTabs: View {
             CGFloat(140)
         )
     }
+    
+    
 
     // Disable the rule because this function is implementing the drag gesture and its animations.
     // It is fairly complicated, so ignore the function body length limitation for now.
@@ -271,6 +273,17 @@ struct EditorTabs: View {
             }
         }
     }
+    private func selectNextTab() {
+        guard let currentIndex = openedTabs.firstIndex(of: editor.selectedTab?.file.id ?? "") else { return }
+        let nextIndex = (currentIndex + 1) % openedTabs.count // Wraps around to the first tab if it's the last one
+        editor.selectedTab = editor.tabs.first { $0.file.id == openedTabs[nextIndex] }
+    }
+
+    private func selectPreviousTab() {
+        guard let currentIndex = openedTabs.firstIndex(of: editor.selectedTab?.file.id ?? ""), !openedTabs.isEmpty else { return }
+        let previousIndex = (currentIndex - 1 + openedTabs.count) % openedTabs.count // Wraps around to the last tab if it's the first one
+        editor.selectedTab = editor.tabs.first { $0.file.id == openedTabs[previousIndex] }
+    }
 
     // swiftlint:enable function_body_length cyclomatic_complexity
 
@@ -385,6 +398,17 @@ struct EditorTabs: View {
                         EditorTabBarNativeInactiveBackground()
                     }
                 }
+                // keyboard shortcuts to go to next and previous tabs
+                Button(action: selectNextTab) {
+                    EmptyView()
+                }
+                .hidden()
+                .keyboardShortcut("]", modifiers: [.command, .shift])
+                Button(action: selectPreviousTab) {
+                    EmptyView()
+                }
+                .hidden()
+                .keyboardShortcut("[", modifiers: [.command, .shift])
             }
             .background {
                 if tabBarStyle == .native {
@@ -412,6 +436,7 @@ struct EditorTabs: View {
                 }
             }
         }
+        
     }
 
     private struct EditorTabOnDropDelegate: DropDelegate {

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Views/EditorTabs.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Views/EditorTabs.swift
@@ -114,9 +114,6 @@ struct EditorTabs: View {
             CGFloat(140)
         )
     }
-    
-    
-
     // Disable the rule because this function is implementing the drag gesture and its animations.
     // It is fairly complicated, so ignore the function body length limitation for now.
     // swiftlint:disable function_body_length cyclomatic_complexity

--- a/CodeEdit/Features/WindowCommands/NavigateCommands.swift
+++ b/CodeEdit/Features/WindowCommands/NavigateCommands.swift
@@ -39,18 +39,20 @@ struct NavigateCommands: Commands {
                 Divider()
 
             }
-
             Group {
                 Button("Show Previous Tab") {
-
+                    editor?.selectPreviousTab()
                 }
-                .disabled(true)
+                .keyboardShortcut("{", modifiers: [.command])
+                .disabled(editor?.tabs.count ?? 0 <= 1)  // Disable if there's one or no tabs
 
                 Button("Show Next Tab") {
-
+                    editor?.selectNextTab()
                 }
-                .disabled(true)
-
+                .keyboardShortcut("}", modifiers: [.command])
+                .disabled(editor?.tabs.count ?? 0 <= 1)  // Disable if there's one or no tabs
+            }
+            Group {
                 Divider()
 
                 Button("Go Forward") {
@@ -62,6 +64,7 @@ struct NavigateCommands: Commands {
                     editor?.goBackInHistory()
                 }
                 .disabled(!(editor?.canGoBackInHistory ?? false))
+                
             }
             .disabled(editor == nil)
         }

--- a/CodeEdit/Features/WindowCommands/NavigateCommands.swift
+++ b/CodeEdit/Features/WindowCommands/NavigateCommands.swift
@@ -64,7 +64,6 @@ struct NavigateCommands: Commands {
                     editor?.goBackInHistory()
                 }
                 .disabled(!(editor?.canGoBackInHistory ?? false))
-                
             }
             .disabled(editor == nil)
         }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

The following keyboard shortcuts are now implemented:
CMD + SHIFT + ] to go to the next tab or, if the user is on the last tab, wrap around to the first tab
CMD + SHIFT + [ to go to the previous tab or, if the user is on the first tab, wrap around to the last tab

### Related Issues

* closes #1658 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/118622417/adc85143-0cd4-4ddb-af3e-f2036dd50491


