### PR TITLE
Fix: Validate filenames consisting solely of extensions

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -47,8 +47,8 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
         let fileExtension = url.pathExtension
 
         // Verifies if the filename consists solely of the file extension, such as '.env', '.gitignore', etc.
-        if fileName.hasPrefix(".") && fileExtension.isEmpty {
-            return .init(rawValue: String(fileName.dropFirst())) ?? .txt
+        if fileName.hasPrefix(".") {
+            return .init(rawValue: fileName.dropFirst().components(separatedBy: ".").first ?? "") ?? .txt
         } else {
             return .init(rawValue: fileExtension) ?? .txt
         }

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -42,7 +42,17 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
     var name: String { url.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines) }
 
     /// Returns the extension of the file or an empty string if no extension is present.
-    var type: FileIcon.FileType { .init(rawValue: url.pathExtension) ?? .txt }
+    var type: FileIcon.FileType {
+        let fileName = url.lastPathComponent
+        let fileExtension = url.pathExtension
+
+        // Verifies if the filename consists solely of the file extension, such as '.env', '.gitignore', etc.
+        if fileName.hasPrefix(".") && fileExtension.isEmpty {
+            return .init(rawValue: String(fileName.dropFirst())) ?? .txt
+        } else {
+            return .init(rawValue: fileExtension) ?? .txt
+        }
+    }
 
     /// Returns the URL of the ``CEWorkspaceFile``
     let url: URL

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -43,16 +43,20 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
 
     /// Returns the extension of the file or an empty string if no extension is present.
     var type: FileIcon.FileType {
-        let fileName = url.lastPathComponent
-        let fileExtension = url.pathExtension
+        let filename = url.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // Verifies if the filename consists solely of file extensions, such as '.env', '.gitignore', etc.
-        if fileName.hasPrefix(".") {
-            return fileName.dropFirst().components(separatedBy: ".")
-                .compactMap { FileIcon.FileType(rawValue: $0) }
-                .first ?? .txt
+        /// First, check if there is a valid file extension.
+        if let type = FileIcon.FileType(rawValue: filename) {
+            return type
         } else {
-            return .init(rawValue: fileExtension) ?? .txt
+            /// If  there's not, verifies every extension for a valid type.
+            let extensions = filename.dropFirst().components(separatedBy: ".").reversed()
+
+            return extensions
+                .compactMap { FileIcon.FileType(rawValue: $0) }
+                .first
+            /// Returns .txt for invalid type.
+            ?? .txt
         }
     }
 

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -46,9 +46,11 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
         let fileName = url.lastPathComponent
         let fileExtension = url.pathExtension
 
-        // Verifies if the filename consists solely of the file extension, such as '.env', '.gitignore', etc.
+        // Verifies if the filename consists solely of file extensions, such as '.env', '.gitignore', etc.
         if fileName.hasPrefix(".") {
-            return .init(rawValue: fileName.dropFirst().components(separatedBy: ".").first ?? "") ?? .txt
+            return fileName.dropFirst().components(separatedBy: ".")
+                .compactMap { FileIcon.FileType(rawValue: $0) }
+                .first ?? .txt
         } else {
             return .init(rawValue: fileExtension) ?? .txt
         }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This pull request resolves an issue where supported files with only extensions (e.g., .env, .gitignore) were not displaying their correct icons.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #1801

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

#### Before:
<img width="244" alt="icons file extensions error" src="https://github.com/CodeEditApp/CodeEdit/assets/83844690/f7cdf314-28c3-4c49-beec-f411679bc905">

#### After:

<img width="240" alt="fixed pull request" src="https://github.com/CodeEditApp/CodeEdit/assets/83844690/9abc50c7-10ae-4dfc-a746-5cfe2333fb2f">

<img width="228" alt=".env.local - .eslintrc.js fix" src="https://github.com/CodeEditApp/CodeEdit/assets/83844690/b6fa90df-b879-468d-a8bb-4716f7703886">



<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
