### PR TITLE
Make status bar an actual divider

### DIFF
--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3f6921a5ec30d1ecb6d6b205cf27a816c318246bb00f0ea367b997cc66527d32",
+  "originHash" : "41fcbec1ecbb7853d9ead798bba9d46f35f28767f4d41a009c8eeee022e99a84",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -85,7 +85,7 @@
     {
       "identity" : "logstream",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/LogStream",
+      "location" : "https://github.com/Wouter01/LogStream",
       "state" : {
         "revision" : "6f83694b2675dcf3b1cea0a52546ff4469c18282",
         "version" : "1.3.0"

--- a/CodeEdit/Features/SplitView/Views/SplitView.swift
+++ b/CodeEdit/Features/SplitView/Views/SplitView.swift
@@ -10,9 +10,11 @@ import SwiftUI
 struct SplitView<Content: View>: View {
     var axis: Axis
     var content: Content
+    var showDividers: Bool = false
 
-    init(axis: Axis, @ViewBuilder content: () -> Content) {
+    init(axis: Axis, showDividers: Bool = false, @ViewBuilder content: () -> Content) {
         self.axis = axis
+        self.showDividers = showDividers
         self.content = content()
     }
 
@@ -21,7 +23,7 @@ struct SplitView<Content: View>: View {
     var body: some View {
         VStack {
             content.variadic { children in
-                SplitViewControllerView(axis: axis, children: children, viewController: $viewController)
+                SplitViewControllerView(axis: axis, children: children, showDividers: showDividers, viewController: $viewController)
             }
         }
         ._trait(SplitViewControllerLayoutValueKey.self, viewController)

--- a/CodeEdit/Features/SplitView/Views/SplitViewControllerView.swift
+++ b/CodeEdit/Features/SplitView/Views/SplitViewControllerView.swift
@@ -11,6 +11,7 @@ struct SplitViewControllerView: NSViewControllerRepresentable {
 
     var axis: Axis
     var children: _VariadicView.Children
+    var showDividers: Bool
     @Binding var viewController: () -> SplitViewController?
 
     func makeNSViewController(context: Context) -> SplitViewController {
@@ -61,7 +62,7 @@ struct SplitViewControllerView: NSViewControllerRepresentable {
     }
 
     func makeCoordinator() -> SplitViewController {
-        SplitViewController(parent: self, axis: axis)
+        SplitViewController(parent: self, axis: axis, showDividers: showDividers)
     }
 }
 
@@ -70,10 +71,12 @@ final class SplitViewController: NSSplitViewController {
     var items: [SplitViewItem] = []
     var axis: Axis
     var parentView: SplitViewControllerView
+    var showDividers: Bool
 
-    init(parent: SplitViewControllerView, axis: Axis = .horizontal) {
+    init(parent: SplitViewControllerView, axis: Axis = .horizontal, showDividers: Bool = true) {
         self.axis = axis
         self.parentView = parent
+        self.showDividers = showDividers
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -93,6 +96,14 @@ final class SplitViewController: NSSplitViewController {
 
     override func splitView(_ splitView: NSSplitView, shouldHideDividerAt dividerIndex: Int) -> Bool {
         false
+    }
+
+    override func splitView(_ splitView: NSSplitView, effectiveRect proposedEffectiveRect: NSRect, forDrawnRect drawnRect: NSRect, ofDividerAt dividerIndex: Int) -> NSRect {
+        if showDividers {
+            super.splitView(splitView, effectiveRect: proposedEffectiveRect, forDrawnRect: drawnRect, ofDividerAt: dividerIndex)
+        } else {
+            .zero
+        }
     }
 
     func collapse(for id: AnyHashable, enabled: Bool) {

--- a/CodeEdit/Features/SplitView/Views/SplitViewControllerView.swift
+++ b/CodeEdit/Features/SplitView/Views/SplitViewControllerView.swift
@@ -98,9 +98,19 @@ final class SplitViewController: NSSplitViewController {
         false
     }
 
-    override func splitView(_ splitView: NSSplitView, effectiveRect proposedEffectiveRect: NSRect, forDrawnRect drawnRect: NSRect, ofDividerAt dividerIndex: Int) -> NSRect {
+    override func splitView(
+        _ splitView: NSSplitView,
+        effectiveRect proposedEffectiveRect: NSRect,
+        forDrawnRect drawnRect: NSRect,
+        ofDividerAt dividerIndex: Int
+    ) -> NSRect {
         if showDividers {
-            super.splitView(splitView, effectiveRect: proposedEffectiveRect, forDrawnRect: drawnRect, ofDividerAt: dividerIndex)
+            super.splitView(
+                splitView,
+                effectiveRect: proposedEffectiveRect,
+                forDrawnRect: drawnRect,
+                ofDividerAt: dividerIndex
+            )
         } else {
             .zero
         }

--- a/CodeEdit/Features/StatusBar/Views/StatusBarView.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarView.swift
@@ -61,9 +61,8 @@ struct StatusBarView: View {
     private var dragGesture: some Gesture {
         return DragGesture.init(coordinateSpace: .global)
             .onChanged { value in
-                // not sure why but -20 seems to give the smoothest performance
-                proxy.setPosition(of: 0, position: value.location.y - 20 - Self.height)
-                proxy.setPosition(of: 1, position: value.location.y - 20)
+                proxy.setPosition(of: 0, position: value.location.y - Self.height / 2)
+                proxy.setPosition(of: 1, position: value.location.y + Self.height / 2)
             }
     }
 }

--- a/CodeEdit/Features/StatusBar/Views/StatusBarView.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarView.swift
@@ -59,9 +59,11 @@ struct StatusBarView: View {
 
     /// A drag gesture to resize the drawer beneath the status bar
     private var dragGesture: some Gesture {
-        DragGesture(coordinateSpace: .global)
+        return DragGesture.init(coordinateSpace: .global)
             .onChanged { value in
-                proxy.setPosition(of: 0, position: value.location.y + Self.height / 2)
+                // not sure why but -20 seems to give the smoothest performance
+                proxy.setPosition(of: 0, position: value.location.y - 20 - Self.height)
+                proxy.setPosition(of: 1, position: value.location.y - 20)
             }
     }
 }

--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -35,7 +35,7 @@ struct WorkspaceView: View {
         if workspace.workspaceFileManager != nil {
             VStack {
                 SplitViewReader { proxy in
-                    SplitView(axis: .vertical) {
+                    SplitView(axis: .vertical, showDividers: false) {
                         EditorLayoutView(
                             layout: editorManager.isFocusingActiveEditor
                             ? editorManager.activeEditor.getEditorLayout() ?? editorManager.editorLayout
@@ -46,10 +46,9 @@ struct WorkspaceView: View {
                         .collapsed($utilityAreaViewModel.isMaximized)
                         .frame(minHeight: 170 + 29 + 29)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .holdingPriority(.init(1))
-                        .safeAreaInset(edge: .bottom, spacing: 0) {
-                            StatusBarView(proxy: proxy)
-                        }
+
+                        StatusBarView(proxy: proxy)
+
                         UtilityAreaView()
                             .collapsable()
                             .collapsed($utilityAreaViewModel.isCollapsed)


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

Previously, the status bar was just attached to the bottom of the editor, whereas in Xcode, it acts essentially as a thick divider. This PR aims to get the status bar to be more like Xcode's.

Relevant SO article: https://stackoverflow.com/questions/40643604/can-i-use-a-custom-view-as-a-nssplitviews-divider/40659541



### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

*  Fixes #1729 

### Checklist
- [ ] fix bug detailed in video below
- [ ] get maximization/collapse buttons to work

<!--- Add things that are not yet implemented above -->

- [ ] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [ ] The issues this PR addresses are related to each other
- [ ] My changes generate no new warnings
- [ ] My code builds and runs on my machine
- [ ] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots

As shown in the video below, normal drags + collapsing the editor work fine, but for some reason collapsing the terminal causes really jank behavior.

https://github.com/CodeEditApp/CodeEdit/assets/65467530/2beabea9-362b-40d4-88f8-3efafbeeaaec

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
