### PR TITLE
Using the correct color when File Icon Type is set to Monochrome

### DIFF
--- a/CodeEdit/Assets.xcassets/Custom Colors/Amber.colorset/Contents.json
+++ b/CodeEdit/Assets.xcassets/Custom Colors/Amber.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.000",
-          "green" : "0.689",
-          "red" : "0.931"
+          "blue" : "0.133",
+          "green" : "0.635",
+          "red" : "0.784"
         }
       },
       "idiom" : "universal"
@@ -20,8 +20,13 @@
         }
       ],
       "color" : {
-        "platform" : "universal",
-        "reference" : "systemYellowColor"
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.302",
+          "green" : "0.812",
+          "red" : "0.961"
+        }
       },
       "idiom" : "universal"
     }

--- a/CodeEdit/Assets.xcassets/Custom Colors/CoolGray.colorset/Contents.json
+++ b/CodeEdit/Assets.xcassets/Custom Colors/CoolGray.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.973",
-          "green" : "0.698",
-          "red" : "0.125"
+          "blue" : "0.553",
+          "green" : "0.541",
+          "red" : "0.518"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.859",
-          "green" : "0.698",
-          "red" : "0.365"
+          "blue" : "0.549",
+          "green" : "0.537",
+          "red" : "0.525"
         }
       },
       "idiom" : "universal"

--- a/CodeEdit/Features/Editor/PathBar/Views/EditorPathBarMenu.swift
+++ b/CodeEdit/Features/Editor/PathBar/Views/EditorPathBarMenu.swift
@@ -61,6 +61,7 @@ final class EditorPathBarMenu: NSMenu, NSMenuDelegate {
 final class PathBarMenuItem: NSMenuItem {
     private let fileItem: CEWorkspaceFile
     private let tappedOpenFile: (CEWorkspaceFile) -> Void
+    private let generalSettings = Settings.shared.preferences.general
 
     init(
         fileItem: CEWorkspaceFile,
@@ -78,6 +79,9 @@ final class PathBarMenuItem: NSMenuItem {
             let subMenu = NSMenu()
             submenu = subMenu
             color = NSColor(named: "FolderBlue") ?? NSColor(.secondary)
+        }
+        if generalSettings.fileIconStyle == .monochrome {
+            color = NSColor(named: "CoolGray") ?? NSColor(.gray)
         }
         let image = fileItem.nsIcon.withSymbolConfiguration(.init(paletteColors: [color]))
         self.image = image

--- a/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
@@ -80,10 +80,14 @@ class FileSystemTableViewCell: StandardTableViewCell {
     /// - Parameter item: The `FileItem` to get the color for
     /// - Returns: A `NSColor` for the given `FileItem`.
     func color(for item: CEWorkspaceFile) -> NSColor {
-        if !item.isFolder && prefs.fileIconStyle == .color {
-            return NSColor(item.iconColor)
+        if prefs.fileIconStyle == .color {
+            if !item.isFolder {
+                return NSColor(item.iconColor)
+            } else {
+                return NSColor(named: "FolderBlue") ?? NSColor(.cyan)
+            }
         } else {
-            return NSColor(named: "FolderBlue")!
+            return NSColor(named: "CoolGray") ?? NSColor(.gray)
         }
     }
 }

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Changes/Views/SourceControlNavigatorChangedFileView.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Changes/Views/SourceControlNavigatorChangedFileView.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 struct SourceControlNavigatorChangedFileView: View {
+    @AppSettings(\.general.fileIconStyle)
+    var fileIconStyle
+
     @EnvironmentObject var sourceControlManager: SourceControlManager
     @Binding var changedFile: CEWorkspaceFile
     @State var staged: Bool
@@ -53,7 +56,7 @@ struct SourceControlNavigatorChangedFileView: View {
                     .truncationMode(.middle)
             }, icon: {
                 Image(nsImage: changedFile.nsIcon)
-                    .foregroundStyle(changedFile.iconColor)
+                    .foregroundStyle(fileIconStyle == .color ? changedFile.iconColor : Color("CoolGray"))
             })
 
             Spacer()

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/History/Views/CommitChangedFileListItemView.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/History/Views/CommitChangedFileListItemView.swift
@@ -8,7 +8,11 @@
 import SwiftUI
 
 struct CommitChangedFileListItemView: View {
+    @AppSettings(\.general.fileIconStyle)
+    var fileIconStyle
+
     @EnvironmentObject var sourceControlManager: SourceControlManager
+
     @Binding var changedFile: CEWorkspaceFile
 
     var folder: String? {
@@ -34,7 +38,7 @@ struct CommitChangedFileListItemView: View {
                     .truncationMode(.middle)
             }, icon: {
                 Image(nsImage: changedFile.nsIcon)
-                    .foregroundStyle(changedFile.iconColor)
+                    .foregroundStyle(fileIconStyle == .color ? changedFile.iconColor : Color("CoolGray"))
             })
 
             Spacer()

--- a/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Repository/Views/SourceControlNavigatorRepositoryItem.swift
+++ b/CodeEdit/Features/NavigatorArea/SourceControlNavigator/Repository/Views/SourceControlNavigatorRepositoryItem.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 struct SourceControlNavigatorRepositoryItem: View {
+    @AppSettings(\.general.fileIconStyle)
+    var fileIconStyle
+
     let item: RepoOutlineGroupItem
 
     @Environment(\.controlActiveState)
@@ -49,11 +52,11 @@ struct SourceControlNavigatorRepositoryItem: View {
                 if item.symbolImage != nil {
                     Image(symbol: item.symbolImage ?? "")
                         .opacity(controlActiveState == .inactive ? 0.5 : 1)
-                        .foregroundStyle(item.imageColor ?? .accentColor)
+                        .foregroundStyle(fileIconStyle == .color ? item.imageColor ?? .accentColor : Color("CoolGray"))
                 } else {
                     Image(systemName: item.systemImage ?? "")
                         .opacity(controlActiveState == .inactive ? 0.5 : 1)
-                        .foregroundStyle(item.imageColor ?? .accentColor)
+                        .foregroundStyle(fileIconStyle == .color ? item.imageColor ?? .accentColor : Color("CoolGray"))
                 }
             })
             .padding(.leading, 1)


### PR DESCRIPTION
### Description

Added CoolGray color and applied to icons when file icon type setting is set to monochrome.

### Related Issues

* #1764

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="1728" alt="image" src="https://github.com/CodeEditApp/CodeEdit/assets/806104/7538fdde-b541-48ac-a74c-8f6af1ec8351">

<img width="1728" alt="image" src="https://github.com/CodeEditApp/CodeEdit/assets/806104/576d74a7-17d6-4c53-a336-427a9bde7c69">