### PR TITLE
Mark Autosave Changes Immediately

### DIFF
--- a/CodeEdit/Features/Documents/CodeFileDocument/CodeFileDocument.swift
+++ b/CodeEdit/Features/Documents/CodeFileDocument/CodeFileDocument.swift
@@ -13,6 +13,7 @@ import CodeEditSourceEditor
 import CodeEditTextView
 import CodeEditLanguages
 import Combine
+import OSLog
 
 enum CodeFileError: Error {
     case failedToDecode
@@ -25,6 +26,8 @@ final class CodeFileDocument: NSDocument, ObservableObject {
     struct OpenOptions {
         let cursorPositions: [CursorPosition]
     }
+
+    static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "CodeFileDocument")
 
     /// The text content of the document, stored as a text storage
     ///
@@ -121,6 +124,7 @@ final class CodeFileDocument: NSDocument, ObservableObject {
 
     override func data(ofType _: String) throws -> Data {
         guard let sourceEncoding, let data = (content?.string as NSString?)?.data(using: sourceEncoding.nsValue) else {
+            Self.logger.error("Failed to encode contents to \(self.sourceEncoding.debugDescription)")
             throw CodeFileError.failedToEncode
         }
         return data
@@ -143,6 +147,8 @@ final class CodeFileDocument: NSDocument, ObservableObject {
         if let validEncoding = FileEncoding(rawEncoding), let nsString {
             self.sourceEncoding = validEncoding
             self.content = NSTextStorage(string: nsString as String)
+        } else {
+            Self.logger.error("Failed to read file from data using encoding: \(rawEncoding)")
         }
     }
 


### PR DESCRIPTION
### Description

- Modifies `CodeFileView` to mark the document as changed immediately when changes occur rather than debounced. This fixes a small issue where the "Edited" marker would appear after the file was saved, because the change notification was debounced.
- Adds some error logging to `CodeFileDocument`.

### Related Issues

- None

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Before:

https://github.com/user-attachments/assets/9ba8b475-6959-44f5-b8f3-90f3131ac743

After:

https://github.com/user-attachments/assets/522fb0e4-6315-4da1-9cf8-b66d097032aa

