### PR TITLE
Use `NSApp.keyWindow` Over Global `keyWindow`

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -433,6 +433,8 @@
 		6CE6226B2A2A1C730013085C /* UtilityAreaTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE6226A2A2A1C730013085C /* UtilityAreaTab.swift */; };
 		6CE6226E2A2A1CDE0013085C /* NavigatorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE6226D2A2A1CDE0013085C /* NavigatorTab.swift */; };
 		6CED16E42A3E660D000EC962 /* String+Lines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CED16E32A3E660D000EC962 /* String+Lines.swift */; };
+		6CFBA54B2C4E168A00E3A914 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFBA54A2C4E168A00E3A914 /* App.swift */; };
+		6CFBA54D2C4E16C900E3A914 /* WindowCloseCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFBA54C2C4E16C900E3A914 /* WindowCloseCommandTests.swift */; };
 		6CFF967429BEBCC300182D6F /* FindCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFF967329BEBCC300182D6F /* FindCommands.swift */; };
 		6CFF967629BEBCD900182D6F /* FileCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFF967529BEBCD900182D6F /* FileCommands.swift */; };
 		6CFF967829BEBCF600182D6F /* MainCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFF967729BEBCF600182D6F /* MainCommands.swift */; };
@@ -1047,6 +1049,8 @@
 		6CE6226A2A2A1C730013085C /* UtilityAreaTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityAreaTab.swift; sourceTree = "<group>"; };
 		6CE6226D2A2A1CDE0013085C /* NavigatorTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigatorTab.swift; sourceTree = "<group>"; };
 		6CED16E32A3E660D000EC962 /* String+Lines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Lines.swift"; sourceTree = "<group>"; };
+		6CFBA54A2C4E168A00E3A914 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+		6CFBA54C2C4E16C900E3A914 /* WindowCloseCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCloseCommandTests.swift; sourceTree = "<group>"; };
 		6CFF967329BEBCC300182D6F /* FindCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindCommands.swift; sourceTree = "<group>"; };
 		6CFF967529BEBCD900182D6F /* FileCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCommands.swift; sourceTree = "<group>"; };
 		6CFF967729BEBCF600182D6F /* MainCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCommands.swift; sourceTree = "<group>"; };
@@ -2758,9 +2762,11 @@
 		6C96191F2C3F27E3009733CE /* CodeEditUITests */ = {
 			isa = PBXGroup;
 			children = (
+				6CFBA54A2C4E168A00E3A914 /* App.swift */,
 				6C9619232C3F2809009733CE /* ProjectPath.swift */,
 				6C9619212C3F27F1009733CE /* Query.swift */,
 				6C96191E2C3F27E3009733CE /* Features */,
+				6CFBA54E2C4E182100E3A914 /* Other Tests */,
 			);
 			path = CodeEditUITests;
 			sourceTree = "<group>";
@@ -2811,6 +2817,14 @@
 				6C48B5C42C0A2835001E9955 /* FileEncoding.swift */,
 			);
 			path = CodeFileDocument;
