### PR TITLE
Fix Edited Indicator Behavior

### DIFF
--- a/CodeEdit/Features/Editor/Views/CodeFileView.swift
+++ b/CodeEdit/Features/Editor/Views/CodeFileView.swift
@@ -80,6 +80,7 @@ struct CodeFileView: View {
             .textUpdatePublisher
             .debounce(for: 1.0, scheduler: DispatchQueue.main)
             .sink { _ in
+                // updateChangeCount is automatically managed by autosave(), so no manual call is necessary
                 codeFile.autosave(withImplicitCancellability: false) { error in
                     if let error {
                         CodeFileDocument.logger.error("Failed to autosave document, error: \(error)")

--- a/CodeEdit/Features/Editor/Views/CodeFileView.swift
+++ b/CodeEdit/Features/Editor/Views/CodeFileView.swift
@@ -83,8 +83,6 @@ struct CodeFileView: View {
                 codeFile.autosave(withImplicitCancellability: false) { error in
                     if let error {
                         CodeFileDocument.logger.error("Failed to autosave document, error: \(error)")
-                    } else {
-                        codeFile.updateChangeCount(.changeCleared)
                     }
                 }
             }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
The edited indicator behavior now properly updates and aligns with Xcode's implementation.

The autosave() method provided by NSDocument automatically calls updateChangeCount accordingly. The else block in the function executed regardless of whether autosaving occurred or was enabled, triggering an unintended cleared state. As such, removing the direct call to updateChangeCount(.changeCleared) resolved the issue as the change count state is now handled properly by the autosave() method.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1898 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

### With Manual Saving

https://github.com/user-attachments/assets/35f3f435-69d7-46a8-ba00-b79269ad03a7

### With Auto Save

https://github.com/user-attachments/assets/5ec5bde3-82f6-4f5c-b4d0-17439e4af85b



