### PR TITLE
Activity View Resize, Inspector Toggle, Window Consistency

### DIFF
--- a/CodeEdit.xcodeproj/xcshareddata/xcschemes/CodeEdit.xcscheme
+++ b/CodeEdit.xcodeproj/xcshareddata/xcschemes/CodeEdit.xcscheme
@@ -78,18 +78,6 @@
                   Identifier = "CodeEditUIUnitTests/testSegmentedControlProminentLight()">
                </Test>
                <Test
-                  Identifier = "DocumentsUnitTests/testSplitViewControllerProducedHapticFeedback()">
-               </Test>
-               <Test
-                  Identifier = "DocumentsUnitTests/testSplitViewControllerProducedHapticFeedbackOnceWhenPlentyChangesOccur()">
-               </Test>
-               <Test
-                  Identifier = "DocumentsUnitTests/testSplitViewControllerSnappedWhenWidthInAppropriateRange()">
-               </Test>
-               <Test
-                  Identifier = "DocumentsUnitTests/testSplitViewControllerStopSnappedWhenWidthIsHigherAppropriateRange()">
-               </Test>
-               <Test
                   Identifier = "WelcomeModuleUnitTests">
                </Test>
                <Test

--- a/CodeEdit/Features/ActivityViewer/ActivityViewer.swift
+++ b/CodeEdit/Features/ActivityViewer/ActivityViewer.swift
@@ -30,13 +30,8 @@ struct ActivityViewer: View {
         .fixedSize(horizontal: false, vertical: false)
         .padding(.horizontal, 10)
         .background {
-            if colorScheme == .dark {
-                RoundedRectangle(cornerRadius: 5)
-                    .opacity(0.10)
-            } else {
-                RoundedRectangle(cornerRadius: 5)
-                    .opacity(0.1)
-            }
+            RoundedRectangle(cornerRadius: 5)
+                .opacity(0.1)
         }
     }
 }

--- a/CodeEdit/Features/ActivityViewer/ActivityViewer.swift
+++ b/CodeEdit/Features/ActivityViewer/ActivityViewer.swift
@@ -13,30 +13,30 @@ struct ActivityViewer: View {
     var colorScheme
 
     @ObservedObject var taskNotificationHandler: TaskNotificationHandler
+
     var body: some View {
-        HStack {
-            HStack(spacing: 0) {
-                // This is only a placeholder for the task popover(coming in the next pr)
-                Rectangle()
-                    .frame(height: 22)
-                    .hidden()
+        HStack(spacing: 0) {
+            // This is only a placeholder for the task popover(coming in the next pr)
+            Rectangle()
+                .frame(height: 22)
+                .hidden()
+                .fixedSize()
 
-                Spacer()
+            Spacer(minLength: 0)
 
-                TaskNotificationView(taskNotificationHandler: taskNotificationHandler)
-            }
-            .padding(.horizontal, 10)
-            .background {
-                if colorScheme == .dark {
-                    RoundedRectangle(cornerRadius: 5)
-                        .opacity(0.10)
-                } else {
-                    RoundedRectangle(cornerRadius: 5)
-                        .opacity(0.1)
-                }
-            }
-            .frame(minWidth: 200, idealWidth: 680)
+            TaskNotificationView(taskNotificationHandler: taskNotificationHandler)
+                .fixedSize()
         }
-        .frame(height: 22)
+        .fixedSize(horizontal: false, vertical: false)
+        .padding(.horizontal, 10)
+        .background {
+            if colorScheme == .dark {
+                RoundedRectangle(cornerRadius: 5)
+                    .opacity(0.10)
+            } else {
+                RoundedRectangle(cornerRadius: 5)
+                    .opacity(0.1)
+            }
+        }
     }
 }

--- a/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditSplitViewController.swift
@@ -74,8 +74,6 @@ final class CodeEditSplitViewController: NSSplitViewController {
                 .inspectorCollapsed
             ) as? Bool ?? true
         }
