### PR TITLE
fix: Searchkit memory leaks

### DIFF
--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "41fcbec1ecbb7853d9ead798bba9d46f35f28767f4d41a009c8eeee022e99a84",
+  "originHash" : "3f6921a5ec30d1ecb6d6b205cf27a816c318246bb00f0ea367b997cc66527d32",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -85,7 +85,7 @@
     {
       "identity" : "logstream",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Wouter01/LogStream",
+      "location" : "https://github.com/CodeEditApp/LogStream",
       "state" : {
         "revision" : "6f83694b2675dcf3b1cea0a52546ff4469c18282",
         "version" : "1.3.0"

--- a/CodeEdit/Features/Documents/Indexer/SearchIndexer+Add.swift
+++ b/CodeEdit/Features/Documents/Indexer/SearchIndexer+Add.swift
@@ -22,7 +22,7 @@ extension SearchIndexer {
         }
 
         return modifyIndexQueue.sync {
-            SKIndexAddDocumentWithText(index, document.takeUnretainedValue(), text as CFString, canReplace)
+            SKIndexAddDocumentWithText(index, document.takeRetainedValue(), text as CFString, canReplace)
         }
     }
 
@@ -66,7 +66,7 @@ extension SearchIndexer {
         let mime = mimeType ?? self.detectMimeType(fileURL)
 
         return modifyIndexQueue.sync {
-            SKIndexAddDocument(index, document.takeUnretainedValue(), mime as CFString?, canReplace)
+            SKIndexAddDocument(index, document.takeRetainedValue(), mime as CFString?, canReplace)
         }
     }
 
@@ -107,7 +107,7 @@ extension SearchIndexer {
     /// - Returns: `true` if the document was successfully removed, `false` otherwise. 
     /// **Note:** If the document didn't exist, this also returns `true`.
     public func removeDocument(url: URL) -> Bool {
-        let document = SKDocumentCreateWithURL(url as CFURL).takeUnretainedValue()
+        let document = SKDocumentCreateWithURL(url as CFURL).takeRetainedValue()
         return self.remove(document: document)
     }
 

--- a/CodeEdit/Features/Documents/Indexer/SearchIndexer+InternalMethods.swift
+++ b/CodeEdit/Features/Documents/Indexer/SearchIndexer+InternalMethods.swift
@@ -64,25 +64,24 @@ extension SearchIndexer {
 
         var isLeaf = true
 
-        let iterator = SKIndexDocumentIteratorCreate(index, inParentDocument).takeUnretainedValue()
+        let iterator = SKIndexDocumentIteratorCreate(index, inParentDocument).takeRetainedValue()
         while let skDocument = SKIndexDocumentIteratorCopyNext(iterator) {
             isLeaf = false
-            self.addLeafURLs(index: index, inParentDocument: skDocument.takeUnretainedValue(), docs: &docs)
+            self.addLeafURLs(index: index, inParentDocument: skDocument.takeRetainedValue(), docs: &docs)
         }
-
         if isLeaf, inParentDocument != nil,
            kSKDocumentStateNotIndexed != SKIndexGetDocumentState(index, inParentDocument) {
-            if let temp = SKDocumentCopyURL(inParentDocument) {
-                let baseURL = temp.takeUnretainedValue() as URL
-                let documentID = SKIndexGetDocumentID(index, inParentDocument)
-                docs.append(
-                    DocumentID(
-                        url: baseURL,
-                        document: inParentDocument!,
-                        documentID: documentID
-                    )
+            let url = SKDocumentCopyURL(inParentDocument).takeRetainedValue()
+
+            let documentID = SKIndexGetDocumentID(index, inParentDocument)
+            docs.append(
+                DocumentID(
+                    url: url as URL,
+                    document: inParentDocument!,
+                    documentID: documentID
                 )
-            }
+            )
+
         }
     }
 

--- a/CodeEdit/Features/Documents/Indexer/SearchIndexer+ProgressiveSearch.swift
+++ b/CodeEdit/Features/Documents/Indexer/SearchIndexer+ProgressiveSearch.swift
@@ -93,7 +93,7 @@ extension SearchIndexer {
 
             let partialResult: [SearchResult] = zip(urls[0..<foundCount], scores)
                 .compactMap { (cfurl, score) -> SearchResult? in
-                    guard let url  = cfurl?.takeUnretainedValue() as URL? else {
+                    guard let url  = cfurl?.takeRetainedValue() as URL? else {
                         return nil
                     }
 

--- a/CodeEdit/Features/Documents/Indexer/SearchIndexer+Terms.swift
+++ b/CodeEdit/Features/Documents/Indexer/SearchIndexer+Terms.swift
@@ -67,11 +67,11 @@ extension SearchIndexer {
 
         var result = [TermCount]()
 
-        let document = SKDocumentCreateWithURL(url as CFURL).takeUnretainedValue()
+        let document = SKDocumentCreateWithURL(url as CFURL).takeRetainedValue()
         let documentID = SKIndexGetDocumentID(index, document)
 
         guard let termVals = SKIndexCopyTermIDArrayForDocumentID(index, documentID),
-              let terms = termVals.takeUnretainedValue() as? [CFIndex] else {
+              let terms = termVals.takeRetainedValue() as? [CFIndex] else {
             return []
         }
 

--- a/CodeEdit/Features/Documents/Indexer/SearchIndexer.swift
+++ b/CodeEdit/Features/Documents/Indexer/SearchIndexer.swift
@@ -67,7 +67,7 @@ public class SearchIndexer {
     private(set) lazy var stopWords: Set<String> = {
         var stopWords: Set<String> = []
         if let index = self.index,
-           let properties = SKIndexGetAnalysisProperties(self.index).takeUnretainedValue() as? [String: Any],
+           let properties = SKIndexGetAnalysisProperties(self.index).takeRetainedValue() as? [String: Any],
            let newStopWords = properties[kSKStopWords as String] as? Set<String> {
             stopWords = newStopWords
         }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
This PR fixes some memory leaks that occurred during the retrieval of search results from SearchKit. This was because I wrongfully used .takeUnretainedValue(), which caused the memory count to be off, leading to thousands of objects not being deinitialized.

I reviewed all the code that uses SearchKit and corrected other instances of wrongful use of .takeUnretainedValue() or .takeRetainedValue().

During profiling, there should no longer be any memory leaks connected to SearchKit.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #1736

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