+			sourceTree = "<group>";
+		};
+		6CFBA54E2C4E182100E3A914 /* Other Tests */ = {
+			isa = PBXGroup;
+			children = (
+				6CFBA54C2C4E16C900E3A914 /* WindowCloseCommandTests.swift */,
+			);
+			path = "Other Tests";
 			sourceTree = "<group>";
 		};
 		77A01E1A2BB33F1E00F0EA38 /* Views */ = {
@@ -4150,6 +4164,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				6C9619242C3F2809009733CE /* ProjectPath.swift in Sources */,
+				6CFBA54B2C4E168A00E3A914 /* App.swift in Sources */,
+				6CFBA54D2C4E16C900E3A914 /* WindowCloseCommandTests.swift in Sources */,
 				6C9619222C3F27F1009733CE /* Query.swift in Sources */,
 				6C9619202C3F27E3009733CE /* ProjectNavigatorUITests.swift in Sources */,
 			);

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -172,7 +172,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
         if workspace?.editorManager?.editorLayout.findSomeEditor(
             except: workspace?.editorManager?.activeEditor
         ) == nil {
-            NSApp.sendAction(#selector(NSWindow.performClose(_:)), to: nil, from: nil)
+            NSApp.sendAction(#selector(NSWindow.performClose(_:)), to: NSApp.keyWindow, from: nil)
         } else {
             workspace?.editorManager?.activeEditor.close()
         }

--- a/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument.swift
@@ -100,6 +100,10 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
             window.setFrame(NSRect(x: 0, y: 0, width: 1400, height: 900), display: true, animate: false)
             window.center()
         }
+
+        window.setAccessibilityIdentifier("workspace")
+        window.setAccessibilityDocument(self.fileURL?.absoluteString)
+
         self.addWindowController(windowController)
 
         window.makeKeyAndOrderFront(nil)

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -44,7 +44,7 @@ struct FileCommands: Commands {
                 if NSApp.target(forAction: #selector(CodeEditWindowController.closeCurrentTab(_:))) != nil {
                     NSApp.sendAction(#selector(CodeEditWindowController.closeCurrentTab(_:)), to: nil, from: nil)
                 } else {
-                    NSApp.sendAction(#selector(NSWindow.performClose(_:)), to: keyWindow, from: nil)
+                    NSApp.sendAction(#selector(NSWindow.performClose(_:)), to: NSApp.keyWindow, from: nil)
                 }
             }
             .keyboardShortcut("w")
@@ -57,19 +57,18 @@ struct FileCommands: Commands {
                         from: nil
                     )
                 } else {
-                    NSApp.sendAction(#selector(NSWindow.performClose(_:)), to: keyWindow, from: nil)
+                    NSApp.sendAction(#selector(NSWindow.performClose(_:)), to: NSApp.keyWindow, from: nil)
                 }
             }
             .keyboardShortcut("w", modifiers: [.control, .shift, .command])
 
             Button("Close Window") {
-                NSApp.sendAction(#selector(NSWindow.performClose(_:)), to: keyWindow, from: nil)
+                NSApp.sendAction(#selector(NSWindow.performClose(_:)), to: NSApp.keyWindow, from: nil)
             }
             .keyboardShortcut("w", modifiers: [.shift, .command])
 
             Button("Close Workspace") {
-                guard let keyWindow = NSApplication.shared.keyWindow else { return }
-                NSApp.sendAction(#selector(NSWindow.performClose(_:)), to: keyWindow, from: nil)
+                NSApp.sendAction(#selector(NSWindow.performClose(_:)), to: NSApp.keyWindow, from: nil)
             }
             .keyboardShortcut("w", modifiers: [.control, .option, .command])
             .disabled(!(NSApplication.shared.keyWindow?.windowController is CodeEditWindowController))

--- a/CodeEditUITests/App.swift
+++ b/CodeEditUITests/App.swift
@@ -1,0 +1,23 @@
+//
+//  App.swift
+//  CodeEditUITests
+//
+//  Created by Khan Winter on 7/21/24.
+//
+
+import XCTest
+
+enum App {
+    static func launchWithCodeEditWorkspace() -> XCUIApplication {
+        let application = XCUIApplication()
+        application.launchArguments = ["--open", projectPath()]
+        application.launch()
+        return application
+    }
+
+    static func launch() -> XCUIApplication {
+        let application = XCUIApplication()
+        application.launch()
+        return application
+    }
+}

--- a/CodeEditUITests/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorUITests.swift
+++ b/CodeEditUITests/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorUITests.swift
@@ -12,18 +12,18 @@ final class ProjectNavigatorUITests: XCTestCase {
     var application: XCUIApplication!
 
     override func setUp() {
-        application = XCUIApplication()
-        application.launchArguments = ["--open", projectPath()]
-        application.launch()
+        application = App.launchWithCodeEditWorkspace()
     }
 
     func testNavigatorOpenFilesAndFolder() {
         let window = Query.getWindow(application)
+        XCTAssertTrue(window.exists, "Window not found")
         // Focus the window
         window.toolbars.firstMatch.click()
 
         // Get the navigator
-        let navigator = Query.Window.getNavigator(window)
+        let navigator = Query.Window.getProjectNavigator(window)
+        XCTAssertTrue(navigator.exists, "Navigator not found")
 
         // Open the README.md
         let readmeRow = Query.Navigator.getProjectNavigatorRow(fileTitle: "README.md", navigator)
@@ -31,6 +31,7 @@ final class ProjectNavigatorUITests: XCTestCase {
         readmeRow.click()
 
         let tabBar = Query.Window.getTabBar(window)
+        XCTAssertTrue(tabBar.exists)
         let readmeTab = Query.TabBar.getTab(labeled: "README.md", tabBar)
         XCTAssertTrue(readmeTab.exists)
 
@@ -38,6 +39,7 @@ final class ProjectNavigatorUITests: XCTestCase {
 
         // Open a folder
         let codeEditFolderRow = Query.Navigator.getProjectNavigatorRow(fileTitle: "CodeEdit", index: 1, navigator)
+        XCTAssertTrue(codeEditFolderRow.exists)
         XCTAssertTrue(
             Query.Navigator.rowContainsDisclosureIndicator(codeEditFolderRow),
             "Folder doesn't have disclosure indicator"

--- a/CodeEditUITests/Other Tests/WindowCloseCommandTests.swift
+++ b/CodeEditUITests/Other Tests/WindowCloseCommandTests.swift
@@ -1,0 +1,115 @@
+//
+//  WindowCloseCommandTests.swift
+//  CodeEditUITests
+//
+//  Created by Khan Winter on 7/21/24.
+//
+
+import XCTest
+
+/// Tests for window closing commands.
+/// - Note: feel free to add on in the future and change this test name.
+final class WindowCloseCommandTests: XCTestCase {
+    // swiftier api (expectation(that: , on:, willEqual:) doesn't work :(
+    let notExistsPredicate = NSPredicate(format: "exists == false")
+
+    var application: XCUIApplication!
+
+    func testWorkspaceWindowCloses() {
+        application = App.launchWithCodeEditWorkspace()
+        let window = Query.getWindow(application)
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Workspace didn't open")
+        window.toolbars.firstMatch.click()
+
+        let expectation = expectation(for: notExistsPredicate, evaluatedWith: window)
+        application.typeKey("w", modifierFlags: .command)
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testWorkspaceTabCloses() {
+        application = App.launchWithCodeEditWorkspace()
+        let window = Query.getWindow(application)
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Workspace didn't open")
+
+        window.toolbars.firstMatch.click()
+
+        let navigator = Query.Window.getProjectNavigator(window)
+        let readmeRow = Query.Navigator.getProjectNavigatorRow(fileTitle: "README.md", navigator)
+        XCTAssertTrue(navigator.exists)
+        XCTAssertTrue(readmeRow.exists)
+        readmeRow.click()
+
+        let tabBar = Query.Window.getTabBar(window)
+        XCTAssertTrue(tabBar.exists)
+        let readmeTab = Query.TabBar.getTab(labeled: "README.md", tabBar)
+        XCTAssertTrue(readmeTab.exists)
+        XCTAssertEqual(tabBar.descendants(matching: .group).count, 1)
+
+        let tabCloseExpectation = expectation(for: notExistsPredicate, evaluatedWith: readmeTab)
+        application.typeKey("w", modifierFlags: .command)
+        wait(for: [tabCloseExpectation], timeout: 5.0)
+        XCTAssertEqual(tabBar.descendants(matching: .group).count, 0)
+
+        let windowCloseExpectation = expectation(for: notExistsPredicate, evaluatedWith: window)
+        application.typeKey("w", modifierFlags: .command)
+        wait(for: [windowCloseExpectation], timeout: 5.0)
+    }
+
+    func testWorkspaceClosesWithTabStillOpen() {
+        application = App.launchWithCodeEditWorkspace()
+        let window = Query.getWindow(application)
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Workspace didn't open")
+
+        window.toolbars.firstMatch.click()
+
+        let navigator = Query.Window.getProjectNavigator(window)
+        let readmeRow = Query.Navigator.getProjectNavigatorRow(fileTitle: "README.md", navigator)
+        XCTAssertTrue(navigator.exists)
+        XCTAssertTrue(readmeRow.exists)
+        readmeRow.click()
+
+        let tabBar = Query.Window.getTabBar(window)
+        XCTAssertTrue(tabBar.exists)
+        let readmeTab = Query.TabBar.getTab(labeled: "README.md", tabBar)
+        XCTAssertTrue(readmeTab.exists)
+        XCTAssertEqual(tabBar.descendants(matching: .group).count, 1)
+
+        let windowCloseExpectation = expectation(for: notExistsPredicate, evaluatedWith: window)
+        application.typeKey("w", modifierFlags: [.shift, .command])
+        wait(for: [windowCloseExpectation], timeout: 5.0)
+    }
+
+    func testSettingsWindowCloses() {
+        application = App.launch()
+        let window = Query.getSettingsWindow(application)
+        application.typeKey(",", modifierFlags: .command)
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Settings didn't open")
+
+        let expectation = expectation(for: notExistsPredicate, evaluatedWith: window)
+        application.typeKey("w", modifierFlags: .command)
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testWelcomeWindowCloses() {
+        application = App.launch()
+        let window = Query.getWelcomeWindow(application)
+        application.typeKey("1", modifierFlags: [.shift, .command])
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Welcome didn't open")
+
+        let expectation = expectation(for: notExistsPredicate, evaluatedWith: window)
+        application.typeKey("w", modifierFlags: .command)
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testAboutWindowCloses() {
+        application = App.launch()
+        let window = Query.getAboutWindow(application)
+        application.typeKey("2", modifierFlags: [.shift, .command])
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "About didn't open")
+
+        let expectation = expectation(for: notExistsPredicate, evaluatedWith: window)
+        application.typeKey("w", modifierFlags: .command)
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+}

--- a/CodeEditUITests/Query.swift
+++ b/CodeEditUITests/Query.swift
@@ -7,35 +7,46 @@
 
 import XCTest
 
+/// Query helpers for querying for specific UI elements. Organized by category in the app.
+/// Queries should not evaluate if an element exists. This allows for tests to expect an element to exist,
+/// perform an action, and then wait for that element to exist.
 enum Query {
-    static func getWindow(_ application: XCUIApplication) -> XCUIElement {
-        let window = application.windows["CodeEdit"]
-        XCTAssertTrue(window.exists, "Window not found")
-        return window
+    static func getWindow(_ application: XCUIApplication, named: String? = nil) -> XCUIElement {
+        if let named {
+            return application.windows[named]
+        } else {
+            return application.windows.element(matching: .window, identifier: "workspace")
+        }
+    }
+
+    static func getSettingsWindow(_ application: XCUIApplication) -> XCUIElement {
+        return application.windows.element(matching: .window, identifier: "settings")
+    }
+
+    static func getWelcomeWindow(_ application: XCUIApplication) -> XCUIElement {
+        return application.windows.element(matching: .window, identifier: "welcome")
+    }
+
+    static func getAboutWindow(_ application: XCUIApplication) -> XCUIElement {
+        return application.windows.element(matching: .window, identifier: "about")
     }
 
     enum Window {
-        static func getNavigator(_ window: XCUIElement) -> XCUIElement {
-            let navigator = window.descendants(matching: .any).matching(identifier: "ProjectNavigator").element
-            XCTAssertTrue(navigator.exists, "Navigator not found")
-            return navigator
+        static func getProjectNavigator(_ window: XCUIElement) -> XCUIElement {
+            return window.descendants(matching: .any).matching(identifier: "ProjectNavigator").element
         }
 
         static func getTabBar(_ window: XCUIElement) -> XCUIElement {
-            let scrollArea = window.descendants(matching: .any).matching(identifier: "TabBar").element
-            XCTAssertTrue(scrollArea.exists)
-            return scrollArea
+            return window.descendants(matching: .any).matching(identifier: "TabBar").element
         }
     }
 
     enum Navigator {
         static func getProjectNavigatorRow(fileTitle: String, index: Int = 0, _ navigator: XCUIElement) -> XCUIElement {
-            let row = navigator
+            return navigator
                 .descendants(matching: .outlineRow)
                 .containing(.textField, identifier: "ProjectNavigatorTableViewCell-\(fileTitle)")
                 .element(boundBy: index)
-            XCTAssertTrue(row.exists)
-            return row
         }
 
         static func disclosureIndicatorForRow(_ row: XCUIElement) -> XCUIElement {


### PR DESCRIPTION
### Description

In the current build, using command-W throws an exception. This fixes that by swapping out the use of the global `keyWindow` with `NSApp.keyWindow`.

This error appears to have appeared recently, but the global `keyWindow` should never have been used in the first place. It may have been the case that the use of this variable was previously linked to a different, similarly named, one by the compiler. But it now points to [this header](https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.6.sdk/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/Headers/AERegistry.h#L421).

I've also added UI tests for all windows for the command-w command, and the command-shift-w command in workspaces.

### Related Issues

- None opened yet.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