-
-        self.insertToolbarItemIfNeeded()
     }
 
     override func viewDidAppear() {
@@ -107,11 +105,9 @@ final class CodeEditSplitViewController: NSSplitViewController {
             let proposedWidth = view.frame.width - proposedPosition
             if proposedWidth <= CodeEditWindowController.minSidebarWidth / 2 {
                 splitViewItems.last?.isCollapsed = true
-                removeToolbarItemIfNeeded()
                 return proposedPosition
             }
             splitViewItems.last?.isCollapsed = false
-            insertToolbarItemIfNeeded()
             return min(view.frame.width - CodeEditWindowController.minSidebarWidth, proposedPosition)
         }
         return proposedPosition
@@ -137,27 +133,6 @@ final class CodeEditSplitViewController: NSSplitViewController {
 
     func saveInspectorCollapsedState(isCollapsed: Bool) {
         workspace.addToWorkspaceState(key: .inspectorCollapsed, value: isCollapsed)
-    }
-
-    /// Quick fix for list tracking separator needing to be added again after closing,
-    /// then opening the inspector with a drag.
-    private func insertToolbarItemIfNeeded() {
-        guard !(
-            view.window?.toolbar?.items.contains(where: { $0.itemIdentifier == .itemListTrackingSeparator }) ?? true
-        ) else {
-            return
-        }
-        view.window?.toolbar?.insertItem(withItemIdentifier: .itemListTrackingSeparator, at: 4)
-    }
-
-    /// Quick fix for list tracking separator needing to be removed after closing the inspector with a drag
-    private func removeToolbarItemIfNeeded() {
-        guard let index = view.window?.toolbar?.items.firstIndex(
-                where: { $0.itemIdentifier == .itemListTrackingSeparator }
-              ) else {
-            return
-        }
-        view.window?.toolbar?.removeItem(at: index)
     }
 
     func hideInspectorToolbarBackground() {

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController+Toolbar.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController+Toolbar.swift
@@ -141,11 +141,3 @@ extension CodeEditWindowController {
         }
     }
 }
-
-class CETrackingSeparatorToolbarItem: NSTrackingSeparatorToolbarItem {
-    init(_ splitView: NSSplitView, dividerIndex: Int) {
-        super.init(itemIdentifier: .itemListTrackingSeparator)
-        self.splitView = splitView
-        self.dividerIndex = dividerIndex
-    }
-}

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController+Toolbar.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController+Toolbar.swift
@@ -118,15 +118,34 @@ extension CodeEditWindowController {
         case .activityViewer:
             let toolbarItem = NSToolbarItem(itemIdentifier: NSToolbarItem.Identifier.activityViewer)
             toolbarItem.visibilityPriority = .user
-            toolbarItem.view = NSHostingView(
+            let view = NSHostingView(
                 rootView: ActivityViewer(
                     taskNotificationHandler: taskNotificationHandler
                 )
             )
 
+            let weakWidth = view.widthAnchor.constraint(equalToConstant: 650)
+            weakWidth.priority = .defaultLow
+            let strongWidth = view.widthAnchor.constraint(greaterThanOrEqualToConstant: 200)
+            strongWidth.priority = .defaultHigh
+
+            NSLayoutConstraint.activate([
+                weakWidth,
+                strongWidth
+            ])
+
+            toolbarItem.view = view
             return toolbarItem
         default:
             return NSToolbarItem(itemIdentifier: itemIdentifier)
         }
+    }
+}
+
+class CETrackingSeparatorToolbarItem: NSTrackingSeparatorToolbarItem {
+    init(_ splitView: NSSplitView, dividerIndex: Int) {
+        super.init(itemIdentifier: .itemListTrackingSeparator)
+        self.splitView = splitView
+        self.dividerIndex = dividerIndex
     }
 }

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -113,7 +113,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
                 .environmentObject(workspace.editorManager)
         }
 
