### PR TITLE
Enabled git push force and tags options

### DIFF
--- a/CodeEdit/Features/SourceControl/Client/GitClient+Push.swift
+++ b/CodeEdit/Features/SourceControl/Client/GitClient+Push.swift
@@ -9,11 +9,23 @@ import Foundation
 
 extension GitClient {
     /// Push changes to remote
-    func pushToRemote(remote: String? = nil, branch: String? = nil, setUpstream: Bool? = false ) async throws {
+    func pushToRemote(
+        remote: String? = nil,
+        branch: String? = nil,
+        setUpstream: Bool? = false,
+        force: Bool? = false,
+        tags: Bool? = false
+    ) async throws {
         var command = "push"
         if let remote, let branch {
             if setUpstream == true {
                 command += " --set-upstream"
+            }
+            if force == true {
+                command += " --force"
+            }
+            if tags == true {
+                command += " --tags"
             }
             command += " \(remote) \(branch)"
         }

--- a/CodeEdit/Features/SourceControl/SourceControlManager+GitClient.swift
+++ b/CodeEdit/Features/SourceControl/SourceControlManager+GitClient.swift
@@ -288,10 +288,16 @@ extension SourceControlManager {
     }
 
     /// Push changes to remote
-    func push(remote: String? = nil, branch: String? = nil, setUpstream: Bool = false) async throws {
+    func push(
+        remote: String? = nil,
+        branch: String? = nil,
+        setUpstream: Bool = false,
+        force: Bool = false,
+        tags: Bool = false
+    ) async throws {
         guard currentBranch != nil else { return }
 
-        try await gitClient.pushToRemote(remote: remote, branch: branch, setUpstream: setUpstream)
+        try await gitClient.pushToRemote(remote: remote, branch: branch, setUpstream: setUpstream, force: force, tags: tags)
 
         await refreshCurrentBranch()
         await self.refreshNumberOfUnsyncedCommits()

--- a/CodeEdit/Features/SourceControl/SourceControlManager+GitClient.swift
+++ b/CodeEdit/Features/SourceControl/SourceControlManager+GitClient.swift
@@ -297,7 +297,13 @@ extension SourceControlManager {
     ) async throws {
         guard currentBranch != nil else { return }
 
-        try await gitClient.pushToRemote(remote: remote, branch: branch, setUpstream: setUpstream, force: force, tags: tags)
+        try await gitClient.pushToRemote(
+            remote: remote,
+            branch: branch,
+            setUpstream: setUpstream,
+            force: force,
+            tags: tags
+        )
 
         await refreshCurrentBranch()
         await self.refreshNumberOfUnsyncedCommits()

--- a/CodeEdit/Features/SourceControl/Views/SourceControlPushView.swift
+++ b/CodeEdit/Features/SourceControl/Views/SourceControlPushView.swift
@@ -75,7 +75,9 @@ struct SourceControlPushView: View {
                 try await sourceControlManager.push(
                     remote: sourceControlManager.operationRemote?.name ?? nil,
                     branch: sourceControlManager.operationBranch?.name ?? nil,
-                    setUpstream: sourceControlManager.currentBranch?.upstream == nil
+                    setUpstream: sourceControlManager.currentBranch?.upstream == nil,
+                    force: sourceControlManager.operationForce,
+                    tags: sourceControlManager.operationIncludeTags
                 )
                 self.loading = false
                 dismiss()


### PR DESCRIPTION
### Description

Missing from #1785 was the force and tags options in the push function. This PR adds them so the UI will work as expected.

### Related Issues

* #1785

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
