### PR TITLE
Use Single Text Storage For Documents

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -322,6 +322,7 @@
 		6C4104E3297C87A000F472BA /* BlurButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4104E2297C87A000F472BA /* BlurButtonStyle.swift */; };
 		6C4104E6297C884F00F472BA /* AboutDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4104E5297C884F00F472BA /* AboutDetailView.swift */; };
 		6C4104E9297C970F00F472BA /* AboutDefaultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4104E8297C970F00F472BA /* AboutDefaultView.swift */; };
+		6C48B5C52C0A2835001E9955 /* FileEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48B5C42C0A2835001E9955 /* FileEncoding.swift */; };
 		6C48D8F22972DAFC00D6D205 /* Env+IsFullscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F12972DAFC00D6D205 /* Env+IsFullscreen.swift */; };
 		6C48D8F42972DB1A00D6D205 /* Env+Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F32972DB1A00D6D205 /* Env+Window.swift */; };
 		6C48D8F72972E5F300D6D205 /* WindowObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F62972E5F300D6D205 /* WindowObserver.swift */; };
@@ -890,6 +891,7 @@
 		6C4104E2297C87A000F472BA /* BlurButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurButtonStyle.swift; sourceTree = "<group>"; };
 		6C4104E5297C884F00F472BA /* AboutDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutDetailView.swift; sourceTree = "<group>"; };
 		6C4104E8297C970F00F472BA /* AboutDefaultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutDefaultView.swift; sourceTree = "<group>"; };
+		6C48B5C42C0A2835001E9955 /* FileEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEncoding.swift; sourceTree = "<group>"; };
 		6C48D8F12972DAFC00D6D205 /* Env+IsFullscreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Env+IsFullscreen.swift"; sourceTree = "<group>"; };
 		6C48D8F32972DB1A00D6D205 /* Env+Window.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Env+Window.swift"; sourceTree = "<group>"; };
 		6C48D8F62972E5F300D6D205 /* WindowObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowObserver.swift; sourceTree = "<group>"; };
@@ -1129,6 +1131,7 @@
 				5831E3CE2933F3DE00D5A6D2 /* Controllers */,
 				611191F82B08CC8000D4459B /* Indexer */,
 				58798249292E78D80085B254 /* CodeFileDocument.swift */,
+				6C48B5C42C0A2835001E9955 /* FileEncoding.swift */,
 				043C321527E3201F006AE443 /* WorkspaceDocument.swift */,
 				043BCF02281DA18A000AC47C /* WorkspaceDocument+SearchState.swift */,
 				61A53A802B4449F00093BF8A /* WorkspaceDocument+Index.swift */,
@@ -3488,6 +3491,7 @@
 				6C48D8F22972DAFC00D6D205 /* Env+IsFullscreen.swift in Sources */,
 				587B9E8729301D8F00AC7927 /* GitHubRepositories.swift in Sources */,
 				6CE6226B2A2A1C730013085C /* UtilityAreaTab.swift in Sources */,
+				6C48B5C52C0A2835001E9955 /* FileEncoding.swift in Sources */,
 				587B9DA329300ABD00AC7927 /* SettingsTextEditor.swift in Sources */,
 				B6F0517B29D9E46400D72287 /* SourceControlSettingsView.swift in Sources */,
 				6C147C4D29A32AA30089B630 /* EditorAreaView.swift in Sources */,
@@ -4932,7 +4936,7 @@
 			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.7.2;
+				minimumVersion = 0.7.3;
 			};
 		};
 		6CDEFC9429E22C2700B7C684 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		6C4104E6297C884F00F472BA /* AboutDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4104E5297C884F00F472BA /* AboutDetailView.swift */; };
 		6C4104E9297C970F00F472BA /* AboutDefaultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4104E8297C970F00F472BA /* AboutDefaultView.swift */; };
 		6C48B5C52C0A2835001E9955 /* FileEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48B5C42C0A2835001E9955 /* FileEncoding.swift */; };
