### PR TITLE
Only Save Workspace Settings If Necessary

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Extensions/CEWorkspaceSettingsData+ProjectSettings.swift
+++ b/CodeEdit/Features/CEWorkspace/Extensions/CEWorkspaceSettingsData+ProjectSettings.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 extension CEWorkspaceSettingsData {
     /// Workspace settings for the project tab.
-    struct ProjectSettings: Codable, Hashable, SearchableSettingsPage {
+    struct ProjectSettings: Codable, Hashable, SearchableSettingsPage, WorkspaceSettingsGroup {
         var searchKeys: [String] {
             [
                 "Project Name",
@@ -25,6 +25,10 @@ extension CEWorkspaceSettingsData {
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.projectName = try container.decodeIfPresent(String.self, forKey: .projectName) ?? ""
+        }
+
+        func isEmpty() -> Bool {
+            projectName == ""
         }
     }
 }

--- a/CodeEdit/Features/CEWorkspace/Extensions/CEWorkspaceSettingsData+TasksSettings.swift
+++ b/CodeEdit/Features/CEWorkspace/Extensions/CEWorkspaceSettingsData+TasksSettings.swift
@@ -10,7 +10,7 @@ import Collections
 
 extension CEWorkspaceSettingsData {
     /// Workspace settings for the tasks tab.
-    struct TasksSettings: Codable, Hashable, SearchableSettingsPage {
+    struct TasksSettings: Codable, Hashable, SearchableSettingsPage, WorkspaceSettingsGroup {
         var items: [CETask] = []
 
         var searchKeys: [String] {
@@ -30,6 +30,10 @@ extension CEWorkspaceSettingsData {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.items = try container.decodeIfPresent([CETask].self, forKey: .items) ?? []
             self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        }
+
+        func isEmpty() -> Bool {
+            items.isEmpty && enabled == true
         }
     }
 }

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceSettingsData.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceSettingsData.swift
@@ -8,12 +8,18 @@
 import SwiftUI
 import Foundation
 
+protocol WorkspaceSettingsGroup {
+    /// Determine if the settings are changed from the defaults.
+    /// Used to check if creating a `.codeedit` folder is necessary on the user's machine.
+    func isEmpty() -> Bool
+}
+
 /// # Workspace Settings
 ///
 /// The model of the workspace settings for `CodeEdit` that control the behavior of some functionality at the workspace
 /// level like the workspace name or defining tasks.  A `JSON` representation is persisted in the workspace's
 /// `./codeedit/settings.json`. file
-struct CEWorkspaceSettingsData: Codable, Hashable {
+struct CEWorkspaceSettingsData: Codable, Hashable, WorkspaceSettingsGroup {
     /// The project global settings
     var project: ProjectSettings = .init()
 
@@ -40,5 +46,9 @@ struct CEWorkspaceSettingsData: Codable, Hashable {
         }
 
         return settings
+    }
+
+    func isEmpty() -> Bool {
+        project.isEmpty() && tasks.isEmpty()
     }
 }

--- a/CodeEdit/Features/Settings/Models/Settings.swift
+++ b/CodeEdit/Features/Settings/Models/Settings.swift
@@ -65,7 +65,6 @@ final class Settings: ObservableObject {
     /// Save``Settings`` model to
     /// `~/Library/Application Support/CodeEdit/settings.json`
     private func savePreferences(_ data: SettingsData) throws {
-        print("Saving...")
         let data = try JSONEncoder().encode(data)
         let json = try JSONSerialization.jsonObject(with: data)
         let prettyJSON = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

I personally dislike unnecessary folders being saved on my computer. This PR adds a check to workspace settings to see if there's any changed settings that need to be saved. If not, it doesn't create the `.codeedit` folder or the `settings.json` file inside it. I've also moved the folder creating logic into the `savePreferences` method to keep that all in the one method.

### Related Issues

N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
