### PR TITLE
Rebuild Cached Files After Rename, Git Status Label

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
@@ -8,6 +8,7 @@
 import Combine
 import Foundation
 import AppKit
+import OSLog
 
 protocol CEWorkspaceFileManagerObserver: AnyObject {
     func fileManagerUpdated(updatedItems: Set<CEWorkspaceFile>)
@@ -38,6 +39,7 @@ protocol CEWorkspaceFileManagerObserver: AnyObject {
 /// ``CEWorkspaceFileManagerObserver`` protocol. Use the ``CEWorkspaceFileManager/addObserver(_:)``
 /// and ``CEWorkspaceFileManager/removeObserver(_:)`` to add or remove observers. Observers are kept as weak references.
 final class CEWorkspaceFileManager {
+    let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "CEWorkspaceFileManager")
     private(set) var fileManager: FileManager
     private(set) var ignoredFilesAndFolders: Set<String>
     private(set) var flattenedFileItems: [String: CEWorkspaceFile]
@@ -220,7 +222,12 @@ final class CEWorkspaceFileManager {
                     // TODO: Handle workspace root changing.
                     continue
                 case .itemCreated, .itemCloned, .itemRemoved, .itemRenamed:
-                    try? self.rebuildFiles(fromItem: parentItem)
+                    do {
+                        try self.rebuildFiles(fromItem: parentItem)
+                    } catch {
+                        // swiftlint:disable:next line_length
+                        self.logger.error("Failed to rebuild files for event: \(event.eventType.rawValue), path: \(event.path, privacy: .sensitive)")
+                    }
                     files.insert(parentItem)
                 }
             }

--- a/CodeEdit/Features/CEWorkspace/Models/DirectoryEventStream.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/DirectoryEventStream.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum FSEvent {
+enum FSEvent: String {
     case changeInDirectory
     case rootChanged
     case itemChangedOwner

--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -271,8 +271,9 @@ final class Editor: ObservableObject, Identifiable {
     /// Remove the given file from tabs.
     /// - Parameter file: The file to remove.
     func removeTab(_ file: CEWorkspaceFile) {
-        tabs.removeAll { tab in
-            tab.file == file
+        tabs.removeAll(where: { tab in tab.file == file })
+        if temporaryTab?.file == file {
+            temporaryTab = nil
         }
     }
 }

--- a/CodeEdit/Features/NavigatorArea/OutlineView/StandardTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/StandardTableViewCell.swift
@@ -88,7 +88,7 @@ class StandardTableViewCell: NSTableCellView {
         secondaryLabel.layer?.cornerRadius = 10.0
         secondaryLabel.font = .systemFont(ofSize: fontSize-2, weight: .bold)
         secondaryLabel.alignment = .center
-        secondaryLabel.textColor = NSColor(Color.secondary)
+        secondaryLabel.textColor = .secondaryLabelColor
     }
 
     func createIcon() -> NSImageView {

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+OutlineTableViewCellDelegate.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+OutlineTableViewCellDelegate.swift
@@ -15,8 +15,22 @@ extension ProjectNavigatorViewController: OutlineTableViewCellDelegate {
             workspace?.editorManager?.editorLayout.closeAllTabs(of: file)
         }
         workspace?.workspaceFileManager?.move(file: file, to: destination)
-        if !file.isFolder {
-            workspace?.editorManager?.openTab(item: .init(url: destination))
+        if let parent = file.parent {
+            do {
+                try workspace?.workspaceFileManager?.rebuildFiles(fromItem: parent)
+
+                // Grab the file connected to the rest of the cached file tree.
+                guard let newFile = workspace?.workspaceFileManager?.getFile(
+                    destination.absoluteURL.path(percentEncoded: false)
+                ),
+                      !newFile.isFolder else {
+                    return
+                }
+
+                workspace?.editorManager?.openTab(item: newFile)
+            } catch {
+                Self.logger.error("Failed to rebuild file item after moving: \(error)")
+            }
         }
     }
 

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
@@ -7,12 +7,17 @@
 
 import AppKit
 import SwiftUI
+import OSLog
 
 /// A `NSViewController` that handles the **ProjectNavigatorView** in the **NavigatorArea**.
 ///
 /// Adds a ``outlineView`` inside a ``scrollView`` which shows the folder structure of the
 /// currently open project.
 final class ProjectNavigatorViewController: NSViewController {
+    static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "",
+        category: "ProjectNavigatorViewController"
+    )
 
     var scrollView: NSScrollView!
     var outlineView: NSOutlineView!


### PR DESCRIPTION
### Description

- Updates the rename method to get a new, cached, file instead of creating one unrelated to the rest of the tree.
- Removes the temporary tab when closing a tab if the tab was the temporary tab.
- Updates the git status label to use a dynamic color, so it appears white when the cell is selected.

### Related Issues

- closes #1854

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Renaming, now selects new file after rename. File changes are saved between names. Editor can close the tab and keeps the ability to select new tabs.

https://github.com/user-attachments/assets/4e724f9c-65f5-457d-9803-4315dcfc15a8

Git status label

![Screenshot 2024-08-25 at 11 32 59 PM](https://github.com/user-attachments/assets/ac76ac0d-0b26-43d3-957f-84431f047a52)


