### PR TITLE
Fix Navigator Area Label Truncation

### DIFF
--- a/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
@@ -165,7 +165,7 @@ extension FindNavigatorListViewController: NSOutlineViewDelegate {
     func outlineView(_ outlineView: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
         guard let tableColumn else { return nil }
         if let item = item as? SearchResultMatchModel {
-            let frameRect = NSRect(x: 0, y: 0, width: tableColumn.width, height: CGFloat.greatestFiniteMagnitude)
+            let frameRect = NSRect(x: 0, y: 0, width: tableColumn.width, height: outlineView.rowHeight)
             return FindNavigatorListMatchCell(frame: frameRect, matchItem: item)
         } else {
             let frameRect = NSRect(

--- a/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorResultList/FindNavigatorMatchListCell.swift
+++ b/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorResultList/FindNavigatorMatchListCell.swift
@@ -20,7 +20,7 @@ final class FindNavigatorListMatchCell: NSTableCellView {
             x: frame.origin.x,
             y: frame.origin.y,
             width: frame.width,
-            height: CGFloat.greatestFiniteMagnitude
+            height: frame.height
         ))
 
         // Create the label

--- a/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
@@ -46,55 +46,45 @@ class FileSystemTableViewCell: StandardTableViewCell {
         imageView?.contentTintColor = color(for: item)
 
         let fileName = item.labelFileName()
+        let fontSize = textField?.font?.pointSize ?? 12
 
-        guard let navigatorFilter else {
+        guard let filter = navigatorFilter?.trimmingCharacters(in: .whitespacesAndNewlines), !filter.isEmpty else {
             textField?.stringValue = fileName
             return
         }
 
-        // Apply bold style if the filename matches the workspace filter
-        if !navigatorFilter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let attributedString = NSMutableAttributedString(string: fileName)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = .byTruncatingMiddle
 
-            // Check if the filename contains the filter text
-            let range = NSString(string: fileName).range(of: navigatorFilter, options: .caseInsensitive)
-            if range.location != NSNotFound {
-                // Set the label color to secondary
-                attributedString.addAttribute(
-                    .foregroundColor,
-                    value: NSColor.secondaryLabelColor,
-                    range: NSRange(location: 0, length: attributedString.length)
-                )
+        /// Initialize default attributes
+        let attributedString = NSMutableAttributedString(string: fileName, attributes: [
+            .paragraphStyle: paragraphStyle,
+            .font: NSFont.systemFont(ofSize: fontSize),
+            .foregroundColor: NSColor.secondaryLabelColor
+        ])
 
-                // If the filter text matches, bold the matching text and set primary label color
-                attributedString.addAttributes(
-                    [
-                        .font: NSFont.boldSystemFont(ofSize: textField?.font?.pointSize ?? 12),
-.foregroundColor: NSColor.labelColor
-                    ],
-                    range: range
-                )
-            } else {
-                // If no match, apply primary label color for parent folder,
-                // or secondary label color for a non-matching file
-                attributedString.addAttribute(
-                    .foregroundColor,
-                    value: item.isFolder ? NSColor.labelColor : NSColor.secondaryLabelColor,
-                    range: NSRange(location: 0, length: attributedString.length)
-                )
-            }
-
-            textField?.attributedStringValue = attributedString
-        } else {
-            // If no filter is applied, reset to normal font and primary label color
-            textField?.attributedStringValue = NSAttributedString(
-                string: fileName,
-                attributes: [
-                    .font: NSFont.systemFont(ofSize: textField?.font?.pointSize ?? 12),
+        /// Check if the filename contains the filter text
+        let range = (fileName as NSString).range(of: filter, options: .caseInsensitive)
+        if range.location != NSNotFound {
+            /// If the filter text matches, bold the matching text and set primary label color
+            attributedString.addAttributes(
+                [
+                    .font: NSFont.boldSystemFont(ofSize: fontSize),
                     .foregroundColor: NSColor.labelColor
-                ]
+                ],
+                range: range
+            )
+        } else {
+            /// If no match, apply primary label color for parent folder,
+            /// or secondary label color for a non-matching file
+            attributedString.addAttribute(
+                .foregroundColor,
+                value: item.isFolder ? NSColor.labelColor : NSColor.secondaryLabelColor,
+                range: NSRange(location: 0, length: attributedString.length)
             )
         }
+
+        textField?.attributedStringValue = attributedString
     }
 
     func addModel() {


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

- Adjusted logic for labels within the Navigator Area so that they truncate properly in all areas
- Resolved an invalid frame error related to the height when using the search feature

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1911 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/e5bdeacc-6b50-48e9-9858-e862b0a6ce7e

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
