### PR TITLE
Project navigator file filtering

### DIFF
--- a/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument.swift
@@ -14,7 +14,8 @@ import LanguageServerProtocol
 @objc(WorkspaceDocument)
 final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     @Published var sortFoldersOnTop: Bool = true
-    @Published var filter: String = ""
+    /// A string used to filter the displayed files and folders in the project navigator area based on user input.
+    @Published var navigatorFilter: String = ""
 
     private var workspaceState: [String: Any] {
         get {

--- a/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument.swift
@@ -14,6 +14,7 @@ import LanguageServerProtocol
 @objc(WorkspaceDocument)
 final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
     @Published var sortFoldersOnTop: Bool = true
+    @Published var filter: String = ""
 
     private var workspaceState: [String: Any] {
         get {

--- a/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
@@ -177,8 +177,7 @@ extension FindNavigatorListViewController: NSOutlineViewDelegate {
             let view = ProjectNavigatorTableViewCell(
                 frame: frameRect,
                 item: (item as? SearchResultModel)?.file,
-                isEditable: false,
-                workspace: workspace
+                isEditable: false
             )
             // We're using a medium label for file names b/c it makes it easier to
             // distinguish quickly which results are from which files.

--- a/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
@@ -177,7 +177,8 @@ extension FindNavigatorListViewController: NSOutlineViewDelegate {
             let view = ProjectNavigatorTableViewCell(
                 frame: frameRect,
                 item: (item as? SearchResultModel)?.file,
-                isEditable: false
+                isEditable: false,
+                workspace: workspace
             )
             // We're using a medium label for file names b/c it makes it easier to
             // distinguish quickly which results are from which files.

--- a/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
@@ -61,7 +61,7 @@ class FileSystemTableViewCell: StandardTableViewCell {
                 attributedString.addAttributes(
                     [
                         .font: NSFont.boldSystemFont(ofSize: textField?.font?.pointSize ?? 12),
-                        .foregroundColor: NSColor.textColor
+.foregroundColor: NSColor.labelColor
                     ],
                     range: range
                 )

--- a/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
@@ -44,7 +44,7 @@ class FileSystemTableViewCell: StandardTableViewCell {
         let fileName = item.labelFileName()
 
         // Apply bold style if the filename matches the workspace filter
-        if let filter = workspace?.filter, !filter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if let filter = workspace?.navigatorFilter, !filter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             let attributedString = NSMutableAttributedString(string: fileName)
 
             // Check if the filename contains the filter text

--- a/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
@@ -15,6 +15,7 @@ class FileSystemTableViewCell: StandardTableViewCell {
     var changeLabelSmallWidth: NSLayoutConstraint!
 
     private let prefs = Settings.shared.preferences.general
+    private var navigatorFilter: String?
 
     /// Initializes the `OutlineTableViewCell` with an `icon` and `label`
     /// Both the icon and label will be colored, and sized based on the user's preferences.
@@ -22,8 +23,11 @@ class FileSystemTableViewCell: StandardTableViewCell {
     ///   - frameRect: The frame of the cell.
     ///   - item: The file item the cell represents.
     ///   - isEditable: Set to true if the user should be able to edit the file name.
-    init(frame frameRect: NSRect, item: CEWorkspaceFile?, isEditable: Bool = true, workspace: WorkspaceDocument?) {
-        super.init(frame: frameRect, isEditable: isEditable, workspace: workspace)
+    ///   - navigatorFilter: An optional string use to filter the navigator area.
+    ///                      (Used for bolding and changing primary/secondary color).
+    init(frame frameRect: NSRect, item: CEWorkspaceFile?, isEditable: Bool = true, navigatorFilter: String? = nil) {
+        super.init(frame: frameRect, isEditable: isEditable)
+        self.navigatorFilter = navigatorFilter
 
         if let item = item {
             addIcon(item: item)
@@ -43,12 +47,17 @@ class FileSystemTableViewCell: StandardTableViewCell {
 
         let fileName = item.labelFileName()
 
+        guard let navigatorFilter else {
+            textField?.stringValue = fileName
+            return
+        }
+
         // Apply bold style if the filename matches the workspace filter
-        if let filter = workspace?.navigatorFilter, !filter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if !navigatorFilter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             let attributedString = NSMutableAttributedString(string: fileName)
 
             // Check if the filename contains the filter text
-            let range = NSString(string: fileName).range(of: filter, options: .caseInsensitive)
+            let range = NSString(string: fileName).range(of: navigatorFilter, options: .caseInsensitive)
             if range.location != NSNotFound {
                 // Set the label color to secondary
                 attributedString.addAttribute(

--- a/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
@@ -22,8 +22,8 @@ class FileSystemTableViewCell: StandardTableViewCell {
     ///   - frameRect: The frame of the cell.
     ///   - item: The file item the cell represents.
     ///   - isEditable: Set to true if the user should be able to edit the file name.
-    init(frame frameRect: NSRect, item: CEWorkspaceFile?, isEditable: Bool = true) {
-        super.init(frame: frameRect, isEditable: isEditable)
+    init(frame frameRect: NSRect, item: CEWorkspaceFile?, isEditable: Bool = true, workspace: WorkspaceDocument?) {
+        super.init(frame: frameRect, isEditable: isEditable, workspace: workspace)
 
         if let item = item {
             addIcon(item: item)
@@ -40,7 +40,24 @@ class FileSystemTableViewCell: StandardTableViewCell {
         fileItem = item
         imageView?.image = item.nsIcon
         imageView?.contentTintColor = color(for: item)
-        textField?.stringValue = item.labelFileName()
+
+        let fileName = item.labelFileName()
+        textField?.stringValue = fileName
+
+        // Apply bold style if the filename matches the workspace filter
+        if let filter = workspace?.filter, fileName.localizedLowercase.contains(filter.localizedLowercase) {
+            let attributedString = NSMutableAttributedString(string: fileName)
+            let range = NSString(string: fileName).range(of: filter, options: .caseInsensitive)
+            attributedString.addAttribute(
+                .font,
+                value: NSFont.boldSystemFont(ofSize: textField?.font?.pointSize ?? 12),
+                range: range
+            )
+            textField?.attributedStringValue = attributedString
+        } else {
+            // Reset to normal font if no match
+            textField?.attributedStringValue = NSAttributedString(string: fileName)
+        }
     }
 
     func addModel() {

--- a/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
@@ -42,21 +42,49 @@ class FileSystemTableViewCell: StandardTableViewCell {
         imageView?.contentTintColor = color(for: item)
 
         let fileName = item.labelFileName()
-        textField?.stringValue = fileName
 
         // Apply bold style if the filename matches the workspace filter
-        if let filter = workspace?.filter, fileName.localizedLowercase.contains(filter.localizedLowercase) {
+        if let filter = workspace?.filter, !filter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             let attributedString = NSMutableAttributedString(string: fileName)
+
+            // Check if the filename contains the filter text
             let range = NSString(string: fileName).range(of: filter, options: .caseInsensitive)
-            attributedString.addAttribute(
-                .font,
-                value: NSFont.boldSystemFont(ofSize: textField?.font?.pointSize ?? 12),
-                range: range
-            )
+            if range.location != NSNotFound {
+                // Set the label color to secondary
+                attributedString.addAttribute(
+                    .foregroundColor,
+                    value: NSColor.secondaryLabelColor,
+                    range: NSRange(location: 0, length: attributedString.length)
+                )
+
+                // If the filter text matches, bold the matching text and set primary label color
+                attributedString.addAttributes(
+                    [
+                        .font: NSFont.boldSystemFont(ofSize: textField?.font?.pointSize ?? 12),
+                        .foregroundColor: NSColor.textColor
+                    ],
+                    range: range
+                )
+            } else {
+                // If no match, apply primary label color for parent folder,
+                // or secondary label color for a non-matching file
+                attributedString.addAttribute(
+                    .foregroundColor,
+                    value: item.isFolder ? NSColor.labelColor : NSColor.secondaryLabelColor,
+                    range: NSRange(location: 0, length: attributedString.length)
+                )
+            }
+
             textField?.attributedStringValue = attributedString
         } else {
-            // Reset to normal font if no match
-            textField?.attributedStringValue = NSAttributedString(string: fileName)
+            // If no filter is applied, reset to normal font and primary label color
+            textField?.attributedStringValue = NSAttributedString(
+                string: fileName,
+                attributes: [
+                    .font: NSFont.systemFont(ofSize: textField?.font?.pointSize ?? 12),
+                    .foregroundColor: NSColor.labelColor
+                ]
+            )
         }
     }
 

--- a/CodeEdit/Features/NavigatorArea/OutlineView/StandardTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/StandardTableViewCell.swift
@@ -10,7 +10,7 @@ import SwiftUI
 class StandardTableViewCell: NSTableCellView {
 
     weak var secondaryLabel: NSTextField?
-    var workspace: WorkspaceDocument?
+    weak var workspace: WorkspaceDocument?
 
     var secondaryLabelRightAligned: Bool = true {
         didSet {

--- a/CodeEdit/Features/NavigatorArea/OutlineView/StandardTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/StandardTableViewCell.swift
@@ -10,7 +10,7 @@ import SwiftUI
 class StandardTableViewCell: NSTableCellView {
 
     weak var secondaryLabel: NSTextField?
-    weak var workspace: WorkspaceDocument?
+    var workspace: WorkspaceDocument?
 
     var secondaryLabelRightAligned: Bool = true {
         didSet {
@@ -24,9 +24,10 @@ class StandardTableViewCell: NSTableCellView {
     ///   - frameRect: The frame of the cell.
     ///   - item: The file item the cell represents.
     ///   - isEditable: Set to true if the user should be able to edit the file name.
-    init(frame frameRect: NSRect, isEditable: Bool = true) {
+    init(frame frameRect: NSRect, isEditable: Bool = true, workspace: WorkspaceDocument?) {
         super.init(frame: frameRect)
         setupViews(frame: frameRect, isEditable: isEditable)
+        self.workspace = workspace
     }
 
     // Default init, assumes isEditable to be false

--- a/CodeEdit/Features/NavigatorArea/OutlineView/StandardTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/StandardTableViewCell.swift
@@ -24,10 +24,10 @@ class StandardTableViewCell: NSTableCellView {
     ///   - frameRect: The frame of the cell.
     ///   - item: The file item the cell represents.
     ///   - isEditable: Set to true if the user should be able to edit the file name.
-    init(frame frameRect: NSRect, isEditable: Bool = true, workspace: WorkspaceDocument?) {
+    init(frame frameRect: NSRect, isEditable: Bool = true) {
         super.init(frame: frameRect)
         setupViews(frame: frameRect, isEditable: isEditable)
-        self.workspace = workspace
+
     }
 
     // Default init, assumes isEditable to be false

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
@@ -36,6 +36,7 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
         nsViewController.hiddenFileExtensions = prefs.preferences.general.hiddenFileExtensions
         /// if the window becomes active from background, it will restore the selection to outline view.
         nsViewController.updateSelection(itemID: workspace.editorManager?.activeEditor.selectedTab?.file.id)
+        nsViewController.filter = workspace.filter
         return
     }
 

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
@@ -36,7 +36,6 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
         nsViewController.hiddenFileExtensions = prefs.preferences.general.hiddenFileExtensions
         /// if the window becomes active from background, it will restore the selection to outline view.
         nsViewController.updateSelection(itemID: workspace.editorManager?.activeEditor.selectedTab?.file.id)
-        nsViewController.filter = workspace.filter
         return
     }
 
@@ -61,6 +60,10 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
                 .sink { [weak self] itemID in
                     self?.controller?.updateSelection(itemID: itemID)
                 }
+                .store(in: &cancellables)
+            workspace.$navigatorFilter
+                .throttle(for: 0.1, scheduler: RunLoop.main, latest: true)
+                .sink { [weak self] _ in self?.controller?.handleFilterChange() }
                 .store(in: &cancellables)
         }
 

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorTableViewCell.swift
@@ -22,14 +22,16 @@ final class ProjectNavigatorTableViewCell: FileSystemTableViewCell {
     ///   - frameRect: The frame of the cell.
     ///   - item: The file item the cell represents.
     ///   - isEditable: Set to true if the user should be able to edit the file name.
+    ///   - navigatorFilter: An optional string use to filter the navigator area.
+    ///                      (Used for bolding and changing primary/secondary color).
     init(
         frame frameRect: NSRect,
         item: CEWorkspaceFile?,
         isEditable: Bool = true,
         delegate: OutlineTableViewCellDelegate? = nil,
-        workspace: WorkspaceDocument?
+        navigatorFilter: String? = nil
     ) {
-        super.init(frame: frameRect, item: item, isEditable: isEditable, workspace: workspace)
+        super.init(frame: frameRect, item: item, isEditable: isEditable, navigatorFilter: navigatorFilter)
         self.textField?.setAccessibilityIdentifier("ProjectNavigatorTableViewCell-\(item?.name ?? "")")
         self.delegate = delegate
     }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorTableViewCell.swift
@@ -26,9 +26,10 @@ final class ProjectNavigatorTableViewCell: FileSystemTableViewCell {
         frame frameRect: NSRect,
         item: CEWorkspaceFile?,
         isEditable: Bool = true,
-        delegate: OutlineTableViewCellDelegate? = nil
+        delegate: OutlineTableViewCellDelegate? = nil,
+        workspace: WorkspaceDocument?
     ) {
-        super.init(frame: frameRect, item: item, isEditable: isEditable)
+        super.init(frame: frameRect, item: item, isEditable: isEditable, workspace: workspace)
         self.textField?.setAccessibilityIdentifier("ProjectNavigatorTableViewCell-\(item?.name ?? "")")
         self.delegate = delegate
     }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDataSource.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDataSource.swift
@@ -15,7 +15,7 @@ extension ProjectNavigatorViewController: NSOutlineViewDataSource {
         }
 
         if let children = workspace?.workspaceFileManager?.childrenOfFile(item) {
-            let filteredChildren = children.filter { fileSearchMatches(filter, for: $0) }
+            let filteredChildren = children.filter { fileSearchMatches(workspace?.navigatorFilter ?? "", for: $0) }
             filteredContentChildren[item] = filteredChildren
             return filteredChildren
         }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDataSource.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDataSource.swift
@@ -8,17 +8,31 @@
 import AppKit
 
 extension ProjectNavigatorViewController: NSOutlineViewDataSource {
+    /// Retrieves the children of a given item for the outline view, applying the current filter if necessary.
+    private func getOutlineViewItems(for item: CEWorkspaceFile) -> [CEWorkspaceFile] {
+        if let cachedChildren = filteredContentChildren[item] {
+            return cachedChildren
+        }
+
+        if let children = workspace?.workspaceFileManager?.childrenOfFile(item) {
+            let filteredChildren = children.filter { fileSearchMatches(filter, for: $0) }
+            filteredContentChildren[item] = filteredChildren
+            return filteredChildren
+        }
+
+        return []
+    }
+
     func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
         if let item = item as? CEWorkspaceFile {
-            return item.isFolder ? workspace?.workspaceFileManager?.childrenOfFile(item)?.count ?? 0 : 0
+            return getOutlineViewItems(for: item).count
         }
         return content.count
     }
 
     func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
-        if let item = item as? CEWorkspaceFile,
-           let children = workspace?.workspaceFileManager?.childrenOfFile(item) {
-            return children[index]
+        if let item = item as? CEWorkspaceFile {
+            return getOutlineViewItems(for: item)[index]
         }
         return content[index]
     }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
@@ -28,7 +28,7 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
             frame: frameRect,
             item: item as? CEWorkspaceFile,
             delegate: self,
-            workspace: workspace
+            navigatorFilter: workspace?.navigatorFilter
         )
         return cell
     }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
@@ -49,8 +49,14 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
     }
 
     func outlineViewItemDidExpand(_ notification: Notification) {
-        guard let id = workspace?.editorManager?.activeEditor.selectedTab?.file.id,
-              let item = workspace?.workspaceFileManager?.getFile(id, createIfNotFound: true),
+        /// Save expanded items' state to restore when finish filtering.
+        guard let workspace else { return }
+        if workspace.filter.isEmpty, let item = notification.userInfo?["NSObject"] as? CEWorkspaceFile {
+            expandedItems.insert(item)
+        }
+
+        guard let id = workspace.editorManager?.activeEditor.selectedTab?.file.id,
+              let item = workspace.workspaceFileManager?.getFile(id, createIfNotFound: true),
               /// update outline selection only if the parent of selected item match with expanded item
               item.parent === notification.userInfo?["NSObject"] as? CEWorkspaceFile else {
             return
@@ -61,7 +67,13 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
         }
     }
 
-    func outlineViewItemDidCollapse(_ notification: Notification) {}
+    func outlineViewItemDidCollapse(_ notification: Notification) {
+        /// Save expanded items' state to restore when finish filtering.
+        guard let workspace else { return }
+        if workspace.filter.isEmpty, let item = notification.userInfo?["NSObject"] as? CEWorkspaceFile {
+            expandedItems.remove(item)
+        }
+    }
 
     func outlineView(_ outlineView: NSOutlineView, itemForPersistentObject object: Any) -> Any? {
         guard let id = object as? CEWorkspaceFile.ID,

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
@@ -56,7 +56,7 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
     func outlineViewItemDidExpand(_ notification: Notification) {
         /// Save expanded items' state to restore when finish filtering.
         guard let workspace else { return }
-        if workspace.filter.isEmpty, let item = notification.userInfo?["NSObject"] as? CEWorkspaceFile {
+        if workspace.navigatorFilter.isEmpty, let item = notification.userInfo?["NSObject"] as? CEWorkspaceFile {
             expandedItems.insert(item)
         }
 
@@ -75,7 +75,7 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
     func outlineViewItemDidCollapse(_ notification: Notification) {
         /// Save expanded items' state to restore when finish filtering.
         guard let workspace else { return }
-        if workspace.filter.isEmpty, let item = notification.userInfo?["NSObject"] as? CEWorkspaceFile {
+        if workspace.navigatorFilter.isEmpty, let item = notification.userInfo?["NSObject"] as? CEWorkspaceFile {
             expandedItems.remove(item)
         }
     }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
@@ -24,8 +24,13 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
         guard let tableColumn else { return nil }
 
         let frameRect = NSRect(x: 0, y: 0, width: tableColumn.width, height: rowHeight)
-
-        return ProjectNavigatorTableViewCell(frame: frameRect, item: item as? CEWorkspaceFile, delegate: self)
+        let cell = ProjectNavigatorTableViewCell(
+            frame: frameRect,
+            item: item as? CEWorkspaceFile,
+            delegate: self,
+            workspace: workspace
+        )
+        return cell
     }
 
     func outlineViewSelectionDidChange(_ notification: Notification) {

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
@@ -217,7 +217,8 @@ final class ProjectNavigatorViewController: NSViewController {
         return false
     }
 
-    /// Saves all children of a given folder item to the filtered content cache, this is specially useful when the name of a folder matches the search.
+    /// Saves all children of a given folder item to the filtered content cache.
+    /// This is specially useful when the name of a folder matches the search.
     /// Just like in Xcode, this shows all the content of the folder.
     private func saveAllContentChildren(for item: CEWorkspaceFile) {
         guard item.isFolder, filteredContentChildren[item] == nil else { return }
@@ -230,7 +231,7 @@ final class ProjectNavigatorViewController: NSViewController {
         }
     }
 
-    /// Restores the expanded state of items in the outline view based on previously expanded items when finish searching.
+    /// Restores the expanded state of items when finish searching.
     private func restoreExpandedState() {
         let copy = expandedItems
         outlineView.collapseItem(outlineView.item(atRow: 0), collapseChildren: true)

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
@@ -198,7 +198,9 @@ final class ProjectNavigatorViewController: NSViewController {
             outlineView.expandItem(outlineView.item(atRow: 0), expandChildren: true)
         }
 
-        noResultsLabel.isHidden = !(filteredContentChildren[content[0]]?.isEmpty ?? false)
+        if let root = content.first(where: { $0.isRoot }), let children = filteredContentChildren[root] {
+            noResultsLabel.isHidden = !children.isEmpty
+        }
     }
 
     /// Checks if the given filter matches the name of the item or any of its children.

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
@@ -199,7 +199,12 @@ final class ProjectNavigatorViewController: NSViewController {
         }
 
         if let root = content.first(where: { $0.isRoot }), let children = filteredContentChildren[root] {
-            noResultsLabel.isHidden = !children.isEmpty
+            if children.isEmpty {
+                noResultsLabel.isHidden = false
+                outlineView.hideRows(at: IndexSet(integer: 0))
+            } else {
+                noResultsLabel.isHidden = true
+            }
         }
     }
 

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
@@ -21,6 +21,7 @@ final class ProjectNavigatorViewController: NSViewController {
 
     var scrollView: NSScrollView!
     var outlineView: NSOutlineView!
+    var noResultsLabel: NSTextField!
 
     /// Gets the folder structure
     ///
@@ -29,6 +30,14 @@ final class ProjectNavigatorViewController: NSViewController {
         guard let folderURL = workspace?.workspaceFileManager?.folderUrl else { return [] }
         guard let root = workspace?.workspaceFileManager?.getFile(folderURL.path) else { return [] }
         return [root]
+    }
+
+    var filteredContentChildren: [CEWorkspaceFile: [CEWorkspaceFile]] = [:]
+    var expandedItems: Set<CEWorkspaceFile> = []
+    var filter: String = "" {
+        didSet {
+            handleFilterChange()
+        }
     }
 
     weak var workspace: WorkspaceDocument?
@@ -94,6 +103,27 @@ final class ProjectNavigatorViewController: NSViewController {
         scrollView.autohidesScrollers = true
 
         outlineView.expandItem(outlineView.item(atRow: 0))
+
+        /// Get autosave expanded items.
+        for row in 0..<outlineView.numberOfRows {
+            if let item = outlineView.item(atRow: row) as? CEWorkspaceFile {
+                if outlineView.isItemExpanded(item) {
+                    expandedItems.insert(item)
+                }
+            }
+        }
+
+        /// "No Filter Results" label.
+        noResultsLabel = NSTextField(labelWithString: "No Filter Results")
+        noResultsLabel.isHidden = true
+        noResultsLabel.font = NSFont.systemFont(ofSize: 16)
+        noResultsLabel.textColor = NSColor.secondaryLabelColor
+        outlineView.addSubview(noResultsLabel)
+        noResultsLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            noResultsLabel.centerXAnchor.constraint(equalTo: outlineView.centerXAnchor),
+            noResultsLabel.centerYAnchor.constraint(equalTo: outlineView.centerYAnchor)
+        ])
     }
 
     init() {
@@ -103,6 +133,7 @@ final class ProjectNavigatorViewController: NSViewController {
     deinit {
         outlineView?.removeFromSuperview()
         scrollView?.removeFromSuperview()
+        noResultsLabel?.removeFromSuperview()
     }
 
     required init?(coder: NSCoder) {
@@ -155,5 +186,70 @@ final class ProjectNavigatorViewController: NSViewController {
         }
     }
 
-    // TODO: File filtering
+    private func handleFilterChange() {
+        filteredContentChildren.removeAll()
+        outlineView.reloadData()
+
+        /// If the filter is empty, show all items and restore the expanded state.
+        if filter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            restoreExpandedState()
+        } else {
+            /// Expand all items for search.
+            outlineView.expandItem(outlineView.item(atRow: 0), expandChildren: true)
+        }
+
+        noResultsLabel.isHidden = !(filteredContentChildren[content[0]]?.isEmpty ?? false)
+    }
+
+    /// Checks if the given filter matches the name of the item or any of its children.
+    func fileSearchMatches(_ filter: String, for item: CEWorkspaceFile) -> Bool {
+        guard !filter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return true }
+
+        if item.name.localizedLowercase.contains(filter.localizedLowercase) {
+            saveAllContentChildren(for: item)
+            return true
+        }
+
+        if let children = workspace?.workspaceFileManager?.childrenOfFile(item) {
+            return children.contains { fileSearchMatches(filter, for: $0) }
+        }
+
+        return false
+    }
+
+    /// Saves all children of a given folder item to the filtered content cache, this is specially useful when the name of a folder matches the search.
+    /// Just like in Xcode, this shows all the content of the folder.
+    private func saveAllContentChildren(for item: CEWorkspaceFile) {
+        guard item.isFolder, filteredContentChildren[item] == nil else { return }
+
+        if let children = workspace?.workspaceFileManager?.childrenOfFile(item) {
+            filteredContentChildren[item] = children
+            for child in children.filter({ $0.isFolder }) {
+                saveAllContentChildren(for: child)
+            }
+        }
+    }
+
+    /// Restores the expanded state of items in the outline view based on previously expanded items when finish searching.
+    private func restoreExpandedState() {
+        let copy = expandedItems
+        outlineView.collapseItem(outlineView.item(atRow: 0), collapseChildren: true)
+
+        for item in copy {
+            expandParentsRecursively(of: item)
+            outlineView.expandItem(item)
+        }
+
+        expandedItems = copy
+    }
+
+    /// Recursively expands all parent items of a given item in the outline view.
+    /// The order of the items may get lost in the `expandedItems` set.
+    /// This means that a children item might be expanded before its parent, causing it not to really expand.
+    private func expandParentsRecursively(of item: CEWorkspaceFile) {
+        if let parent = item.parent {
+            expandParentsRecursively(of: parent)
+            outlineView.expandItem(parent)
+        }
+    }
 }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
@@ -34,11 +34,6 @@ final class ProjectNavigatorViewController: NSViewController {
 
     var filteredContentChildren: [CEWorkspaceFile: [CEWorkspaceFile]] = [:]
     var expandedItems: Set<CEWorkspaceFile> = []
-    var filter: String = "" {
-        didSet {
-            handleFilterChange()
-        }
-    }
 
     weak var workspace: WorkspaceDocument?
 
@@ -186,14 +181,18 @@ final class ProjectNavigatorViewController: NSViewController {
         }
     }
 
-    private func handleFilterChange() {
+    func handleFilterChange() {
         filteredContentChildren.removeAll()
         outlineView.reloadData()
 
+        guard let workspace else { return }
+
         /// If the filter is empty, show all items and restore the expanded state.
-        if filter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if workspace.navigatorFilter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             restoreExpandedState()
+            outlineView.autosaveExpandedItems = true
         } else {
+            outlineView.autosaveExpandedItems = false
             /// Expand all items for search.
             outlineView.expandItem(outlineView.item(atRow: 0), expandChildren: true)
         }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
@@ -25,7 +25,7 @@ struct ProjectNavigatorToolbarBottom: View {
             addNewFileButton
             PaneTextField(
                 "Filter",
-                text: $workspace.filter,
+                text: $workspace.navigatorFilter,
                 leadingAccessories: {
                     FilterDropDownIconButton(menu: {
                         Button {
@@ -33,10 +33,10 @@ struct ProjectNavigatorToolbarBottom: View {
                         } label: {
                             Text(workspace.sortFoldersOnTop ? "Alphabetically" : "Folders on top")
                         }
-                    }, isOn: !workspace.filter.isEmpty)
+                    }, isOn: !workspace.navigatorFilter.isEmpty)
                     .padding(.leading, 4)
                     .foregroundStyle(
-                        workspace.filter.isEmpty
+                        workspace.navigatorFilter.isEmpty
                         ? Color(nsColor: .secondaryLabelColor)
                         : Color(nsColor: .controlAccentColor)
                     )
@@ -57,7 +57,7 @@ struct ProjectNavigatorToolbarBottom: View {
                     .padding(.trailing, 2.5)
                 },
                 clearable: true,
-                hasValue: !workspace.filter.isEmpty || recentsFilter || sourceControlFilter
+                hasValue: !workspace.navigatorFilter.isEmpty || recentsFilter || sourceControlFilter
             )
         }
         .padding(.horizontal, 5)
@@ -124,7 +124,7 @@ struct ProjectNavigatorToolbarBottom: View {
     /// when the user clears the filter.
     private var clearFilterButton: some View {
         Button {
-            workspace.filter = ""
+            workspace.navigatorFilter = ""
             NSApp.keyWindow?.makeFirstResponder(nil)
         } label: {
             Image(systemName: "xmark.circle.fill")

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
@@ -17,7 +17,6 @@ struct ProjectNavigatorToolbarBottom: View {
     @EnvironmentObject var workspace: WorkspaceDocument
     @EnvironmentObject var editorManager: EditorManager
 
-    @State var filter: String = ""
     @State var recentsFilter: Bool = false
     @State var sourceControlFilter: Bool = false
 
@@ -26,7 +25,7 @@ struct ProjectNavigatorToolbarBottom: View {
             addNewFileButton
             PaneTextField(
                 "Filter",
-                text: $filter,
+                text: $workspace.filter,
                 leadingAccessories: {
                     FilterDropDownIconButton(menu: {
                         Button {
@@ -34,10 +33,10 @@ struct ProjectNavigatorToolbarBottom: View {
                         } label: {
                             Text(workspace.sortFoldersOnTop ? "Alphabetically" : "Folders on top")
                         }
-                    }, isOn: !filter.isEmpty)
+                    }, isOn: !workspace.filter.isEmpty)
                     .padding(.leading, 4)
                     .foregroundStyle(
-                        filter.isEmpty
+                        workspace.filter.isEmpty
                         ? Color(nsColor: .secondaryLabelColor)
                         : Color(nsColor: .controlAccentColor)
                     )
@@ -58,12 +57,8 @@ struct ProjectNavigatorToolbarBottom: View {
                     .padding(.trailing, 2.5)
                 },
                 clearable: true,
-                hasValue: !filter.isEmpty || recentsFilter || sourceControlFilter
+                hasValue: !workspace.filter.isEmpty || recentsFilter || sourceControlFilter
             )
-            //            .onChange(of: filter, perform: {
-            // TODO: Filter Workspace Files
-            //                workspace.filter = $0
-            //            })
         }
         .padding(.horizontal, 5)
         .frame(height: 28, alignment: .center)
@@ -129,7 +124,7 @@ struct ProjectNavigatorToolbarBottom: View {
     /// when the user clears the filter.
     private var clearFilterButton: some View {
         Button {
-            filter = ""
+            workspace.filter = ""
             NSApp.keyWindow?.makeFirstResponder(nil)
         } label: {
             Image(systemName: "xmark.circle.fill")


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

This pull request adds the ability to search files and folders in the navigator area. The following features were added:

1. Typing in the "Filter" textfield now searches through files and folders.
2. When a folder matches the filter, all of its content appears.
3. When searching, all of the folders get expanded.
4. The state of the folders that were expanded by the user before searching gets saved, so that when they finish searching, everything returns back to place.
5. When searching, the characters/words in the file and folder names that match the search get **bold**.
6. When there are no search results a label "No Filter Results" appears.
7. The search, just like in Xcode, is case-insensitive.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1139

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

(From description list)
1. Typing in the "Filter" textfield now searches through files and folders.

https://github.com/user-attachments/assets/ef7a9806-c578-4077-933f-34c334a31ac2

2. When a folder matches the filter, all of its content appears.
3. When searching, all of the folders get expanded.
5. When searching, the characters/words in the file and folder names that match the search get **bold**.

https://github.com/user-attachments/assets/ef94d63a-b1d2-46ab-8c4c-2f5462fb08d9

4. The state of the folders that were expanded by the user before searching gets saved, so that when they finish searching, everything returns back to place.
 
https://github.com/user-attachments/assets/6085403e-18b5-4eeb-a929-62f84f095657

6. When there are no search results a label "No Filter Results" appears.
7. The search, just like in Xcode, is case-insensitive.

https://github.com/user-attachments/assets/65546fb5-baf1-473e-bc44-f2f1eac02d91









<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
