### PR TITLE
perf(search): Resolved issue with SearchKit

### DIFF
--- a/CodeEdit/Features/Documents/WorkspaceDocument+Find.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument+Find.swift
@@ -15,7 +15,6 @@ extension WorkspaceDocument.SearchState {
     /// - Returns: A modified search term according to the specified search mode.
     func getSearchTerm(_ query: String) -> String {
         let newQuery = stripSpecialCharacters(from: (caseSensitive ? query : query.lowercased()))
-//        let newQuery = caseSensitive ? query : query.lowercased()
         guard let mode = selectedMode.third else {
             return newQuery
         }
@@ -53,7 +52,8 @@ extension WorkspaceDocument.SearchState {
     /// Except its using the word boundary anchor(\b) instead of the asterisk(\*).
     /// This is needed to highlight the search results correctly.
     func getRegexPattern(_ query: String) -> String {
-        let newQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let newQuery = NSRegularExpression.escapedPattern(for: query.trimmingCharacters(in: .whitespacesAndNewlines))
+
         guard let mode = selectedMode.third else {
             return newQuery
         }
@@ -185,15 +185,10 @@ extension WorkspaceDocument.SearchState {
             return
         }
 
-        var options: NSRegularExpression.Options = [.ignoreMetacharacters]
-        if !caseSensitive {
-            options.insert(.caseInsensitive)
-        }
-
         // Attempt to create a regular expression from the provided query
         guard let regex = try? NSRegularExpression(
             pattern: query,
-            options: options
+            options: caseSensitive ? [] : .caseInsensitive
         ) else {
             await setStatus(.failed(errorMessage: "Invalid regular expression."))
             return


### PR DESCRIPTION
### Description
This PR addresses an issue where the search algorithm was unable to process certain special characters (e.g.`,`, `(`, `*`, `:`). This limitation prevented users from finding content that included these characters in their queries.

For example, searching for "info": in a JSON file would not return any results due to this limitation.

Contents.json:
```json
{
    "info": "xcode": {
        [...] 
    }
}
```
The fix in this PR corrects the search algorithm to handle these special characters, allowing users to successfully search for content that includes them.
### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

na

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
- [x] fix tests

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
