### PR TITLE
Bug fix. #1875

### DIFF
--- a/CodeEdit/Features/Tasks/Models/CEActiveTask.swift
+++ b/CodeEdit/Features/Tasks/Models/CEActiveTask.swift
@@ -140,10 +140,8 @@ class CEActiveTask: ObservableObject, Identifiable, Hashable {
         }
     }
 
-    func clearOutput() async {
-        await MainActor.run {
-            output = ""
-        }
+    func clearOutput() {
+        output = ""
     }
 
     private func createStatusTaskNotification() {

--- a/CodeEdit/Features/UtilityArea/DebugUtility/TaskOutputActionsView.swift
+++ b/CodeEdit/Features/UtilityArea/DebugUtility/TaskOutputActionsView.swift
@@ -71,9 +71,7 @@ struct TaskOutputActionsView: View {
             .help("Scroll down to the bottom")
 
             Button {
-                Task {
-                    await activeTask.clearOutput()
-                }
+                activeTask.clearOutput()
             } label: {
                 Image(systemName: "trash")
             }


### PR DESCRIPTION

<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
TaskOutputView cleared after a double tap on Clear output button in TaskOutputActionsView

<!--- REQUIRED: Describe what changed in detail -->
I think with such a simple operation there is no need to apply asynchrony 

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1875

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [ ] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

Before

https://github.com/user-attachments/assets/89c283e2-6f7a-41f8-a5c3-edeca0ec4f20

After

https://github.com/user-attachments/assets/d3b8c03c-f73b-4344-9961-83109fd3f6b0