+		6C48B5C92C0B5F7A001E9955 /* NSTextStorage+isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48B5C72C0B5F7A001E9955 /* NSTextStorage+isEmpty.swift */; };
 		6C48D8F22972DAFC00D6D205 /* Env+IsFullscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F12972DAFC00D6D205 /* Env+IsFullscreen.swift */; };
 		6C48D8F42972DB1A00D6D205 /* Env+Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F32972DB1A00D6D205 /* Env+Window.swift */; };
 		6C48D8F72972E5F300D6D205 /* WindowObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C48D8F62972E5F300D6D205 /* WindowObserver.swift */; };
@@ -892,6 +893,7 @@
 		6C4104E5297C884F00F472BA /* AboutDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutDetailView.swift; sourceTree = "<group>"; };
 		6C4104E8297C970F00F472BA /* AboutDefaultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutDefaultView.swift; sourceTree = "<group>"; };
 		6C48B5C42C0A2835001E9955 /* FileEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEncoding.swift; sourceTree = "<group>"; };
+		6C48B5C72C0B5F7A001E9955 /* NSTextStorage+isEmpty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSTextStorage+isEmpty.swift"; sourceTree = "<group>"; };
 		6C48D8F12972DAFC00D6D205 /* Env+IsFullscreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Env+IsFullscreen.swift"; sourceTree = "<group>"; };
 		6C48D8F32972DB1A00D6D205 /* Env+Window.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Env+Window.swift"; sourceTree = "<group>"; };
 		6C48D8F62972E5F300D6D205 /* WindowObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowObserver.swift; sourceTree = "<group>"; };
@@ -2198,6 +2200,7 @@
 				588847672992AAB800996D95 /* Array */,
 				6CBD1BC42978DE3E006639D5 /* Text */,
 				5831E3D02934036D00D5A6D2 /* NSTableView */,
+				6C48B5C82C0B5F7A001E9955 /* NSTextStorage */,
 				5831E3CA2933E86F00D5A6D2 /* View */,
 				5831E3C72933E7F700D5A6D2 /* Bundle */,
 				5831E3C62933E7E600D5A6D2 /* Color */,
@@ -2438,6 +2441,15 @@
 			);
 			path = FindNavigatorResultList;
 			sourceTree = "<group>";
