### PR TITLE
Closing tabs while Open Quickly or Command Palette is open is no longer allowed.

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController.swift
@@ -14,7 +14,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
     @Published var inspectorCollapsed = false
     @Published var toolbarCollapsed = false
 
-    private var modalOpen = false
+    private var panelOpen = false
 
     var observers: [NSKeyValueObservation] = []
 
@@ -111,26 +111,26 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
             if let commandPalettePanel {
                 if commandPalettePanel.isKeyWindow {
                     commandPalettePanel.close()
-                    self.modalOpen = false
+                    self.panelOpen = false
                     state.reset()
                     return
                 } else {
                     state.reset()
                     window?.addChildWindow(commandPalettePanel, ordered: .above)
                     commandPalettePanel.makeKeyAndOrderFront(self)
-                    self.modalOpen = true
+                    self.panelOpen = true
                 }
             } else {
                 let panel = SearchPanel()
                 self.commandPalettePanel = panel
                 let contentView = QuickActionsView(state: state) {
                     panel.close()
-                    self.modalOpen = false
+                    self.panelOpen = false
                 }
                 panel.contentView = NSHostingView(rootView: SettingsInjector { contentView })
                 window?.addChildWindow(panel, ordered: .above)
                 panel.makeKeyAndOrderFront(self)
-                self.modalOpen = true
+                self.panelOpen = true
             }
         }
     }
@@ -140,12 +140,12 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
             if let quickOpenPanel {
                 if quickOpenPanel.isKeyWindow {
                     quickOpenPanel.close()
-                    self.modalOpen = false
+                    self.panelOpen = false
                     return
                 } else {
                     window?.addChildWindow(quickOpenPanel, ordered: .above)
                     quickOpenPanel.makeKeyAndOrderFront(self)
-                    self.modalOpen = true
+                    self.panelOpen = true
                 }
             } else {
                 let panel = SearchPanel()
@@ -153,7 +153,7 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
 
                 let contentView = OpenQuicklyView(state: state) {
                     panel.close()
-                    self.modalOpen = false
+                    self.panelOpen = false
                 } openFile: { file in
                     workspace.editorManager?.openTab(item: file)
                 }.environmentObject(workspace)
@@ -161,13 +161,13 @@ final class CodeEditWindowController: NSWindowController, NSToolbarDelegate, Obs
                 panel.contentView = NSHostingView(rootView: SettingsInjector { contentView })
                 window?.addChildWindow(panel, ordered: .above)
                 panel.makeKeyAndOrderFront(self)
-                self.modalOpen = true
+                self.panelOpen = true
             }
         }
     }
 
     @IBAction func closeCurrentTab(_ sender: Any) {
-        if self.modalOpen { return }
+        if self.panelOpen { return }
         if (workspace?.editorManager?.activeEditor.tabs ?? []).isEmpty {
             self.closeActiveEditor(self)
         } else {

--- a/CodeEdit/Features/Settings/SettingsView.swift
+++ b/CodeEdit/Features/Settings/SettingsView.swift
@@ -152,6 +152,7 @@ struct SettingsView: View {
                 }
             }
             .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
+            .scrollDisabled(true)
             .navigationSplitViewColumnWidth(215)
         } detail: {
             Group {

--- a/CodeEdit/Features/Settings/SettingsView.swift
+++ b/CodeEdit/Features/Settings/SettingsView.swift
@@ -147,7 +147,7 @@ struct SettingsView: View {
             List { }
                 .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
                 .scrollDisabled(true)
-                .frame(maxHeight: 30)
+                .frame(height: 30)
             List(selection: $selectedPage) {
                 Section {
                     ForEach(Self.pages) { pageAndSettings in

--- a/CodeEdit/Features/Settings/SettingsView.swift
+++ b/CodeEdit/Features/Settings/SettingsView.swift
@@ -144,6 +144,10 @@ struct SettingsView: View {
 
     var body: some View {
         NavigationSplitView {
+            List { }
+                .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
+                .scrollDisabled(true)
+                .frame(maxHeight: 30)
             List(selection: $selectedPage) {
                 Section {
                     ForEach(Self.pages) { pageAndSettings in
@@ -151,8 +155,6 @@ struct SettingsView: View {
                     }
                 }
             }
-            .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
-            .scrollDisabled(true)
             .navigationSplitViewColumnWidth(215)
         } detail: {
             Group {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
When Open Quickly or Command Palette is open, open tabs are no longer allowed to be closed using cmd + w
<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

Close tab works when the 'Open Quickly' or 'Quick Actions' modal is open closes #1796 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots

https://github.com/user-attachments/assets/94c57753-7327-418e-8390-976ae8965662


<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
