### PR TITLE
delete warning message uses enumerator instead of shallow search

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
@@ -136,10 +136,7 @@ extension CEWorkspaceFileManager {
             messageText = "Are you sure you want to delete \"\(file.name)\"?"
             informativeText = "This item will be deleted immediately. You can't undo this action."
         } else {
-            let childrenCount = try? fileManager.contentsOfDirectory(
-                at: file.url,
-                includingPropertiesForKeys: nil
-            ).count
+            let childrenCount = fileManager.enumerator(atPath: file.url.path)?.allObjects.count
 
             if let childrenCount {
                 messageText = "Are you sure you want to delete the \((childrenCount) + 1) selected items?"


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

The delete function shows a warning before deleting files with the amount of files being deleted. It initially used fileManager.contentsOfDirectory() which only performs a shallow search and ignores files nested into folders it finds, producing an incorrect count of files. My change uses enumerator instead to get a deeper search of files and produce a correct file count in the warning.
<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #1695

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
