### PR TITLE
Fix Navigator Key Navigation Explosion

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -380,6 +380,7 @@
 		6C5B63DE29C76213005454BA /* WindowCodeFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5B63DD29C76213005454BA /* WindowCodeFileView.swift */; };
 		6C5C891B2A3F736500A94FE1 /* FocusedValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5C891A2A3F736500A94FE1 /* FocusedValues.swift */; };
 		6C5FDF7A29E6160000BC08C0 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5FDF7929E6160000BC08C0 /* AppSettings.swift */; };
+		6C6362D42C3E321A0025570D /* Editor+History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6362D32C3E321A0025570D /* Editor+History.swift */; };
 		6C66C31329D05CDC00DE9ED2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 6C66C31229D05CDC00DE9ED2 /* GRDB */; };
 		6C6BD6EF29CD12E900235D17 /* ExtensionManagerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6BD6EE29CD12E900235D17 /* ExtensionManagerWindow.swift */; };
 		6C6BD6F129CD13FA00235D17 /* ExtensionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6BD6F029CD13FA00235D17 /* ExtensionDiscovery.swift */; };
@@ -402,6 +403,7 @@
 		6C85BB402C2105ED00EB5DEF /* CodeEditKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6C85BB3F2C2105ED00EB5DEF /* CodeEditKit */; };
 		6C85BB412C21061A00EB5DEF /* GitHubComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587B9E3C29301D8F00AC7927 /* GitHubComment.swift */; };
 		6C85BB442C210EFD00EB5DEF /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = 6C85BB432C210EFD00EB5DEF /* SwiftUIIntrospect */; };
+		6C85F7562C3CA638008E9836 /* EditorHistoryMenus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C85F7552C3CA638008E9836 /* EditorHistoryMenus.swift */; };
 		6C91D57229B176FF0059A90D /* EditorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C91D57129B176FF0059A90D /* EditorManager.swift */; };
 		6C97EBCC2978760400302F95 /* AcknowledgementsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C97EBCB2978760400302F95 /* AcknowledgementsWindowController.swift */; };
 		6CA1AE952B46950000378EAB /* EditorInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA1AE942B46950000378EAB /* EditorInstance.swift */; };
@@ -997,6 +999,7 @@
 		6C5B63DD29C76213005454BA /* WindowCodeFileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowCodeFileView.swift; sourceTree = "<group>"; };
 		6C5C891A2A3F736500A94FE1 /* FocusedValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedValues.swift; sourceTree = "<group>"; };
 		6C5FDF7929E6160000BC08C0 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		6C6362D32C3E321A0025570D /* Editor+History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Editor+History.swift"; sourceTree = "<group>"; };
 		6C6BD6EE29CD12E900235D17 /* ExtensionManagerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionManagerWindow.swift; sourceTree = "<group>"; };
 		6C6BD6F029CD13FA00235D17 /* ExtensionDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDiscovery.swift; sourceTree = "<group>"; };
 		6C6BD6F529CD145F00235D17 /* ExtensionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInfo.swift; sourceTree = "<group>"; };
@@ -1010,6 +1013,7 @@
 		6C82D6B829BFE34900495C54 /* HelpCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpCommands.swift; sourceTree = "<group>"; };
 		6C82D6BB29C00CD900495C54 /* FirstResponderPropertyWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstResponderPropertyWrapper.swift; sourceTree = "<group>"; };
 		6C82D6C529C012AD00495C54 /* NSApp+openWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSApp+openWindow.swift"; sourceTree = "<group>"; };
+		6C85F7552C3CA638008E9836 /* EditorHistoryMenus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorHistoryMenus.swift; sourceTree = "<group>"; };
 		6C91D57129B176FF0059A90D /* EditorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorManager.swift; sourceTree = "<group>"; };
 		6C97EBCB2978760400302F95 /* AcknowledgementsWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsWindowController.swift; sourceTree = "<group>"; };
 		6CA1AE942B46950000378EAB /* EditorInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorInstance.swift; sourceTree = "<group>"; };
@@ -2308,6 +2312,7 @@
 				DE6F77862813625500D00A76 /* EditorTabBarDivider.swift */,
 				287776E827E34BC700D46668 /* EditorTabBarView.swift */,
 				B6AB09A22AAABFEC0003A3A6 /* EditorTabBarLeadingAccessories.swift */,
