### PR TITLE
Utility area show/hide animates with push/pull rather than revealing

### DIFF
--- a/CodeEdit/Features/UtilityArea/ViewModels/UtilityAreaViewModel.swift
+++ b/CodeEdit/Features/UtilityArea/ViewModels/UtilityAreaViewModel.swift
@@ -52,8 +52,6 @@ class UtilityAreaViewModel: ObservableObject {
     }
 
     func togglePanel() {
-        withAnimation {
-            self.isCollapsed.toggle()
-        }
+        self.isCollapsed.toggle()
     }
 }

--- a/CodeEdit/Features/UtilityArea/Views/UtilityAreaView.swift
+++ b/CodeEdit/Features/UtilityArea/Views/UtilityAreaView.swift
@@ -24,21 +24,26 @@ struct UtilityAreaView: View {
     @State var selection: UtilityAreaTab? = .terminal
 
     var body: some View {
-        VStack(spacing: 0) {
-            if let selection {
-                selection
-            } else {
-                Text("Tab not found")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                if let selection {
+                    selection
+                } else {
+                    Text("Tab not found")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .offset(y: utilityAreaViewModel.isCollapsed ? geometry.size.height : 0)
+            .safeAreaInset(edge: .leading, spacing: 0) {
+                HStack(spacing: 0) {
+                    AreaTabBar(items: $utilityAreaViewModel.tabItems, selection: $selection, position: .side)
+                        .offset(y: utilityAreaViewModel.isCollapsed ? geometry.size.height : 0)
+                    Divider()
+                        .overlay(Color(nsColor: colorScheme == .dark ? .black : .clear))
+                }
             }
         }
-        .safeAreaInset(edge: .leading, spacing: 0) {
-            HStack(spacing: 0) {
-                AreaTabBar(items: $utilityAreaViewModel.tabItems, selection: $selection, position: .side)
-                Divider()
-                    .overlay(Color(nsColor: colorScheme == .dark ? .black : .clear))
-            }
-        }
+        .animation(.snappy, value: utilityAreaViewModel.isCollapsed)
         .overlay(alignment: .bottomTrailing) {
             HStack(spacing: 5) {
                 Divider()


### PR DESCRIPTION
### Description

Similar to Xcode, the utility area will push or pull the content when collapsing, instead of just clipping through the content.

### Related Issues

Closes #1635 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/CodeEditApp/CodeEdit/assets/29493784/8a7d7987-cef7-4227-9fbb-aaf7335ba410

