### PR TITLE
Fixing display errors of certain files

### DIFF
--- a/CodeEdit/Features/Documents/CodeFileDocument.swift
+++ b/CodeEdit/Features/Documents/CodeFileDocument.swift
@@ -65,23 +65,34 @@ final class CodeFileDocument: NSDocument, ObservableObject {
     /// - Note: The UTType doesn't necessarily mean the file extension, it can be the MIME
     /// type or any other form of data representation.
     var utType: UTType? {
-        if content != nil && content?.isEmpty ?? true {
-            return .text
+            if content != nil && content?.isEmpty ?? true {
+                return .text
+            }
+            guard let fileType, let type = UTType(fileType) else {
+                return nil
+            }
+            Swift.print(fileType)
+            Swift.print(type.isDeclared)
+            if type.conforms(to: .text) {
+                return .text
+            }
+            if type.conforms(to: .image) {
+                return .image
+            }
+            if type.conforms(to: .pdf) {
+                return .pdf
+            }
+            if type.conforms(to: .audiovisualContent) {
+                return type
+            }
+            if type.conforms(to: .spreadsheet) {
+                return type
+            }
+            if type.conforms(to: .data) {
+                return .text
+            }
+            return type
         }
-        guard let fileType, let type = UTType(fileType) else {
-            return nil
-        }
-        if type.conforms(to: .text) {
-            return .text
-        }
-        if type.conforms(to: .image) {
-            return .image
-        }
-        if type.conforms(to: .pdf) {
-            return .pdf
-        }
-        return type
-    }
 
     /// Specify options for opening the file such as the initial cursor positions.
     /// Nulled by ``CodeFileView`` on first load.


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
This PR will fix the not displaying of files such as .env or .jsx files along with a list of others.
It is currently in draft state as I am going to figure out something to display if we can not render the file at all.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #ISSUE_NUMBER

### Checklist

<!--- Add things that are not yet implemented above -->

- [ ] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [ ] The issues this PR addresses are related to each other
- [ ] My changes generate no new warnings
- [ ] My code builds and runs on my machine
- [ ] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
