### PR TITLE
add UTType conformance checks in `NonTextFileView` to properly preview files using QuickLook

### DIFF
--- a/CodeEdit/Features/Documents/CodeFileDocument.swift
+++ b/CodeEdit/Features/Documents/CodeFileDocument.swift
@@ -54,13 +54,9 @@ final class CodeFileDocument: NSDocument, ObservableObject {
     /// Document-specific overridden line wrap preference.
     @Published var wrapLines: Bool?
 
-    /// The type of data this document contains.
+    /// The type of data this file document contains.
     ///
-    /// If for example, the file ends with `.py`, its type is a text file.
-    /// Or if it ends with `.png`, then it is an image.
-    /// Same goes for PDF and video formats.
-    ///
-    /// Also, if the text content is not empty, it is a text file.
+    /// If its text content is not nil, a `text` UTType is returned.
     ///
     /// - Note: The UTType doesn't necessarily mean the file extension, it can be the MIME
     /// type or any other form of data representation.

--- a/CodeEdit/Features/Editor/Views/NonTextFileView.swift
+++ b/CodeEdit/Features/Editor/Views/NonTextFileView.swift
@@ -24,17 +24,16 @@ struct NonTextFileView: View {
 
         Group {
             if let fileURL = fileDocument.fileURL {
+                if let utType = fileDocument.utType {
 
-                switch fileDocument.utType {
-                case .some(.image):
-                    ImageFileView(fileURL)
-                        .modifier(UpdateStatusBarInfo(withURL: fileURL))
-
-                case .some(.pdf):
-                    PDFFileView(fileURL)
-                        .modifier(UpdateStatusBarInfo(withURL: fileURL))
-
-                default:
+                    if utType.conforms(to: .image) {
+                        ImageFileView(fileURL)
+                            .modifier(UpdateStatusBarInfo(withURL: fileURL))
+                    } else if utType.conforms(to: .pdf) {
+                        PDFFileView(fileURL)
+                            .modifier(UpdateStatusBarInfo(withURL: fileURL))
+                    }
+                } else {
                     AnyFileView(fileURL)
                         .modifier(UpdateStatusBarInfo(withURL: fileURL))
                 }


### PR DESCRIPTION
### Description

This PR helps to properly preview files using QuickLook.

See #1768.

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

---

Cc: @bombardier200 
