### PR TITLE
Fixes an issue where "Close Tabs to the Right" would also close the tab the action was performed on.

### DIFF
--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarContextMenu.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarContextMenu.swift
@@ -53,10 +53,11 @@ struct EditorTabBarContextMenu: ViewModifier {
                         }
                     }
                 }
+
                 Button("Close Tabs to the Right") {
                     withAnimation {
-                        if let index = tabs.tabs.firstIndex(where: { $0.file == item }) {
-                            tabs.tabs[index...].forEach {
+                        if let index = tabs.tabs.firstIndex(where: { $0.file == item }), index + 1 < tabs.tabs.count {
+                            tabs.tabs[(index + 1)...].forEach {
                                 tabs.closeTab(file: $0.file)
                             }
                         }


### PR DESCRIPTION

<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Currently, CodeEdit closes the tab where "Close Tabs to the Right" was used on, this doesn't happen in Xcode. Just starts deleting from `index + 1`, verifying the `index + 1` exists.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues


<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1900

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [ ] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

Before:

https://github.com/user-attachments/assets/c5395d7e-f9dd-440f-a7bf-8f6743223393

After:


https://github.com/user-attachments/assets/963e243b-0e20-4917-8420-9254e6c5cdb2

