### PR TITLE
Windows Restore Correct Size

### DIFF
--- a/CodeEdit/Features/Documents/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument.swift
@@ -89,9 +89,6 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         // SwiftUI also ignores this value, so it just manages to set the initial window size. *Hopefully* this
         // is fixed in the future.
         // ----
-        if let rectString = getFromWorkspaceState(.workspaceWindowSize) as? String {
-            window.setContentSize(NSRectFromString(rectString).size)
-        }
         let windowController = CodeEditWindowController(
             window: window,
             workspace: self,
@@ -99,8 +96,9 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         )
 
         if let rectString = getFromWorkspaceState(.workspaceWindowSize) as? String {
-            window.setFrameOrigin(NSRectFromString(rectString).origin)
+            window.setFrame(NSRectFromString(rectString), display: true, animate: false)
         } else {
+            window.setFrame(NSRect(x: 0, y: 0, width: 1400, height: 900), display: true, animate: false)
             window.center()
         }
         self.addWindowController(windowController)


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

In #1776 changes were made to the windowing system. Previously, a hacky method to trick SwiftUI into setting the initial frame was used, and was removed. This adds back the functionality w/o any of the jank.

### Related Issues

- closes #1787 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/35942988/028140bb-c576-4517-9f40-b71b454b43fa

