### PR TITLE
Search bar scrolls with the list closes #1818

### DIFF
--- a/CodeEdit/Features/Settings/SettingsView.swift
+++ b/CodeEdit/Features/Settings/SettingsView.swift
@@ -152,6 +152,7 @@ struct SettingsView: View {
                 }
             }
             .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
+            .scrollDisabled(true)
             .navigationSplitViewColumnWidth(215)
         } detail: {
             Group {

--- a/CodeEdit/Features/Settings/SettingsView.swift
+++ b/CodeEdit/Features/Settings/SettingsView.swift
@@ -147,7 +147,7 @@ struct SettingsView: View {
             List { }
                 .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
                 .scrollDisabled(true)
-                .frame(maxHeight: 30)
+                .frame(height: 30)
             List(selection: $selectedPage) {
                 Section {
                     ForEach(Self.pages) { pageAndSettings in

--- a/CodeEdit/Features/Settings/SettingsView.swift
+++ b/CodeEdit/Features/Settings/SettingsView.swift
@@ -144,6 +144,10 @@ struct SettingsView: View {
 
     var body: some View {
         NavigationSplitView {
+            List { }
+                .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
+                .scrollDisabled(true)
+                .frame(maxHeight: 30)
             List(selection: $selectedPage) {
                 Section {
                     ForEach(Self.pages) { pageAndSettings in
@@ -151,8 +155,6 @@ struct SettingsView: View {
                     }
                 }
             }
-            .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
-            .scrollDisabled(true)
             .navigationSplitViewColumnWidth(215)
         } detail: {
             Group {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

The search bar in the SettingsView is now on a different List that has no contents, the only purpose is to contain the search bar. Now it functions like the macOS System Settings search bar

### Related Issues

Search bar scrolls with the list closes #1818 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots

https://github.com/user-attachments/assets/ae243097-9713-4cf3-9fc5-dc83b9501556

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