+		};
+		6C48B5C82C0B5F7A001E9955 /* NSTextStorage */ = {
+			isa = PBXGroup;
+			children = (
+				6C48B5C72C0B5F7A001E9955 /* NSTextStorage+isEmpty.swift */,
+			);
+			name = NSTextStorage;
+			path = CodeEdit/Utils/Extensions/NSTextStorage;
+			sourceTree = SOURCE_ROOT;
 		};
 		6C48D8EF2972DAC300D6D205 /* Environment */ = {
 			isa = PBXGroup;
@@ -3742,6 +3754,7 @@
 				6C81916729B3E80700B75C92 /* ModifierKeysObserver.swift in Sources */,
 				613899BC2B6E709C00A5CAF6 /* URL+FuzzySearchable.swift in Sources */,
 				611192002B08CCD700D4459B /* SearchIndexer+Memory.swift in Sources */,
+				6C48B5C92C0B5F7A001E9955 /* NSTextStorage+isEmpty.swift in Sources */,
 				587B9E8129301D8F00AC7927 /* PublicKey.swift in Sources */,
 				611191FE2B08CCD200D4459B /* SearchIndexer+File.swift in Sources */,
 				77A01E302BB4270F00F0EA38 /* ProjectCEWorkspaceSettingsView.swift in Sources */,

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3f6921a5ec30d1ecb6d6b205cf27a816c318246bb00f0ea367b997cc66527d32",
+  "originHash" : "41fcbec1ecbb7853d9ead798bba9d46f35f28767f4d41a009c8eeee022e99a84",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
       "state" : {
-        "revision" : "620b463c88894741e20d4711c9435b33547de5d2",
-        "version" : "0.1.18"
+        "revision" : "5b27f139269e1ea49ceae5e56dca44a3ccad50a1",
+        "version" : "0.1.19"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
       "state" : {
-        "revision" : "7360f00bf7ec8e93b4833357bd254bef7e5c943d",
-        "version" : "0.7.2"
+        "revision" : "cf85789d527d569e94edfd674c5ac8071b244dd9",
+        "version" : "0.7.3"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "86b980464bcb67693e2053283c7a99bdc6f358bc",
-        "version" : "0.7.3"
+        "revision" : "80911be6bcdae5e35ef5ed351adf6dda9b57e555",
+        "version" : "0.7.4"
       }
     },
     {
@@ -85,7 +85,7 @@
     {
       "identity" : "logstream",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/LogStream",
+      "location" : "https://github.com/Wouter01/LogStream",
       "state" : {
         "revision" : "6f83694b2675dcf3b1cea0a52546ff4469c18282",
         "version" : "1.3.0"

--- a/CodeEdit/Features/Documents/CodeFileDocument.swift
+++ b/CodeEdit/Features/Documents/CodeFileDocument.swift
@@ -65,7 +65,7 @@ final class CodeFileDocument: NSDocument, ObservableObject {
     /// - Note: The UTType doesn't necessarily mean the file extension, it can be the MIME
     /// type or any other form of data representation.
     var utType: UTType? {
-        if content != nil && (content?.length ?? 0) > 0 {
+        if content != nil && content?.isEmpty ?? true {
             return .text
         }
         guard let fileType, let type = UTType(fileType) else {
@@ -177,9 +177,5 @@ final class CodeFileDocument: NSDocument, ObservableObject {
         }
 
         self.isDocumentEditedSubject.send(self.isDocumentEdited)
-    }
-
-    deinit {
-        Swift.print("Deinit!")
     }
 }

--- a/CodeEdit/Features/Documents/CodeFileDocument.swift
+++ b/CodeEdit/Features/Documents/CodeFileDocument.swift
@@ -33,11 +33,14 @@ final class CodeFileDocument: NSDocument, ObservableObject {
     /// enough.
     ///
     /// To receive notifications for content updates, subscribe to one of the publishers on ``contentCoordinator``.
-    var content: NSTextStorage = NSTextStorage(string: "")
+    var content: NSTextStorage?
+
+    /// The string encoding of the original file. Used to save the file back to the encoding it was loaded from.
+    var sourceEncoding: FileEncoding?
 
     /// The coordinator to use to subscribe to edit events and cursor location events.
     /// See ``CodeEditSourceEditor/CombineCoordinator``.
-//    @Published var contentCoordinator: CombineCoordinator = CombineCoordinator()
+    @Published var contentCoordinator: CombineCoordinator = CombineCoordinator()
 
     /// Used to override detected languages.
     @Published var language: CodeLanguage?
@@ -62,7 +65,7 @@ final class CodeFileDocument: NSDocument, ObservableObject {
     /// - Note: The UTType doesn't necessarily mean the file extension, it can be the MIME
     /// type or any other form of data representation.
     var utType: UTType? {
-        if !self.content.isEmpty {
+        if content != nil && (content?.length ?? 0) > 0 {
             return .text
         }
         guard let fileType, let type = UTType(fileType) else {
@@ -128,7 +131,7 @@ final class CodeFileDocument: NSDocument, ObservableObject {
     }
 
     override func data(ofType _: String) throws -> Data {
-        guard let data = (content.string as NSString).data(using: NSUTF8StringEncoding) else {
+        guard let sourceEncoding, let data = (content?.string as NSString?)?.data(using: sourceEncoding.nsValue) else {
             throw CodeFileError.failedToEncode
         }
         return data
@@ -138,8 +141,20 @@ final class CodeFileDocument: NSDocument, ObservableObject {
     /// It should not throw error as unsupported files can still be opened by QLPreviewView.
     override func read(from data: Data, ofType _: String) throws {
         var nsString: NSString?
-        NSString.stringEncoding(for: data, encodingOptions: nil, convertedString: &nsString, usedLossyConversion: nil)
-        self.content = nsString as? String ?? ""
+        let rawEncoding = NSString.stringEncoding(
+            for: data,
+            encodingOptions: [
+                .allowLossyKey: false, // Fail if using lossy encoding.
+                .suggestedEncodingsKey: FileEncoding.allCases.map { $0.nsValue },
+                .useOnlySuggestedEncodingsKey: true
+            ],
+            convertedString: &nsString,
+            usedLossyConversion: nil
+        )
+        if let validEncoding = FileEncoding(rawEncoding), let nsString {
+            self.sourceEncoding = validEncoding
+            self.content = NSTextStorage(string: nsString as String)
+        }
     }
 
     /// Triggered when change occurred

--- a/CodeEdit/Features/Documents/FileEncoding.swift
+++ b/CodeEdit/Features/Documents/FileEncoding.swift
@@ -35,4 +35,4 @@ enum FileEncoding: CaseIterable {
             return nil
         }
     }
-    }
+}

--- a/CodeEdit/Features/Documents/FileEncoding.swift
+++ b/CodeEdit/Features/Documents/FileEncoding.swift
@@ -1,0 +1,38 @@
+//
+//  FileEncoding.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 5/31/24.
+//
+
+import Foundation
+
+enum FileEncoding: CaseIterable {
+    case utf8
+    case utf16BE
+    case utf16LE
+
+    var nsValue: UInt {
+        switch self {
+        case .utf8:
+            return NSUTF8StringEncoding
+        case .utf16BE:
+            return NSUTF16BigEndianStringEncoding
+        case .utf16LE:
+            return NSUTF16LittleEndianStringEncoding
+        }
+    }
+
+    init?(_ int: UInt) {
+        switch int {
+        case NSUTF8StringEncoding:
+            self = .utf8
+        case NSUTF16BigEndianStringEncoding:
+            self = .utf16BE
+        case NSUTF16LittleEndianStringEncoding:
+            self = .utf16LE
+        default:
+            return nil
+        }
+    }
+    }

--- a/CodeEdit/Features/Editor/Models/EditorInstance.swift
+++ b/CodeEdit/Features/Editor/Models/EditorInstance.swift
@@ -77,7 +77,6 @@ class EditorInstance: Hashable {
         /// - Returns: The number of lines contained by the given range. Or `0` if the text view could not be found,
         ///            or lines could not be found for the given range.
         func linesInRange(_ range: NSRange) -> Int {
-            // TODO: textView should be public, workaround for now
             guard let controller = textViewController,
                   let scrollView = controller.view as? NSScrollView,
                   let textView = scrollView.documentView as? TextView,

--- a/CodeEdit/Features/Editor/Views/CodeFileView.swift
+++ b/CodeEdit/Features/Editor/Views/CodeFileView.swift
@@ -105,7 +105,7 @@ struct CodeFileView: View {
 
     var body: some View {
         CodeEditSourceEditor(
-            codeFile.content,
+            codeFile.content ?? NSTextStorage(),
             language: getLanguage(),
             theme: selectedTheme.editor.editorTheme,
             font: font,
@@ -156,8 +156,8 @@ struct CodeFileView: View {
         }
         return codeFile.language ?? CodeLanguage.detectLanguageFrom(
             url: url,
-            prefixBuffer: codeFile.content.string.getFirstLines(5),
-            suffixBuffer: codeFile.content.string.getLastLines(5)
+            prefixBuffer: codeFile.content?.string.getFirstLines(5),
+            suffixBuffer: codeFile.content?.string.getLastLines(5)
         )
     }
 

--- a/CodeEdit/Features/Editor/Views/CodeFileView.swift
+++ b/CodeEdit/Features/Editor/Views/CodeFileView.swift
@@ -48,15 +48,15 @@ struct CodeFileView: View {
 
     @StateObject private var themeModel: ThemeModel = .shared
 
-    private var cancellables = [AnyCancellable]()
+    private var cancellables = Set<AnyCancellable>()
 
     private let isEditable: Bool
 
     private let undoManager = CEUndoManager()
 
     init(codeFile: CodeFileDocument, textViewCoordinators: [TextViewCoordinator] = [], isEditable: Bool = true) {
-        self.codeFile = codeFile
-        self.textViewCoordinators = textViewCoordinators
+        self._codeFile = .init(wrappedValue: codeFile)
+        self.textViewCoordinators = textViewCoordinators + [codeFile.contentCoordinator]
         self.isEditable = isEditable
 
         if let openOptions = codeFile.openOptions {
@@ -65,16 +65,12 @@ struct CodeFileView: View {
         }
 
         codeFile
-            .$content
-            .dropFirst()
-            .debounce(
-                for: 0.25,
-                scheduler: DispatchQueue.main
-            )
+            .contentCoordinator
+            .textUpdatePublisher
+            .debounce(for: 0.25, scheduler: DispatchQueue.main)
             .sink { _ in
                 codeFile.updateChangeCount(.changeDone)
-                codeFile.autosave(withImplicitCancellability: false) { _ in
-                }
+                codeFile.autosave(withImplicitCancellability: false) { _ in }
             }
             .store(in: &cancellables)
 
@@ -109,7 +105,7 @@ struct CodeFileView: View {
 
     var body: some View {
         CodeEditSourceEditor(
-            $codeFile.content,
+            codeFile.content,
             language: getLanguage(),
             theme: selectedTheme.editor.editorTheme,
             font: font,
@@ -160,8 +156,8 @@ struct CodeFileView: View {
         }
         return codeFile.language ?? CodeLanguage.detectLanguageFrom(
             url: url,
-            prefixBuffer: codeFile.content.getFirstLines(5),
-            suffixBuffer: codeFile.content.getLastLines(5)
+            prefixBuffer: codeFile.content.string.getFirstLines(5),
+            suffixBuffer: codeFile.content.string.getLastLines(5)
         )
     }
 

--- a/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorPositionLabel.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorPositionLabel.swift
@@ -24,6 +24,7 @@ struct StatusBarCursorPositionLabel: View {
     /// Updates the source of cursor position notifications.
     func updateSource() {
         tab = editorManager.activeEditor.selectedTab
+//        print(editorManager.activeEditor.selectedTab)
     }
 
     /// Finds the lines contained by a range in the currently selected document.
@@ -97,12 +98,15 @@ struct StatusBarCursorPositionLabel: View {
             updateSource()
         }
         .onReceive(editorManager.activeEditor.objectWillChange) { _ in
+//            print("editorManager.activeEditor.objectWillChange")
             updateSource()
         }
         .onChange(of: editorManager.activeEditor) { _ in
+//            print("editorManager.activeEditor")
             updateSource()
         }
         .onChange(of: editorManager.activeEditor.selectedTab) { _ in
+//            print("editorManager.activeEditor.selectedTab")
             updateSource()
         }
     }

--- a/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorPositionLabel.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorPositionLabel.swift
@@ -24,7 +24,6 @@ struct StatusBarCursorPositionLabel: View {
     /// Updates the source of cursor position notifications.
     func updateSource() {
         tab = editorManager.activeEditor.selectedTab
-//        print(editorManager.activeEditor.selectedTab)
     }
 
     /// Finds the lines contained by a range in the currently selected document.
@@ -98,15 +97,12 @@ struct StatusBarCursorPositionLabel: View {
             updateSource()
         }
         .onReceive(editorManager.activeEditor.objectWillChange) { _ in
-//            print("editorManager.activeEditor.objectWillChange")
             updateSource()
         }
         .onChange(of: editorManager.activeEditor) { _ in
-//            print("editorManager.activeEditor")
             updateSource()
         }
         .onChange(of: editorManager.activeEditor.selectedTab) { _ in
-//            print("editorManager.activeEditor.selectedTab")
             updateSource()
         }
     }

--- a/CodeEdit/Utils/Extensions/NSTextStorage/NSTextStorage+isEmpty.swift
+++ b/CodeEdit/Utils/Extensions/NSTextStorage/NSTextStorage+isEmpty.swift
@@ -1,0 +1,14 @@
+//
+//  NSTextStorage+isEmpty.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 5/19/24.
+//
+
+import AppKit
+
+extension NSTextStorage {
+    var isEmpty: Bool {
+        length == 0
+    }
+}

--- a/CodeEditTests/Features/CodeFile/CodeFileTests.swift
+++ b/CodeEditTests/Features/CodeFile/CodeFileTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import CodeEdit
 
 final class CodeFileUnitTests: XCTestCase {
-    func testViewContentLoading() throws {
+    var fileURL: URL!
+
+    override func setUp() async throws {
         let directory = try FileManager.default.url(
             for: .developerApplicationDirectory,
             in: .userDomainMask,
@@ -21,9 +23,10 @@ final class CodeFileUnitTests: XCTestCase {
             .appendingPathComponent("CodeEdit", isDirectory: true)
             .appendingPathComponent("WorkspaceClientTests", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        fileURL = directory.appendingPathComponent("fakeFile.swift")
+    }
 
-        let fileURL = directory.appendingPathComponent("fakeFile.swift")
-
+    func testLoadUTF8Encoding() throws {
         let fileContent = "func test(){}"
 
         try fileContent.data(using: .utf8)?.write(to: fileURL)
@@ -32,6 +35,29 @@ final class CodeFileUnitTests: XCTestCase {
             withContentsOf: fileURL,
             ofType: "public.source-code"
         )
-        XCTAssertEqual(codeFile.content, fileContent)
+        XCTAssertEqual(codeFile.content?.string, fileContent)
+        XCTAssertEqual(codeFile.sourceEncoding, .utf8)
+    }
+
+    func testWriteUTF8Encoding() throws {
+        let codeFile = CodeFileDocument()
+        codeFile.content = NSTextStorage(string: "func test(){}")
+        codeFile.sourceEncoding = .utf8
+        try codeFile.write(to: fileURL, ofType: "public.source-code")
+
+        let data = try Data(contentsOf: fileURL)
+        var nsString: NSString?
+        let fileEncoding = NSString.stringEncoding(
+            for: data,
+            encodingOptions: [
+                .suggestedEncodingsKey: FileEncoding.allCases.map { $0.nsValue },
+                .useOnlySuggestedEncodingsKey: true
+            ],
+            convertedString: &nsString,
+            usedLossyConversion: nil
+        )
+
+        XCTAssertEqual(codeFile.content?.string as NSString?, nsString)
+        XCTAssertEqual(fileEncoding, NSUTF8StringEncoding)
     }
 }


### PR DESCRIPTION
### Description

Right now, `CodeFileView` is reevaluated each keystroke, causing a severe lag on large files. On top of being reevaluated it does a string compare on `CodeFileDocument.content`, which causes a hang for large files that then need to be compared character by character. This comparison isn't consistent, and is up to SwiftUI's heuristic for choosing when to compare the published variable.

This PR changes `CodeFileDocument` to use a non-published `NSTextStorage` object to store the document's contents. This means we have a single copy of the document across the entire app. Before, there was a copy stored in the text view's text storage, as well as in the code file document's `content` string. This also makes editing more efficient, as the contents of the document aren't copied each keystroke from the text view's text storage to the document's Swift String. Finally, SwiftUI will not attempt to compare views using this property as it's not published and the CodeFileView has a stable identifier.

This also enables listening to changes in the document via a new combine object that publishes notifications for changes in the content and cursor position changes. These are used now to update the auto-save timer rather than listening for changes in the content publisher.

### Related Issues

* closes #1728 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code