+				6C85F7552C3CA638008E9836 /* EditorHistoryMenus.swift */,
 				B6AB09A42AAAC00F0003A3A6 /* EditorTabBarTrailingAccessories.swift */,
 			);
 			path = Views;
@@ -2973,6 +2978,7 @@
 			isa = PBXGroup;
 			children = (
 				6C147C3D29A3281D0089B630 /* Editor.swift */,
+				6C6362D32C3E321A0025570D /* Editor+History.swift */,
 				5994B6D92BD6B408006A4C5F /* Editor+TabSwitch.swift */,
 				6CA1AE942B46950000378EAB /* EditorInstance.swift */,
 				6C147C3E29A3281D0089B630 /* EditorLayout.swift */,
@@ -3941,6 +3947,7 @@
 				30B088162C0D53080063A882 /* LSPCache.swift in Sources */,
 				B6F0517929D9E3C900D72287 /* SourceControlGitView.swift in Sources */,
 				587B9E8329301D8F00AC7927 /* GitHubPullRequest.swift in Sources */,
+				6C85F7562C3CA638008E9836 /* EditorHistoryMenus.swift in Sources */,
 				5878DA82291863F900DD95A3 /* AcknowledgementsView.swift in Sources */,
 				587B9E8529301D8F00AC7927 /* GitHubReview.swift in Sources */,
 				58D01C9A293167DC00C5B6B4 /* CodeEditKeychain.swift in Sources */,
@@ -3975,6 +3982,7 @@
 				30B087FC2C0D53080063A882 /* LanguageServer+CallHierarchy.swift in Sources */,
 				6CFF967C29BEBD5200182D6F /* WindowCommands.swift in Sources */,
 				587B9E7229301D8F00AC7927 /* GitJSONPostRouter.swift in Sources */,
+				6C6362D42C3E321A0025570D /* Editor+History.swift in Sources */,
 				6C85BB412C21061A00EB5DEF /* GitHubComment.swift in Sources */,
 				5878DAB0291D627C00DD95A3 /* EditorPathBarMenu.swift in Sources */,
 				04BA7C242AE2E7CD00584E1C /* SourceControlNavigatorSyncView.swift in Sources */,

--- a/CodeEdit/Features/Editor/Models/Editor+History.swift
+++ b/CodeEdit/Features/Editor/Models/Editor+History.swift
@@ -1,0 +1,71 @@
+//
+//  Editor+History.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 7/9/24.
+//
+
+import Foundation
+
+/// Methods for modifying the history list on the editor.
+extension Editor {
+    /// Add the tab to the history list.
+    /// - Parameter tab: The tab to add to the history.
+    func addToHistory(_ tab: Tab) {
+        if history.first != tab {
+            history.prepend(tab)
+        }
+    }
+
+    /// Clear any tabs in the "future" on the history list. Resets the history offset and removes any tabs that were
+    /// available to navigate forwards to.
+    func clearFuture() {
+        guard historyOffset > 0 else { return } // nothing to clear, avoid an out of bounds error
+        history.removeFirst(historyOffset)
+        historyOffset = 0
+    }
+
+    /// Move backwards in the history list by one place.
+    func goBackInHistory() {
+        if canGoBackInHistory {
+            historyOffset += 1
+        }
+    }
+
+    /// Move forwards in the history list by one place.
+    func goForwardInHistory() {
+        if canGoForwardInHistory {
+            historyOffset -= 1
+        }
+    }
+
+    // TODO: move to @Observable so this works better
+    /// Warning: NOT published!
+    var canGoBackInHistory: Bool {
+        historyOffset != history.count - 1 && !history.isEmpty
+    }
+
+    // TODO: move to @Observable so this works better
+    /// Warning: NOT published!
+    var canGoForwardInHistory: Bool {
+        historyOffset != 0
+    }
+
+    /// Called by the ``Editor`` class when the history offset is changed.
+    ///
+    /// This method updates the selected tab to the current tab in the history offset.
+    /// If the tab is not opened, it is opened without modifying the history list.
+    /// - Warning: Do not use except in the ``historyOffset``'s `didSet`.
+    func historyOffsetDidChange() {
+        let tab = history[historyOffset]
+
+        if !tabs.contains(tab) {
+            if let temporaryTab, tabs.contains(temporaryTab) {
+                closeTab(file: temporaryTab.file, fromHistory: true)
+            }
+            temporaryTab = tab
+            openTab(file: tab.file, fromHistory: true)
+        }
+        selectedTab = tab
+    }
+}

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabView.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabView.swift
@@ -89,9 +89,8 @@ struct EditorTabView: View {
         if editor.selectedTab?.file != item {
             let tabItem = EditorInstance(file: item)
             editor.selectedTab = tabItem
-            editor.history.removeFirst(editor.historyOffset)
-            editor.history.prepend(tabItem)
-            editor.historyOffset = 0
+            editor.clearFuture()
+            editor.addToHistory(tabItem)
         }
     }
 

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorHistoryMenus.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorHistoryMenus.swift
@@ -1,0 +1,78 @@
+//
+//  EditorHistoryMenus.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 7/8/24.
+//
+
+import SwiftUI
+
+struct EditorHistoryMenus: View {
+    @EnvironmentObject private var editorManager: EditorManager
+    @EnvironmentObject private var editor: Editor
+
+    var body: some View {
+        Group {
+            Menu {
+                ForEach(
+                    Array(editor.history.dropFirst(editor.historyOffset+1).enumerated()),
+                    id: \.offset
+                ) { index, tab in
+                    Button {
+                        editorManager.activeEditor = editor
+                        editor.historyOffset += index + 1
+                    } label: {
+                        HStack {
+                            tab.file.icon
+                            Text(tab.file.name)
+                        }
+                    }
+                }
+            } label: {
+                Image(systemName: "chevron.left")
+                    .opacity(editor.historyOffset == editor.history.count - 1 || editor.history.isEmpty ? 0.5 : 1)
+                    .frame(height: EditorTabBarView.height - 2)
+                    .padding(.horizontal, 4)
+            } primaryAction: {
+                editorManager.activeEditor = editor
+                editor.goBackInHistory()
+            }
+            .disabled(editor.historyOffset == editor.history.count - 1 || editor.history.isEmpty)
+            .help("Navigate back")
+
+            Menu {
+                ForEach(
+                    Array(editor.history.prefix(editor.historyOffset).reversed().enumerated()),
+                    id: \.offset
+                ) { index, tab in
+                    Button {
+                        editorManager.activeEditor = editor
+                        editor.historyOffset -= index + 1
+                    } label: {
+                        HStack {
+                            tab.file.icon
+                            Text(tab.file.name)
+                        }
+                    }
+                }
+            } label: {
+                Image(systemName: "chevron.right")
+                    .opacity(editor.historyOffset == 0 ? 0.5 : 1)
+                    .frame(height: EditorTabBarView.height - 2)
+                    .padding(.horizontal, 4)
+            } primaryAction: {
+                editorManager.activeEditor = editor
+                editor.goForwardInHistory()
+            }
+            .disabled(editor.historyOffset == 0)
+            .help("Navigate forward")
+        }
+        .buttonStyle(.icon)
+        .controlSize(.small)
+        .font(EditorTabBarAccessoryIcon.iconFont)
+    }
+}
+
+#Preview {
+    EditorHistoryMenus()
+}

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarLeadingAccessories.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarLeadingAccessories.swift
@@ -12,7 +12,6 @@ struct EditorTabBarLeadingAccessories: View {
     private var activeState
 
     @EnvironmentObject private var editorManager: EditorManager
-
     @EnvironmentObject private var editor: Editor
 
     @State private var otherEditor: Editor?
@@ -53,64 +52,7 @@ struct EditorTabBarLeadingAccessories: View {
                     .padding(.horizontal, 4)
             }
 
-            Group {
-                Menu {
-                    ForEach(
-                        Array(editor.history.dropFirst(editor.historyOffset+1).enumerated()),
-                        id: \.offset
-                    ) { index, tab in
-                        Button {
-                            editorManager.activeEditor = editor
-                            editor.historyOffset += index + 1
-                        } label: {
-                            HStack {
-                                tab.file.icon
-                                Text(tab.file.name)
-                            }
-                        }
-                    }
-                } label: {
-                    Image(systemName: "chevron.left")
-                        .opacity(editor.historyOffset == editor.history.count-1 || editor.history.isEmpty ? 0.5 : 1)
-                        .frame(height: EditorTabBarView.height - 2)
-                        .padding(.horizontal, 4)
-                } primaryAction: {
-                    editorManager.activeEditor = editor
-                    editor.goBackInHistory()
-                }
-                .disabled(editor.historyOffset == editor.history.count-1 || editor.history.isEmpty)
-                .help("Navigate back")
-
-                Menu {
-                    ForEach(
-                        Array(editor.history.prefix(editor.historyOffset).reversed().enumerated()),
-                        id: \.offset
-                    ) { index, tab in
-                        Button {
-                            editorManager.activeEditor = editor
-                            editor.historyOffset -= index + 1
-                        } label: {
-                            HStack {
-                                tab.file.icon
-                                Text(tab.file.name)
-                            }
-                        }
-                    }
-                } label: {
-                    Image(systemName: "chevron.right")
-                        .opacity(editor.historyOffset == 0 ? 0.5 : 1)
-                        .frame(height: EditorTabBarView.height - 2)
-                        .padding(.horizontal, 4)
-                } primaryAction: {
-                    editorManager.activeEditor = editor
-                    editor.goForwardInHistory()
-                }
-                .disabled(editor.historyOffset == 0)
-                .help("Navigate forward")
-            }
-            .buttonStyle(.icon)
-            .controlSize(.small)
-            .font(EditorTabBarAccessoryIcon.iconFont)
+            EditorHistoryMenus()
         }
         .foregroundColor(.secondary)
         .buttonStyle(.plain)

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
@@ -73,8 +73,6 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
             for item in updatedItems {
                 outlineView.reloadItem(item, reloadChildren: true)
             }
