### PR TITLE
Fix Monochrome Setting Crash

### DIFF
--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
@@ -36,7 +36,7 @@ final class ProjectNavigatorViewController: NSViewController {
     var iconColor: SettingsData.FileIconStyle = .color {
         willSet {
             if newValue != iconColor {
-                outlineView.reloadData()
+                outlineView?.reloadData()
             }
         }
     }


### PR DESCRIPTION
### Description

Fixes a crash with the monochrome setting. The icon color value's `willSet` was being called before `outlineView` was set up, causing an unexpected `nil` exception. This adds an optional to the call so it's safe to call now.

### Related Issues

- closes #1871 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A