### PR TITLE
fix: Source Control Menu Commit Name

### DIFF
--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorMenu.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorMenu.swift
@@ -165,7 +165,7 @@ final class ProjectNavigatorMenu: NSMenu {
     private func sourceControlMenu(item: CEWorkspaceFile) -> NSMenu {
         let sourceControlMenu = NSMenu(title: "Source Control")
         sourceControlMenu.addItem(
-            withTitle: "Commit \"\(String(describing: item.fileName))\"...",
+            withTitle: "Commit \"\(String(describing: item.fileName()))\"...",
             action: nil,
             keyEquivalent: ""
         )


### PR DESCRIPTION
### Description
Correct source control menu commit menu file name reading。

### Related Issues

- closes #1856 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots
**After changes**
<img width="452" alt="image" src="https://github.com/user-attachments/assets/77f76cd0-e329-4dfa-931f-8b49bfd9f74e">
