### PR TITLE
View text files that are not UTF-8 encoded

### DIFF
--- a/CodeEdit/Features/Documents/CodeFileDocument.swift
+++ b/CodeEdit/Features/Documents/CodeFileDocument.swift
@@ -124,8 +124,9 @@ final class CodeFileDocument: NSDocument, ObservableObject {
     /// This function is used for decoding files.
     /// It should not throw error as unsupported files can still be opened by QLPreviewView.
     override func read(from data: Data, ofType _: String) throws {
-        guard let content = String(data: data, encoding: .utf8) else { return }
-        self.content = content
+        var nsString: NSString?
+        NSString.stringEncoding(for: data, encodingOptions: nil, convertedString: &nsString, usedLossyConversion: nil)
+        self.content = nsString as? String ?? ""
     }
 
     /// Triggered when change occurred


### PR DESCRIPTION
### Description

This PR allows CodeEdit to show file contents in a different encoding from utf8.

The files in the related issues show up. I don't know how accurately, but it does a good job.

**NOTE:** Files are still saved using UTF8 encoding. 

### Related Issues

* Fixes #1726 
* Fixes #1263

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots
**BEFORE:**

https://github.com/CodeEditApp/CodeEdit/assets/49006567/7a332f1f-cdc4-427a-82c8-b0dfe231b71c

**AFTER:**

https://github.com/CodeEditApp/CodeEdit/assets/49006567/1aed4be6-fb4c-480b-92a9-b1b1dcc8b58d


