### PR TITLE
New tabs after current focused tab#1704

### DIFF
--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -195,7 +195,12 @@ final class Editor: ObservableObject, Identifiable {
         if let index {
             tabs.insert(item, at: index)
         } else {
-            tabs.append(item)
+            guard let currentTab = selectedTab, let currentIndex = tabs.firstIndex(of: currentTab)
+            else {
+                tabs.append(item)
+                return
+            }
+            tabs.insert(item, at: tabs.index(after: currentIndex))
         }
         selectedTab = item
         if !fromHistory {

--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -200,7 +200,8 @@ final class Editor: ObservableObject, Identifiable {
                 tabs.append(item)
                 return
             }
-            tabs.insert(item, at: tabs.index(after: currentIndex))
+            let nextIndex = tabs.index(after: currentIndex)
+            tabs.insert(item, at: nextIndex)
         }
         selectedTab = item
         if !fromHistory {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
Fixed issue where new tabs opened at the end of all opened files instead of next to currently selected file.

<!--- REQUIRED: Describe what changed in detail -->
Within the open tab function, found the currently selected tab and appended the file to be opened in the next index.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

- https://github.com/CodeEditApp/CodeEdit/issues/1704

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots
**![Screen Recording 2024-05-13 at 6 49 48 PM](https://github.com/CodeEditApp/CodeEdit/assets/27977043/c32f34b2-3b09-4973-a5c3-5835ac60d1a9)**

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
