### PR TITLE
Fix rendering of git commits with bodies in the History Inspector

### DIFF
--- a/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
@@ -31,14 +31,14 @@ extension GitClient {
         dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
 
         let output = try await run(
-            "log --pretty=%h¦%H¦%s¦%aN¦%ae¦%cn¦%ce¦%aD¦%b¦%D¦ \(maxCountString) \(branchNameString) \(fileLocalPath)"
+            "log -z --pretty=%h¦%H¦%s¦%aN¦%ae¦%cn¦%ce¦%aD¦%b¦%D¦ \(maxCountString) \(branchNameString) \(fileLocalPath)"
                 .trimmingCharacters(in: .whitespacesAndNewlines)
         )
         let remote = try await run("ls-remote --get-url")
         let remoteURL = URL(string: remote.trimmingCharacters(in: .whitespacesAndNewlines))
 
         return output
-            .split(separator: "\n")
+            .split(separator: "\0")
             .map { line -> GitCommit in
                 let parameters = String(line).components(separatedBy: "¦")
                 let infoRef = parameters[safe: 9]


### PR DESCRIPTION
### Description

`GitClient`'s `getCommitHistory` method fetches git history by executing `git log`, with a format string that _can_ render multi-line content for a commit, then parses the string into individual commits by splitting on newline. This approach breaks when multi-line content is encountered.

In this PR, I pass `-z` to `git log`, so that entries are terminated with a null byte instead of a newline, then when parsing the content, split on `\0` instead of `\n`.

### Related Issues

* closes #1741 

### Checklist

<!--- Add things that are not yet implemented above -->

- [ ] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [ ] The issues this PR addresses are related to each other
- [ ] My changes generate no new warnings
- [ ] My code builds and runs on my machine
- [ ] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots

Before:

![CleanShot 2024-06-02 at 10  12 52@2x](https://github.com/CodeEditApp/CodeEdit/assets/116432/cdf6e3b8-a8fe-4f63-9a34-693bad687995)

After:

![CleanShot 2024-06-02 at 10  21 30@2x](https://github.com/CodeEditApp/CodeEdit/assets/116432/3489c3fc-54b8-428d-b37d-f92620d772cc)
