### PR TITLE
allow files with a utType that is neither image nor PDF to be previewed

### DIFF
--- a/CodeEdit/Features/Editor/Views/NonTextFileView.swift
+++ b/CodeEdit/Features/Editor/Views/NonTextFileView.swift
@@ -24,23 +24,16 @@ struct NonTextFileView: View {
 
         Group {
             if let fileURL = fileDocument.fileURL {
-                if let utType = fileDocument.utType {
-
-                    if utType.conforms(to: .image) {
-                        ImageFileView(fileURL)
-                            .modifier(UpdateStatusBarInfo(withURL: fileURL))
-                    } else if utType.conforms(to: .pdf) {
-                        PDFFileView(fileURL)
-                            .modifier(UpdateStatusBarInfo(withURL: fileURL))
-                    } else {
-                        AnyFileView(fileURL)
-                            .modifier(UpdateStatusBarInfo(withURL: fileURL))
-                    }
+                if fileDocument.utType != nil && fileDocument.utType!.conforms(to: .image) {
+                    ImageFileView(fileURL)
+                        .modifier(UpdateStatusBarInfo(withURL: fileURL))
+                } else if fileDocument.utType != nil && fileDocument.utType!.conforms(to: .pdf) {
+                    PDFFileView(fileURL)
+                        .modifier(UpdateStatusBarInfo(withURL: fileURL))
                 } else {
                     AnyFileView(fileURL)
                         .modifier(UpdateStatusBarInfo(withURL: fileURL))
                 }
-
             } else {
                 ZStack {
                     Text("Cannot retrieve URL to the file you opened.")

--- a/CodeEdit/Features/Editor/Views/NonTextFileView.swift
+++ b/CodeEdit/Features/Editor/Views/NonTextFileView.swift
@@ -32,6 +32,9 @@ struct NonTextFileView: View {
                     } else if utType.conforms(to: .pdf) {
                         PDFFileView(fileURL)
                             .modifier(UpdateStatusBarInfo(withURL: fileURL))
+                    } else {
+                        AnyFileView(fileURL)
+                            .modifier(UpdateStatusBarInfo(withURL: fileURL))
                     }
                 } else {
                     AnyFileView(fileURL)

--- a/CodeEdit/Features/Editor/Views/NonTextFileView.swift
+++ b/CodeEdit/Features/Editor/Views/NonTextFileView.swift
@@ -21,15 +21,21 @@ struct NonTextFileView: View {
     @EnvironmentObject private var statusBarViewModel: StatusBarViewModel
 
     var body: some View {
-
         Group {
             if let fileURL = fileDocument.fileURL {
-                if fileDocument.utType != nil && fileDocument.utType!.conforms(to: .image) {
-                    ImageFileView(fileURL)
-                        .modifier(UpdateStatusBarInfo(withURL: fileURL))
-                } else if fileDocument.utType != nil && fileDocument.utType!.conforms(to: .pdf) {
-                    PDFFileView(fileURL)
-                        .modifier(UpdateStatusBarInfo(withURL: fileURL))
+                if let utType = fileDocument.utType {
+
+                    if utType.conforms(to: .image) {
+                        ImageFileView(fileURL)
+                            .modifier(UpdateStatusBarInfo(withURL: fileURL))
+                    } else if utType.conforms(to: .pdf) {
+                        PDFFileView(fileURL)
+                            .modifier(UpdateStatusBarInfo(withURL: fileURL))
+                    } else {
+                        AnyFileView(fileURL)
+                            .modifier(UpdateStatusBarInfo(withURL: fileURL))
+                    }
+
                 } else {
                     AnyFileView(fileURL)
                         .modifier(UpdateStatusBarInfo(withURL: fileURL))
@@ -44,6 +50,5 @@ struct NonTextFileView: View {
             statusBarViewModel.dimensions = nil
             statusBarViewModel.fileSize = nil
         }
-
     }
 }

--- a/CodeEdit/Features/Editor/Views/NonTextFileView.swift
+++ b/CodeEdit/Features/Editor/Views/NonTextFileView.swift
@@ -35,7 +35,6 @@ struct NonTextFileView: View {
                         AnyFileView(fileURL)
                             .modifier(UpdateStatusBarInfo(withURL: fileURL))
                     }
-
                 } else {
                     AnyFileView(fileURL)
                         .modifier(UpdateStatusBarInfo(withURL: fileURL))


### PR DESCRIPTION
### Description

Forgot an extra `else` statement. See [`f9433bd` (#1783)](https://github.com/CodeEditApp/CodeEdit/pull/1783/commits/f9433bd76dfff121e98e03bdd26925cf977a90d6#diff-de7783fe06b8a8ac19486146dc64c8958447f31bc1c4ba31b44d577e82500de6)

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
