### PR TITLE
SwiftLint GH Actions Reporter

### DIFF
--- a/.github/scripts/test_app.sh
+++ b/.github/scripts/test_app.sh
@@ -9,7 +9,7 @@ elif [ $1 = "arm" ]; then
 fi
 
 echo "Building with arch: ${ARCH}"
-swiftlint --version
+echo "SwiftLint Version: $(swiftlint --version)"
 
 export LC_CTYPE=en_US.UTF-8
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: GitHub Action for SwiftLint
-        run: swiftlint --strict
+        run: swiftlint --reporter github-actions-logging --strict


### PR DESCRIPTION
Small change to the lint runner. Will mark lint errors as annotations in the review screen instead of requiring looking at the action logs.

Example:
![image](https://github.com/CodeEditApp/CodeEdit/assets/35942988/bc5afd62-b8ee-419a-a466-c5cfdeba7261)
