### PR TITLE
Show Git history in the History Inspector, even when a remote is not configured

### DIFF
--- a/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
@@ -34,7 +34,7 @@ extension GitClient {
             "log -z --pretty=%h¦%H¦%s¦%aN¦%ae¦%cn¦%ce¦%aD¦%b¦%D¦ \(maxCountString) \(branchNameString) \(fileLocalPath)"
                 .trimmingCharacters(in: .whitespacesAndNewlines)
         )
-        let remoteURL = await getRemoteURL()
+        let remoteURL = try await getRemoteURL()
 
         return output
             .split(separator: "\0")

--- a/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+CommitHistory.swift
@@ -34,8 +34,7 @@ extension GitClient {
             "log -z --pretty=%h¦%H¦%s¦%aN¦%ae¦%cn¦%ce¦%aD¦%b¦%D¦ \(maxCountString) \(branchNameString) \(fileLocalPath)"
                 .trimmingCharacters(in: .whitespacesAndNewlines)
         )
-        let remote = try await run("ls-remote --get-url")
-        let remoteURL = URL(string: remote.trimmingCharacters(in: .whitespacesAndNewlines))
+        let remoteURL = await getRemoteURL()
 
         return output
             .split(separator: "\0")

--- a/CodeEdit/Features/Git/Client/GitClient+Remote.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+Remote.swift
@@ -37,12 +37,15 @@ extension GitClient {
     /// > will be used, unless there’s an upstream branch configured for the current branch.
     /// > (Reference: https://git-scm.com/docs/git-ls-remote, https://git-scm.com/docs/git-fetch)
     /// - Returns: A URL if a remote is configured, nil otherwise
-    func getRemoteURL() async -> URL? {
+    /// - Throws: `GitClientError.outputError` if the underlying git command fails unexpectedly
+    func getRemoteURL() async throws -> URL? {
         do {
             let remote = try await run("ls-remote --get-url")
             return URL(string: remote.trimmingCharacters(in: .whitespacesAndNewlines))
-        } catch {
+        } catch GitClientError.noRemoteConfigured {
             return nil
+        } catch {
+            throw error
         }
     }
 }

--- a/CodeEdit/Features/Git/Client/GitClient+Remote.swift
+++ b/CodeEdit/Features/Git/Client/GitClient+Remote.swift
@@ -31,6 +31,20 @@ extension GitClient {
     func removeRemote(name: String) async throws {
         _ = try await run("remote rm \(name)")
     }
+
+    /// Get the URL of the remote
+    /// > Note: If a git repository has multiple remotes, by default the `origin` remote
+    /// > will be used, unless there’s an upstream branch configured for the current branch.
+    /// > (Reference: https://git-scm.com/docs/git-ls-remote, https://git-scm.com/docs/git-fetch)
+    /// - Returns: A URL if a remote is configured, nil otherwise
+    func getRemoteURL() async -> URL? {
+        do {
+            let remote = try await run("ls-remote --get-url")
+            return URL(string: remote.trimmingCharacters(in: .whitespacesAndNewlines))
+        } catch {
+            return nil
+        }
+    }
 }
 
 func parseGitRemotes(from output: String) -> [GitRemote] {

--- a/CodeEdit/Features/Git/Client/GitClient.swift
+++ b/CodeEdit/Features/Git/Client/GitClient.swift
@@ -13,12 +13,14 @@ class GitClient {
         case outputError(String)
         case notGitRepository
         case failedToDecodeURL
+        case noRemoteConfigured
 
         var description: String {
             switch self {
             case .outputError(let string): string
             case .notGitRepository: "Not a git repository"
             case .failedToDecodeURL: "Failed to decode URL"
+            case .noRemoteConfigured: "No remote configured"
             }
         }
     }
@@ -61,6 +63,10 @@ class GitClient {
     private func processCommonErrors(_ output: String) throws -> String {
         if output.contains("fatal: not a git repository") {
             throw GitClientError.notGitRepository
+        }
+
+        if output.contains("fatal: No remote configured") {
+            throw GitClientError.noRemoteConfigured
         }
 
         if output.hasPrefix("fatal:") {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

The previous method of determining the remote URL for a git commit would `throw` if no remote was configured. This led to the History Inspector panel being empty if the file being edited was under version control with Git but did not have a remote configured.

This PR makes the check for a remote non-fatal if a remote is not configured, setting the `remoteURL` property of a `GitCommit` to `nil` instead.

### Related Issues

* closes #1743 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="1393" alt="Screenshot 2024-06-03 at 2 29 52 PM" src="https://github.com/CodeEditApp/CodeEdit/assets/116432/20daee90-2248-40a8-b5f4-d01214e1fad9">

