### PR TITLE
Automatic Window Deminimization on Dock Icon Click

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -74,6 +74,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             return false
         }
 
+        /// Check if all windows are either miniaturized or not visible.
+        /// If so, attempt to find the first miniaturized window and deminiaturize it.
         guard sender.windows.allSatisfy({ $0.isMiniaturized || !$0.isVisible }) else { return false }
         sender.windows.first(where: { $0.isMiniaturized })?.deminiaturize(sender)
         return false

--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -69,12 +69,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if flag {
+        guard flag else {
+            handleOpen()
             return false
         }
 
-        handleOpen()
-
+        guard sender.windows.allSatisfy({ $0.isMiniaturized || !$0.isVisible }) else { return false }
+        sender.windows.first(where: { $0.isMiniaturized })?.deminiaturize(sender)
         return false
     }
 


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
When clicking the app icon in the dock, if no other windows are open, the app will now automatically deminimize a window. This behavior is consistent with the current functionality in Xcode.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1905 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

https://github.com/user-attachments/assets/b41d4774-0fc6-4c2d-9c3f-e0fa996f5d51

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
