### PR TITLE
EditorManager Always Opens Files

### DIFF
--- a/CodeEdit/Features/Editor/Models/Editor+History.swift
+++ b/CodeEdit/Features/Editor/Models/Editor+History.swift
@@ -63,9 +63,10 @@ extension Editor {
             if let temporaryTab, tabs.contains(temporaryTab) {
                 closeTab(file: temporaryTab.file, fromHistory: true)
             }
-            let newTab = Tab(file: file)
-            temporaryTab = newTab
-            openTab(tab: newTab, fromHistory: true)
+            openTab(file: file, fromHistory: true)
+            if let tab = tabs.first(where: { $0.file.id == file.id }) {
+                temporaryTab = tab
+            }
         }
         setSelectedTab(file)
     }

--- a/CodeEdit/Features/Editor/Models/Editor+History.swift
+++ b/CodeEdit/Features/Editor/Models/Editor+History.swift
@@ -12,8 +12,8 @@ extension Editor {
     /// Add the tab to the history list.
     /// - Parameter tab: The tab to add to the history.
     func addToHistory(_ tab: Tab) {
-        if history.first != tab {
-            history.prepend(tab)
+        if history.first != tab.file {
+            history.prepend(tab.file)
         }
     }
 
@@ -57,15 +57,16 @@ extension Editor {
     /// If the tab is not opened, it is opened without modifying the history list.
     /// - Warning: Do not use except in the ``historyOffset``'s `didSet`.
     func historyOffsetDidChange() {
-        let tab = history[historyOffset]
+        let file = history[historyOffset]
 
-        if !tabs.contains(tab) {
+        if !tabs.contains(where: { $0.file == file }) {
             if let temporaryTab, tabs.contains(temporaryTab) {
                 closeTab(file: temporaryTab.file, fromHistory: true)
             }
-            temporaryTab = tab
-            openTab(file: tab.file, fromHistory: true)
+            let newTab = Tab(file: file)
+            temporaryTab = newTab
+            openTab(tab: newTab, fromHistory: true)
         }
-        selectedTab = tab
+        setSelectedTab(file)
     }
 }

--- a/CodeEdit/Features/Editor/Models/Editor+TabSwitch.swift
+++ b/CodeEdit/Features/Editor/Models/Editor+TabSwitch.swift
@@ -12,10 +12,10 @@ extension Editor {
         guard let currentTab = selectedTab, let currentIndex = tabs.firstIndex(of: currentTab) else { return }
         let nextIndex = tabs.index(after: currentIndex)
         if nextIndex < tabs.endIndex {
-            selectedTab = tabs[nextIndex]
+            setSelectedTab(tabs[nextIndex].file)
         } else {
             // Wrap around to the first tab if it's the last one
-            selectedTab = tabs.first
+            setSelectedTab(tabs.first?.file)
         }
     }
 
@@ -23,10 +23,10 @@ extension Editor {
         guard let currentTab = selectedTab, let currentIndex = tabs.firstIndex(of: currentTab) else { return }
         let previousIndex = tabs.index(before: currentIndex)
         if previousIndex >= tabs.startIndex {
-            selectedTab = tabs[previousIndex]
+            setSelectedTab(tabs[previousIndex].file)
         } else {
             // Wrap around to the last tab if it's the first one
-            selectedTab = tabs.last
+            setSelectedTab(tabs.last?.file)
         }
     }
 }

--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -110,7 +110,7 @@ final class Editor: ObservableObject, Identifiable {
         }
         self.selectedTab = tab
         if tab.file.fileDocument == nil {
-            do { // eat this error for ease of API use.
+            do { // Ignore this error for simpler API usage.
                 try openFile(item: tab)
             } catch {
                 print(error)

--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -20,14 +20,14 @@ final class Editor: ObservableObject, Identifiable {
 
             if tabs.count > oldValue.count {
                 // Amount of tabs grew, so set the first new as selected.
-                selectedTab = change.first
+                setSelectedTab(change.first?.file)
             } else {
                 // Selected file was removed
                 if let selectedTab, change.contains(selectedTab) {
                     if let oldIndex = oldValue.firstIndex(of: selectedTab), oldIndex - 1 < tabs.count, !tabs.isEmpty {
-                        self.selectedTab = tabs[max(0, oldIndex-1)]
+                        setSelectedTab(tabs[max(0, oldIndex-1)].file)
                     } else {
-                        self.selectedTab = nil
+                        setSelectedTab(nil)
                     }
                 }
             }
@@ -45,10 +45,10 @@ final class Editor: ObservableObject, Identifiable {
 
     /// Maintains the list of tabs that have been switched to.
     /// - Warning: Use the ``addToHistory(_:)`` or ``clearFuture()`` methods to modify this. Do not modify directly.
-    @Published var history: Deque<Tab> = []
+    @Published var history: Deque<CEWorkspaceFile> = []
 
     /// Currently selected tab.
-    @Published var selectedTab: Tab?
+    @Published private(set) var selectedTab: Tab?
 
     @Published var temporaryTab: Tab?
 
@@ -96,6 +96,26 @@ final class Editor: ObservableObject, Identifiable {
     /// Gets the editor layout.
     func getEditorLayout() -> EditorLayout? {
         return parent?.getEditorLayout(with: id)
+    }
+
+    /// Set the selected tab. Loads the file's contents if it hasn't already been opened.
+    /// - Parameter file: The file to set as the selected tab.
+    func setSelectedTab(_ file: CEWorkspaceFile?) {
+        guard let file else {
+            selectedTab = nil
+            return
+        }
+        guard let tab = self.tabs.first(where: { $0.file == file }) else {
+            return
+        }
+        self.selectedTab = tab
+        if tab.file.fileDocument == nil {
+            do { // eat this error for ease of API use.
+                try openFile(item: tab)
+            } catch {
+                print(error)
+            }
+        }
     }
 
     /// Closes a tab in the editor.

--- a/CodeEdit/Features/Editor/Models/EditorLayout+StateRestoration.swift
+++ b/CodeEdit/Features/Editor/Models/EditorLayout+StateRestoration.swift
@@ -96,9 +96,9 @@ extension EditorManager {
         editor.tabs = OrderedSet(resolvedTabs)
         if let selectedTab = editor.selectedTab {
             if let resolvedFile = fileManager.getFile(selectedTab.file.url.path(), createIfNotFound: true) {
-                editor.selectedTab = EditorInstance(file: resolvedFile)
+                editor.setSelectedTab(resolvedFile)
             } else {
-                editor.selectedTab = nil
+                editor.setSelectedTab(nil)
             }
         }
     }

--- a/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabView.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabView.swift
@@ -88,7 +88,7 @@ struct EditorTabView: View {
         editorManager.activeEditor = editor
         if editor.selectedTab?.file != item {
             let tabItem = EditorInstance(file: item)
-            editor.selectedTab = tabItem
+            editor.setSelectedTab(item)
             editor.clearFuture()
             editor.addToHistory(tabItem)
         }

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorHistoryMenus.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorHistoryMenus.swift
@@ -17,14 +17,14 @@ struct EditorHistoryMenus: View {
                 ForEach(
                     Array(editor.history.dropFirst(editor.historyOffset+1).enumerated()),
                     id: \.offset
-                ) { index, tab in
+                ) { index, file in
                     Button {
                         editorManager.activeEditor = editor
                         editor.historyOffset += index + 1
                     } label: {
                         HStack {
-                            tab.file.icon
-                            Text(tab.file.name)
+                            file.icon
+                            Text(file.name)
                         }
                     }
                 }
@@ -44,14 +44,14 @@ struct EditorHistoryMenus: View {
                 ForEach(
                     Array(editor.history.prefix(editor.historyOffset).reversed().enumerated()),
                     id: \.offset
-                ) { index, tab in
+                ) { index, file in
                     Button {
                         editorManager.activeEditor = editor
                         editor.historyOffset -= index + 1
                     } label: {
                         HStack {
-                            tab.file.icon
-                            Text(tab.file.name)
+                            file.icon
+                            Text(file.name)
                         }
                     }
                 }

--- a/CodeEdit/Features/Editor/Views/EditorAreaView.swift
+++ b/CodeEdit/Features/Editor/Views/EditorAreaView.swift
@@ -61,6 +61,14 @@ struct EditorAreaView: View {
                     .opacity(dimEditorsWithoutFocus && editor != editorManager.activeEditor ? 0.5 : 1)
                 } else {
                     LoadingFileView(selected.file.name)
+                        .onAppear {
+                            if let file = selected.file.fileDocument {
+                                self.codeFile = file
+                            }
+                        }
+                        .onReceive(selected.file.fileDocumentPublisher) { latestValue in
+                            self.codeFile = latestValue
+                        }
                 }
 
             } else {


### PR DESCRIPTION
### Description

Updates the editor manager to use a private variable for the selected tab, and a setter method. This method handles opening the underlying code document if necessary and moves the ownership of opening the code file to the editor manager. This was unclear before, which led to documents being opened multiple times (there was a comment in the editor.swift file about this earlier).

This also updates the history to use the `CEWorkspaceFile` rather than tabs, to indicate that items in the history are unrelated to their UI representation and are given a new tab instance when opened (if necessary).

Also updates the loading indicator to update the UI when it receives an update as well as attempt to do so when it appears. This change ensure that if the code file property is set, it is reflected in the UI.

### Related Issues

* N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/user-attachments/assets/787be39b-0394-4575-9e45-1d2a6db633f8