-        let inspector = NSSplitViewItem(viewController: NSHostingController(rootView: inspectorView))
+        let inspector = NSSplitViewItem(inspectorWithViewController: NSHostingController(rootView: inspectorView))
         inspector.titlebarSeparatorStyle = .none
         inspector.minimumThickness = Self.minSidebarWidth
         inspector.isCollapsed = true

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -10,8 +10,6 @@ import SwiftUI
 import Combine
 
 final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, ObservableObject {
-    static let minSidebarWidth: CGFloat = 242
-
     @Published var navigatorCollapsed = false
     @Published var inspectorCollapsed = false
     @Published var toolbarCollapsed = false
@@ -43,11 +41,20 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
         self.workspaceSettings = CEWorkspaceSettings(workspaceDocument: workspace)
         setupSplitView(with: workspace)
 
-        let view = CodeEditSplitView(controller: splitViewController).ignoresSafeArea()
-
+        // Previous:
         // An NSHostingController is used, so the root viewController of the window is a SwiftUI-managed one.
         // This allows us to use some SwiftUI features, like focusedSceneObject.
-        contentViewController = NSHostingController(rootView: view)
+        // -----
+        // let view = CodeEditSplitView(controller: splitViewController).ignoresSafeArea()
+        // contentViewController = NSHostingController(rootView: view)
+        // -----
+        //
+        // New:
+        // The previous decision led to a very jank split controller mechanism because SwiftUI's layout system is not
+        // very compatible with AppKit's when it comes to the inspector/navigator toolbar & split view system.
+        // -----
+        contentViewController = splitViewController
+        // -----
 
         observers = [
             splitViewController.splitViewItems.first!.observe(\.isCollapsed, changeHandler: { [weak self] item, _ in
@@ -70,60 +77,18 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
     }
 
     private func setupSplitView(with workspace: WorkspaceDocument) {
-        let feedbackPerformer = NSHapticFeedbackManager.defaultPerformer
-        let splitVC = CodeEditSplitViewController(workspace: workspace, feedbackPerformer: feedbackPerformer)
-
-        let navigatorViewModel = NavigatorSidebarViewModel()
-        navigatorSidebarViewModel = navigatorViewModel
-
-        let settingsView = SettingsInjector {
-            NavigatorAreaView(workspace: workspace, viewModel: navigatorViewModel)
-                .environmentObject(workspace)
-                .environmentObject(workspace.editorManager)
+        guard let window else {
+            assertionFailure("No window found for this controller. Cannot set up content.")
+            return
         }
 
-        let navigator = NSSplitViewItem(
-            sidebarWithViewController: NSHostingController(rootView: settingsView)
+        let navigatorModel = NavigatorSidebarViewModel()
+        navigatorSidebarViewModel = navigatorModel
+        self.splitViewController = CodeEditSplitViewController(
+            workspace: workspace,
+            navigatorViewModel: navigatorModel,
+            windowRef: window
         )
-        navigator.titlebarSeparatorStyle = .none
-        navigator.minimumThickness = Self.minSidebarWidth
-        navigator.collapseBehavior = .useConstraints
-
-        splitVC.addSplitViewItem(navigator)
-
-        let workspaceView = SettingsInjector {
-            WindowObserver(window: window!) {
-                WorkspaceView()
-                    .environmentObject(workspace)
-                    .environmentObject(workspace.editorManager)
-                    .environmentObject(workspace.statusBarViewModel)
-                    .environmentObject(workspace.utilityAreaModel)
-            }
-        }
-
-        let mainContent = NSSplitViewItem(viewController: NSHostingController(rootView: workspaceView))
-        mainContent.titlebarSeparatorStyle = .line
-        mainContent.holdingPriority = .init(50)
-
-        splitVC.addSplitViewItem(mainContent)
-
-        let inspectorView = SettingsInjector {
-            InspectorAreaView(viewModel: InspectorAreaViewModel())
-                .environmentObject(workspace)
-                .environmentObject(workspace.editorManager)
-        }
-
-        let inspector = NSSplitViewItem(inspectorWithViewController: NSHostingController(rootView: inspectorView))
-        inspector.titlebarSeparatorStyle = .none
-        inspector.minimumThickness = Self.minSidebarWidth
-        inspector.isCollapsed = true
-        inspector.canCollapse = true
-        inspector.collapseBehavior = .useConstraints
-        inspector.isSpringLoaded = true
-
-        splitVC.addSplitViewItem(inspector)
-
-        self.splitViewController = splitVC
         self.listenToDocumentEdited(workspace: workspace)
     }
 

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowControllerExtensions.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowControllerExtensions.swift
@@ -13,9 +13,9 @@ extension CodeEditWindowController {
     func toggleFirstPanel() {
         guard let firstSplitView = splitViewController.splitViewItems.first else { return }
         firstSplitView.animator().isCollapsed.toggle()
-//        if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
-//            codeEditSplitVC.saveNavigatorCollapsedState(isCollapsed: firstSplitView.isCollapsed)
-//        }
+        if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
+            codeEditSplitVC.saveNavigatorCollapsedState(isCollapsed: firstSplitView.isCollapsed)
+        }
     }
 
     @objc
@@ -29,8 +29,7 @@ extension CodeEditWindowController {
             lastSplitView.animator().isCollapsed.toggle()
         }
 
-//        codeEditSplitVC.saveInspectorCollapsedState(isCollapsed: lastSplitView.isCollapsed)
-//        codeEditSplitVC.hideInspectorToolbarBackground()
+        codeEditSplitVC.saveInspectorCollapsedState(isCollapsed: lastSplitView.isCollapsed)
     }
 
     /// These are example items that added as commands to command palette

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowControllerExtensions.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowControllerExtensions.swift
@@ -20,25 +20,17 @@ extension CodeEditWindowController {
 
     @objc
     func toggleLastPanel() {
-        guard let lastSplitView = splitViewController.splitViewItems.last else { return }
-
-        if let toolbar = window?.toolbar,
-           lastSplitView.isCollapsed,
-           !toolbar.items.map(\.itemIdentifier).contains(.itemListTrackingSeparator) {
-            window?.toolbar?.insertItem(withItemIdentifier: .itemListTrackingSeparator, at: 4)
+        guard let lastSplitView = splitViewController.splitViewItems.last,
+              let codeEditSplitVC = splitViewController as? CodeEditSplitViewController else {
+            return
         }
+
         NSAnimationContext.runAnimationGroup { _ in
             lastSplitView.animator().isCollapsed.toggle()
-        } completionHandler: { [weak self] in
-            if lastSplitView.isCollapsed {
-                self?.window?.animator().toolbar?.removeItem(at: 4)
-            }
         }
 
-        if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
-            codeEditSplitVC.saveInspectorCollapsedState(isCollapsed: lastSplitView.isCollapsed)
-            codeEditSplitVC.hideInspectorToolbarBackground()
-        }
+        codeEditSplitVC.saveInspectorCollapsedState(isCollapsed: lastSplitView.isCollapsed)
+        codeEditSplitVC.hideInspectorToolbarBackground()
     }
 
     /// These are example items that added as commands to command palette

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowControllerExtensions.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowControllerExtensions.swift
@@ -13,9 +13,9 @@ extension CodeEditWindowController {
     func toggleFirstPanel() {
         guard let firstSplitView = splitViewController.splitViewItems.first else { return }
         firstSplitView.animator().isCollapsed.toggle()
-        if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
-            codeEditSplitVC.saveNavigatorCollapsedState(isCollapsed: firstSplitView.isCollapsed)
-        }
+//        if let codeEditSplitVC = splitViewController as? CodeEditSplitViewController {
+//            codeEditSplitVC.saveNavigatorCollapsedState(isCollapsed: firstSplitView.isCollapsed)
+//        }
     }
 
     @objc
@@ -29,8 +29,8 @@ extension CodeEditWindowController {
             lastSplitView.animator().isCollapsed.toggle()
         }
 
-        codeEditSplitVC.saveInspectorCollapsedState(isCollapsed: lastSplitView.isCollapsed)
-        codeEditSplitVC.hideInspectorToolbarBackground()
+//        codeEditSplitVC.saveInspectorCollapsedState(isCollapsed: lastSplitView.isCollapsed)
+//        codeEditSplitVC.hideInspectorToolbarBackground()
     }
 
     /// These are example items that added as commands to command palette

--- a/CodeEdit/Features/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument.swift
@@ -80,14 +80,16 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
             backing: .buffered,
             defer: false
         )
+        // Note For anyone hoping to switch back to a Root-SwiftUI window:
+        // See Commit 0200c87 for more details and to see what was previously here.
+        // -----
         // Setting the "min size" like this is hacky, but SwiftUI overrides the contentRect and
         // any of the built-in window size functions & autosave stuff. So we have to set it like this.
         // SwiftUI also ignores this value, so it just manages to set the initial window size. *Hopefully* this
         // is fixed in the future.
+        // ----
         if let rectString = getFromWorkspaceState(.workspaceWindowSize) as? String {
-            window.minSize = NSRectFromString(rectString).size
-        } else {
-            window.minSize = .init(width: 1400, height: 900)
+            window.setContentSize(NSRectFromString(rectString).size)
         }
         let windowController = CodeEditWindowController(
             window: window,

--- a/CodeEdit/Features/InspectorArea/Views/InspectorAreaView.swift
+++ b/CodeEdit/Features/InspectorArea/Views/InspectorAreaView.swift
@@ -5,6 +5,7 @@
 //  Created by Austin Condiff on 3/21/22.
 //
 
+import AppKit
 import SwiftUI
 
 struct InspectorAreaView: View {
@@ -52,13 +53,6 @@ struct InspectorAreaView: View {
             }
         }
         .clipShape(Rectangle())
-        .frame(
-            minWidth: CodeEditWindowController.minSidebarWidth,
-            idealWidth: 300,
-            minHeight: 0,
-            maxHeight: .infinity,
-            alignment: .top
-        )
         .safeAreaInset(edge: .trailing, spacing: 0) {
             if sidebarPosition == .side {
                 HStack(spacing: 0) {

--- a/CodeEdit/Features/InspectorArea/Views/InspectorAreaView.swift
+++ b/CodeEdit/Features/InspectorArea/Views/InspectorAreaView.swift
@@ -5,7 +5,6 @@
 //  Created by Austin Condiff on 3/21/22.
 //
 
-import AppKit
 import SwiftUI
 
 struct InspectorAreaView: View {
@@ -52,7 +51,6 @@ struct InspectorAreaView: View {
                 NoSelectionInspectorView()
             }
         }
-        .clipShape(Rectangle())
         .safeAreaInset(edge: .trailing, spacing: 0) {
             if sidebarPosition == .side {
                 HStack(spacing: 0) {

--- a/CodeEditTests/Features/Documents/Mocks/NSHapticFeedbackPerformerMock.swift
+++ b/CodeEditTests/Features/Documents/Mocks/NSHapticFeedbackPerformerMock.swift
@@ -9,14 +9,19 @@ import Cocoa
 
 final class NSHapticFeedbackPerformerMock: NSObject, NSHapticFeedbackPerformer {
 
-    var invokedPerform = false
+    var invokedPerform: Bool {
+        invokedPerformCount > 0
+    }
     var invokedPerformCount = 0
 
     func perform(
         _ pattern: NSHapticFeedbackManager.FeedbackPattern,
         performanceTime: NSHapticFeedbackManager.PerformanceTime
     ) {
-        invokedPerform = true
         invokedPerformCount += 1
+    }
+
+    func reset() {
+        invokedPerformCount = 0
     }
 }


### PR DESCRIPTION
### Description

Fixes a few issues with the windowing system, the toolbar, and the inspector.

- Makes the activity view resizable
- Removes the jank code used for the inspector tracking item in the toolbar
  - Replaces it with an inspector split item, allowing AppKit to handle the tracking exactly like Xcode's.
  - Removes animation glitches made more obvious with the activity view.
  - This also fixes a small bug where the inspector tracking item would be visible when the app opened and the inspector was closed.
- Removes the root SwiftUI view, which was causing a lot of layout issues with the toolbar & inspector toggling. SwiftUI doesn't interop well with this stuff, so if in the future we absolutely need a SwiftUI API like `focusedSceneObject` we'll have to hack it into each of the three split views. 

Misc:
- Moved the split view setup code inside the split view.

There's still some work to do on the toolbar. In the example video the branch picker disappears before the activity view, which imo should be the other way around. But it's def a step in the right direction.

### Related Issues

* closes #1224
* related https://github.com/CodeEditApp/CodeEdit/pull/1769

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Before:

Toolbar removing wrong view:

https://github.com/CodeEditApp/CodeEdit/assets/35942988/745d92e5-8c9e-4f88-8283-4f4362d840a3

Resizing is awful:

https://github.com/CodeEditApp/CodeEdit/assets/35942988/586cc642-3e75-473b-b045-8317ee728a84

Now:

https://github.com/CodeEditApp/CodeEdit/assets/35942988/330b8a70-9d49-4d37-8fe5-66617d9ef4f8

Still works w/ side tabs
![Screenshot 2024-06-23 at 7 38 33 PM](https://github.com/CodeEditApp/CodeEdit/assets/35942988/745e9416-d528-4c82-9660-1293820d2fc4)