-
-            controller?.updateSelection(itemID: workspace.editorManager.activeEditor.selectedTab?.file.id)
         }
 
         deinit {

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
@@ -289,7 +289,9 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
 
         if !item.isFolder && shouldSendSelectionUpdate {
             DispatchQueue.main.async {
+                self.shouldSendSelectionUpdate = false
                 self.workspace?.editorManager.activeEditor.openTab(file: item, asTemporary: true)
+                self.shouldSendSelectionUpdate = true
             }
         }
     }
@@ -299,12 +301,12 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
     }
 
     func outlineViewItemDidExpand(_ notification: Notification) {
-        guard
-            let id = workspace?.editorManager.activeEditor.selectedTab?.file.id,
-            let item = workspace?.workspaceFileManager?.getFile(id, createIfNotFound: true)
-        else { return }
-        /// update outline selection only if the parent of selected item match with expanded item
-        guard item.parent === notification.userInfo?["NSObject"] as? CEWorkspaceFile else { return }
+        guard let id = workspace?.editorManager.activeEditor.selectedTab?.file.id,
+              let item = workspace?.workspaceFileManager?.getFile(id, createIfNotFound: true),
+              /// update outline selection only if the parent of selected item match with expanded item
+              item.parent === notification.userInfo?["NSObject"] as? CEWorkspaceFile else {
+            return
+        }
         /// select active file under collapsed folder only if its parent is expanding
         if outlineView.isItemExpanded(item.parent) {
             updateSelection(itemID: item.id)
@@ -356,7 +358,9 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
             expandParent(item: parent)
         }
         let row = outlineView.row(forItem: fileItem)
+        shouldSendSelectionUpdate = false
         outlineView.selectRowIndexes(.init(integer: row), byExtendingSelection: false)
+        shouldSendSelectionUpdate = true
 
         if row < 0 {
             let alert = NSAlert()


### PR DESCRIPTION
### Description

Fixes an issue discussed a few different [times](https://canary.discord.com/channels/951544472238444645/952640818068463667/1254534027537285280) with the navigator.

To reproduce:
- Enable "reveal in project navigator" setting.
- Select a file
- Using the arrow keys, move up or down to a folder in the navigator
- Eventually, the app will freeze.

This fixes that bug, and another one I found on the way.

In this PR:
- Add a few more cases where `shouldSendSelectionUpdate` in the navigator outline view needed to be set. In these cases, extra selection events were being sent back to the navigator when a tab was opened. This was one of the reasons for the freeze as a few files were being opened over and over again.
- Removes a call to `updateSelection` when receiving a notice that the directory monitor has updated. This was causing an issue where, when revealing a previously unloaded directory, the selection would jump back to the opened tab rather than staying on the folder being opened.
- Cleans up some of the editor history code, adding a few methods and moving as much history code as possible to an extension.

### Related Issues

* Maybe closes #1721. @austincondiff can you check if that's working now? In my quick check it was.

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEdit/assets/35942988/e2c8bc57-8729-4991-8ee4-83ab852c35af
