### PR TITLE
Fix/navigation commands

### DIFF
--- a/CodeEdit/Features/WindowCommands/NavigateCommands.swift
+++ b/CodeEdit/Features/WindowCommands/NavigateCommands.swift
@@ -9,7 +9,10 @@ import SwiftUI
 
 struct NavigateCommands: Commands {
 
-    @FocusedObject var editor: Editor?
+    @UpdatingWindowController var windowController: CodeEditWindowController?
+    private var editor: Editor? {
+        windowController?.workspace?.editorManager?.activeEditor
+    }
 
     var body: some Commands {
         CommandMenu("Navigate") {

--- a/CodeEdit/Features/WindowCommands/Utils/WindowControllerPropertyWrapper.swift
+++ b/CodeEdit/Features/WindowCommands/Utils/WindowControllerPropertyWrapper.swift
@@ -39,6 +39,7 @@ struct UpdatingWindowController: DynamicProperty {
         private var objectWillChangeCancellable: AnyCancellable?
         private var utilityAreaCancellable: AnyCancellable? // ``ViewCommands`` needs this.
         private var windowCancellable: AnyCancellable?
+        private var activeEditorCancellable: AnyCancellable?
 
         init() {
             windowCancellable = NSApp.publisher(for: \.keyWindow).sink { [weak self] window in
@@ -51,6 +52,8 @@ struct UpdatingWindowController: DynamicProperty {
             objectWillChangeCancellable = nil
             utilityAreaCancellable?.cancel()
             utilityAreaCancellable = nil
+            activeEditorCancellable?.cancel()
+            activeEditorCancellable = nil
 
             self.controller = controller
 
@@ -58,6 +61,10 @@ struct UpdatingWindowController: DynamicProperty {
                 self?.objectWillChange.send()
             }
             utilityAreaCancellable = controller?.workspace?.utilityAreaModel?.objectWillChange.sink { [weak self] in
+                self?.objectWillChange.send()
+            }
+            let activeEditor = controller?.workspace?.editorManager?.activeEditor
+            activeEditorCancellable = activeEditor?.objectWillChange.sink { [weak self] in
                 self?.objectWillChange.send()
             }
             self.objectWillChange.send()


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Fixes the following issues,

1. Show Previous and Next Tab menu items are disabled even if multiple tabs are opened
2. Pressing ⌘ { and ⌘ } does not do anything.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues


<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes, #1848 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->


https://github.com/user-attachments/assets/80f981d2-e3ee-4d5a-8049-ea5491caf968


<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
