### PR TITLE
remove autobraces setting

### DIFF
--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
@@ -42,9 +42,6 @@ extension SettingsData {
         /// A flag indicating whether type-over completion is enabled
         var enableTypeOverCompletion: Bool = true
 
-        /// A flag indicating whether braces are automatically completed
-        var autocompleteBraces: Bool = true
-
         /// A flag indicating whether to wrap lines to editor width
         var wrapLinesToEditorWidth: Bool = true
 
@@ -76,10 +73,6 @@ extension SettingsData {
                 Bool.self,
                 forKey: .enableTypeOverCompletion
             ) ?? true
-            self.autocompleteBraces = try container.decodeIfPresent(
-                Bool.self,
-                forKey: .autocompleteBraces
-            ) ?? true
             self.wrapLinesToEditorWidth = try container.decodeIfPresent(
                 Bool.self,
                 forKey: .wrapLinesToEditorWidth
@@ -110,15 +103,6 @@ extension SettingsData {
                 id: "prefs.text_editing.type_over_completion",
                 command: CommandClosureWrapper {
                     Settings.shared.preferences.textEditing.enableTypeOverCompletion.toggle()
-                }
-            )
-
-            mgr.addCommand(
-                name: "Toggle Autocomplete Braces",
-                title: "Toggle Autocomplete Braces",
-                id: "prefs.text_editing.autocomplete_braces",
-                command: CommandClosureWrapper {
-                    Settings.shared.preferences.textEditing.autocompleteBraces.toggle()
                 }
             )
 

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -26,7 +26,6 @@ struct TextEditingSettingsView: View {
                 letterSpacing
             }
             Section {
-                autocompleteBraces
                 enableTypeOverCompletion
             }
             Section {
@@ -49,13 +48,6 @@ private extension TextEditingSettingsView {
             step: 1,
             format: .number
         )
-    }
-
-    @ViewBuilder private var autocompleteBraces: some View {
-        Toggle(isOn: $textEditing.autocompleteBraces) {
-            Text("Autocomplete braces")
-            Text("Automatically insert closing braces (\"}\")")
-        }
     }
 
     @ViewBuilder private var enableTypeOverCompletion: some View {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

This removes the setting to toggle automatic braces/brackets completion. This setting was completely non-functional and when disabled, braces were still closed automatically. This Pull Request removes the non-functional setting until it can be implemented properly, which would require communication between the settings and the CodeEditSourceEditor.

<!--- REQUIRED: Describe what changed in detail -->

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
