### PR TITLE
Add Command to Hide Interface

### DIFF
--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -112,7 +112,7 @@ extension ViewCommands {
             windowController?.toolbarCollapsed ?? true
         }
 
-        private var labelForInterfaceToggle: String {
+        private var interfaceToggleLabel: String {
             let shouldShow = navigatorCollapsed && inspectorCollapsed &&
                              toolbarCollapsed && !showEditorPathBar
             return "\(shouldShow ? "Show" : "Hide") Interface"
@@ -149,7 +149,7 @@ extension ViewCommands {
             .disabled(windowController == nil)
             .keyboardShortcut("t", modifiers: [.option, .command])
 
-            Button(labelForInterfaceToggle) {
+            Button(interfaceToggleLabel) {
                 if isAnyPanelVisible {
                     if !navigatorCollapsed {
                         windowController?.toggleFirstPanel()

--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -71,7 +71,7 @@ struct ViewCommands: Commands {
 
             Divider()
 
-            HideCommands()
+            HideCommands(showEditorPathBar: $showEditorPathBar)
 
             Divider()
 
@@ -94,6 +94,7 @@ struct ViewCommands: Commands {
 extension ViewCommands {
     struct HideCommands: View {
         @UpdatingWindowController var windowController: CodeEditWindowController?
+        @Binding var showEditorPathBar: Bool
 
         var navigatorCollapsed: Bool {
             windowController?.navigatorCollapsed ?? true
@@ -109,6 +110,18 @@ extension ViewCommands {
 
         var toolbarCollapsed: Bool {
             windowController?.toolbarCollapsed ?? true
+        }
+
+        private var labelForInterfaceToggle: String {
+            let shouldShow = navigatorCollapsed && inspectorCollapsed &&
+                             toolbarCollapsed && !showEditorPathBar
+            return "\(shouldShow ? "Show" : "Hide") Interface"
+        }
+
+        private var isAnyPanelVisible: Bool {
+            return !navigatorCollapsed || !inspectorCollapsed ||
+                   !utilityAreaCollapsed || !toolbarCollapsed ||
+                   showEditorPathBar
         }
 
         var body: some View {
@@ -135,6 +148,39 @@ extension ViewCommands {
             }
             .disabled(windowController == nil)
             .keyboardShortcut("t", modifiers: [.option, .command])
+
+            Button(labelForInterfaceToggle) {
+                if isAnyPanelVisible {
+                    if !navigatorCollapsed {
+                        windowController?.toggleFirstPanel()
+                    }
+
+                    if !inspectorCollapsed {
+                        windowController?.toggleLastPanel()
+                    }
+
+                    if !utilityAreaCollapsed {
+                        CommandManager.shared.executeCommand("open.drawer")
+                    }
+
+                    if !toolbarCollapsed {
+                        windowController?.toggleToolbar()
+                    }
+
+                    if showEditorPathBar {
+                        showEditorPathBar.toggle()
+                    }
+
+                } else {
+                    // If all are closed, you can choose to open them again
+                    windowController?.toggleFirstPanel()
+                    windowController?.toggleLastPanel()
+                    windowController?.toggleToolbar()
+                    showEditorPathBar.toggle()
+                }
+            }
+            .disabled(windowController == nil)
+            .keyboardShortcut(".", modifiers: [.command])
         }
     }
 }


### PR DESCRIPTION

<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

At the moment this code, toggles navigator, inspector, utility, pathbar and toolbar area and handles all cases for each of them when using hide interface.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1632

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- 


[x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/b5d9f27c-7a1d-4fcd-a2ce-79f4470cb0f2


<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
