### PR TITLE
Update Recently Opened Menu

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -108,7 +108,7 @@
 		581BFB672926431000D251EC /* WelcomeWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581BFB5A2926431000D251EC /* WelcomeWindowView.swift */; };
 		581BFB682926431000D251EC /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581BFB5B2926431000D251EC /* WelcomeView.swift */; };
 		581BFB692926431000D251EC /* WelcomeActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581BFB5C2926431000D251EC /* WelcomeActionView.swift */; };
-		581BFB6B2926431000D251EC /* RecentProjectItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581BFB5E2926431000D251EC /* RecentProjectItem.swift */; };
+		581BFB6B2926431000D251EC /* RecentProjectListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581BFB5E2926431000D251EC /* RecentProjectListItem.swift */; };
 		582213F0291834A500EFE361 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582213EF291834A500EFE361 /* AboutView.swift */; };
 		583E528C29361B39001AB554 /* CodeEditUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583E527529361B39001AB554 /* CodeEditUITests.swift */; };
 		583E528D29361B39001AB554 /* testHelpButtonDark.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 583E527929361B39001AB554 /* testHelpButtonDark.1.png */; };
@@ -383,6 +383,9 @@
 		6C2C155A29B4F4CC00EA60A5 /* Variadic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2C155929B4F4CC00EA60A5 /* Variadic.swift */; };
 		6C2C155D29B4F4E500EA60A5 /* SplitViewReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2C155C29B4F4E500EA60A5 /* SplitViewReader.swift */; };
 		6C2C156129B4F52F00EA60A5 /* SplitViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2C156029B4F52F00EA60A5 /* SplitViewModifiers.swift */; };
+		6C3E12D32CC830D700DD12F1 /* RecentProjectsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C3E12D22CC830D700DD12F1 /* RecentProjectsStore.swift */; };
+		6C3E12D62CC8388000DD12F1 /* URL+componentCompare.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C3E12D52CC8388000DD12F1 /* URL+componentCompare.swift */; };
+		6C3E12D82CC83CB600DD12F1 /* RecentProjectsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C3E12D72CC83CB600DD12F1 /* RecentProjectsMenu.swift */; };
 		6C4104E3297C87A000F472BA /* BlurButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4104E2297C87A000F472BA /* BlurButtonStyle.swift */; };
 		6C4104E6297C884F00F472BA /* AboutDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4104E5297C884F00F472BA /* AboutDetailView.swift */; };
 		6C4104E9297C970F00F472BA /* AboutDefaultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4104E8297C970F00F472BA /* AboutDefaultView.swift */; };
@@ -451,6 +454,7 @@
 		6CBA0D512A1BF524002C6FAA /* SegmentedControlImproved.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBA0D502A1BF524002C6FAA /* SegmentedControlImproved.swift */; };
 		6CBD1BC62978DE53006639D5 /* Font+Caption3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBD1BC52978DE53006639D5 /* Font+Caption3.swift */; };
 		6CBE1CFB2B71DAA6003AC32E /* Loopable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBE1CFA2B71DAA6003AC32E /* Loopable.swift */; };
+		6CC00A8B2CBEF150004E8134 /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6CC00A8A2CBEF150004E8134 /* CodeEditSourceEditor */; };
 		6CC17B4F2C432AE000834E2C /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6CC17B4E2C432AE000834E2C /* CodeEditSourceEditor */; };
 		6CC17B512C43311900834E2C /* ProjectNavigatorViewController+NSOutlineViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC17B502C43311900834E2C /* ProjectNavigatorViewController+NSOutlineViewDataSource.swift */; };
 		6CC17B532C43314000834E2C /* ProjectNavigatorViewController+NSOutlineViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC17B522C43314000834E2C /* ProjectNavigatorViewController+NSOutlineViewDelegate.swift */; };
@@ -464,7 +468,6 @@
 		6CD26C7B2C8EA8A500ADBA38 /* LSPCache+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD26C792C8EA8A500ADBA38 /* LSPCache+Data.swift */; };
 		6CD26C7D2C8EA8F400ADBA38 /* LanguageServer+DocumentSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD26C7C2C8EA8F400ADBA38 /* LanguageServer+DocumentSync.swift */; };
 		6CD26C812C8F8A4400ADBA38 /* LanguageIdentifier+CodeLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD26C802C8F8A4400ADBA38 /* LanguageIdentifier+CodeLanguage.swift */; };
-		6CD26C852C8F907800ADBA38 /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6CD26C842C8F907800ADBA38 /* CodeEditSourceEditor */; };
 		6CD26C872C8F90FD00ADBA38 /* LazyServiceWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD26C862C8F90FD00ADBA38 /* LazyServiceWrapper.swift */; };
 		6CD26C8A2C8F91ED00ADBA38 /* LanguageServer+DocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD26C892C8F91ED00ADBA38 /* LanguageServer+DocumentTests.swift */; };
 		6CD3CA552C8B508200D83DCD /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6CD3CA542C8B508200D83DCD /* CodeEditSourceEditor */; };
@@ -785,7 +788,7 @@
 		581BFB5A2926431000D251EC /* WelcomeWindowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeWindowView.swift; sourceTree = "<group>"; };
 		581BFB5B2926431000D251EC /* WelcomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		581BFB5C2926431000D251EC /* WelcomeActionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeActionView.swift; sourceTree = "<group>"; };
-		581BFB5E2926431000D251EC /* RecentProjectItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentProjectItem.swift; sourceTree = "<group>"; };
+		581BFB5E2926431000D251EC /* RecentProjectListItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentProjectListItem.swift; sourceTree = "<group>"; };
 		582213EF291834A500EFE361 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		583E527529361B39001AB554 /* CodeEditUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeEditUITests.swift; sourceTree = "<group>"; };
 		583E527929361B39001AB554 /* testHelpButtonDark.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testHelpButtonDark.1.png; sourceTree = "<group>"; };
@@ -1058,6 +1061,9 @@
 		6C2C155929B4F4CC00EA60A5 /* Variadic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variadic.swift; sourceTree = "<group>"; };
 		6C2C155C29B4F4E500EA60A5 /* SplitViewReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewReader.swift; sourceTree = "<group>"; };
 		6C2C156029B4F52F00EA60A5 /* SplitViewModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewModifiers.swift; sourceTree = "<group>"; };
+		6C3E12D22CC830D700DD12F1 /* RecentProjectsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentProjectsStore.swift; sourceTree = "<group>"; };
+		6C3E12D52CC8388000DD12F1 /* URL+componentCompare.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+componentCompare.swift"; sourceTree = "<group>"; };
+		6C3E12D72CC83CB600DD12F1 /* RecentProjectsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentProjectsMenu.swift; sourceTree = "<group>"; };
 		6C4104E2297C87A000F472BA /* BlurButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurButtonStyle.swift; sourceTree = "<group>"; };
 		6C4104E5297C884F00F472BA /* AboutDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutDetailView.swift; sourceTree = "<group>"; };
 		6C4104E8297C970F00F472BA /* AboutDefaultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutDefaultView.swift; sourceTree = "<group>"; };
@@ -1303,6 +1309,7 @@
 				58F2EB1E292FB954004A9BDE /* Sparkle in Frameworks */,
 				6C147C4529A329350089B630 /* OrderedCollections in Frameworks */,
 				6CE21E872C650D2C0031B056 /* SwiftTerm in Frameworks */,
+				6CC00A8B2CBEF150004E8134 /* CodeEditSourceEditor in Frameworks */,
 				6CD3CA552C8B508200D83DCD /* CodeEditSourceEditor in Frameworks */,
 				6C0617D62BDB4432008C9C42 /* LogStream in Frameworks */,
 				6CC17B4F2C432AE000834E2C /* CodeEditSourceEditor in Frameworks */,
@@ -1312,7 +1319,6 @@
 				6C85BB442C210EFD00EB5DEF /* SwiftUIIntrospect in Frameworks */,
 				6CB446402B6DFF3A00539ED0 /* CodeEditSourceEditor in Frameworks */,
 				2816F594280CF50500DD548B /* CodeEditSymbols in Frameworks */,
-				6CD26C852C8F907800ADBA38 /* CodeEditSourceEditor in Frameworks */,
 				30CB64942C16CA9100CC8A9E /* LanguageClient in Frameworks */,
 				6C6BD6F829CD14D100235D17 /* CodeEditKit in Frameworks */,
 				6C0824A12C5C0C9700A0751E /* SwiftTerm in Frameworks */,
@@ -1644,6 +1650,7 @@
 		581BFB4B2926431000D251EC /* Welcome */ = {
 			isa = PBXGroup;
 			children = (
+				6C3E12D42CC830DE00DD12F1 /* Model */,
 				581BFB562926431000D251EC /* Views */,
 			);
 			path = Welcome;
@@ -1657,7 +1664,7 @@
 				581BFB5B2926431000D251EC /* WelcomeView.swift */,
 				581BFB5C2926431000D251EC /* WelcomeActionView.swift */,
 				6C186209298BF5A800C663EA /* RecentProjectsListView.swift */,
-				581BFB5E2926431000D251EC /* RecentProjectItem.swift */,
+				581BFB5E2926431000D251EC /* RecentProjectListItem.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2858,6 +2865,14 @@
 			path = ChangedFile;
 			sourceTree = "<group>";
 		};
+		6C3E12D42CC830DE00DD12F1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				6C3E12D22CC830D700DD12F1 /* RecentProjectsStore.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		6C48B5DB2C0D664A001E9955 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -2910,8 +2925,9 @@
 			children = (
 				B66A4E4429C8E86D004573B4 /* CommandsFixes.swift */,
 				6C82D6BB29C00CD900495C54 /* FirstResponderPropertyWrapper.swift */,
-				6CC17B5A2C44258700834E2C /* WindowControllerPropertyWrapper.swift */,
+				6C3E12D72CC83CB600DD12F1 /* RecentProjectsMenu.swift */,
 				6CD035892C3461160091E1F4 /* KeyWindowControllerObserver.swift */,
+				6CC17B5A2C44258700834E2C /* WindowControllerPropertyWrapper.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3087,6 +3103,7 @@
 			children = (
 				77EF6C032C57DE4B00984B69 /* URL+ResouceValues.swift */,
 				77EF6C0A2C60C80800984B69 /* URL+Filename.swift */,
+				6C3E12D52CC8388000DD12F1 /* URL+componentCompare.swift */,
 			);
 			path = URL;
 			sourceTree = "<group>";
@@ -3696,8 +3713,8 @@
 				6CE21E862C650D2C0031B056 /* SwiftTerm */,
 				6C4E37FB2C73E00700AEE7B5 /* SwiftTerm */,
 				6CD3CA542C8B508200D83DCD /* CodeEditSourceEditor */,
-				6CD26C842C8F907800ADBA38 /* CodeEditSourceEditor */,
 				6CB94D022CA1205100E8651C /* AsyncAlgorithms */,
+				6CC00A8A2CBEF150004E8134 /* CodeEditSourceEditor */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -3794,8 +3811,8 @@
 				303E88452C276FD100EEA8D9 /* XCRemoteSwiftPackageReference "LanguageClient" */,
 				303E88462C276FD600EEA8D9 /* XCRemoteSwiftPackageReference "LanguageServerProtocol" */,
 				6C4E37FA2C73E00700AEE7B5 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
-				6CD26C832C8F907800ADBA38 /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */,
 				6CB94D012CA1205100E8651C /* XCRemoteSwiftPackageReference "swift-async-algorithms" */,
+				6CC00A892CBEF150004E8134 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */,
 			);
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
 			projectDirPath = "";
@@ -4090,6 +4107,7 @@
 				587B9E8229301D8F00AC7927 /* GitHubPreviewHeader.swift in Sources */,
 				611191FC2B08CCB800D4459B /* SearchIndexer+AsyncController.swift in Sources */,
 				B6966A282C2F683300259C2D /* SourceControlPullView.swift in Sources */,
+				6C3E12D32CC830D700DD12F1 /* RecentProjectsStore.swift in Sources */,
 				30B088112C0D53080063A882 /* LanguageServer+SignatureHelp.swift in Sources */,
 				6C578D8929CD36E400DC73B2 /* Commands+ForEach.swift in Sources */,
 				611192082B08CCFD00D4459B /* SearchIndexer+Terms.swift in Sources */,
@@ -4132,6 +4150,7 @@
 				58798238292E30B90085B254 /* FeedbackWindowController.swift in Sources */,
 				B6CFD80D2C1B9A8000E63F1A /* FontWeightPicker.swift in Sources */,
 				587B9E6C29301D8F00AC7927 /* GitLabNamespace.swift in Sources */,
+				6C3E12D82CC83CB600DD12F1 /* RecentProjectsMenu.swift in Sources */,
 				30AB4EC22BF7253200ED4431 /* KeyValueTable.swift in Sources */,
 				6139B9142C29B35D00CA584B /* TaskManager.swift in Sources */,
 				6C48D8F22972DAFC00D6D205 /* Env+IsFullscreen.swift in Sources */,
@@ -4218,7 +4237,7 @@
 				6CB9144B29BEC7F100BC47F2 /* (null) in Sources */,
 				587B9E7429301D8F00AC7927 /* URL+URLParameters.swift in Sources */,
 				61538B902B111FE800A88846 /* String+AppearancesOfSubstring.swift in Sources */,
-				581BFB6B2926431000D251EC /* RecentProjectItem.swift in Sources */,
+				581BFB6B2926431000D251EC /* RecentProjectListItem.swift in Sources */,
 				587FB99029C1246400B519DD /* EditorTabView.swift in Sources */,
 				587B9DA429300ABD00AC7927 /* SearchPanel.swift in Sources */,
 				58D01C95293167DC00C5B6B4 /* Bundle+Info.swift in Sources */,
@@ -4244,6 +4263,7 @@
 				581550D429FBD37D00684881 /* ProjectNavigatorToolbarBottom.swift in Sources */,
 				66AF6CE72BF17FFB00D83C9D /* UpdateStatusBarInfo.swift in Sources */,
 				587B9E7E29301D8F00AC7927 /* GitHubGistRouter.swift in Sources */,
+				6C3E12D62CC8388000DD12F1 /* URL+componentCompare.swift in Sources */,
 				B6AB09A52AAAC00F0003A3A6 /* EditorTabBarTrailingAccessories.swift in Sources */,
 				04BA7C0B2AE2A2D100584E1C /* GitBranch.swift in Sources */,
 				6CAAF69229BCC71C00A1F48A /* (null) in Sources */,
@@ -5562,6 +5582,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		6CC00A892CBEF150004E8134 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../CodeEditSourceEditor;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -5691,14 +5718,6 @@
 				version = 1.0.1;
 			};
 		};
-		6CD26C832C8F907800ADBA38 /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.8.1;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -5789,13 +5808,12 @@
 			package = 6CB94D012CA1205100E8651C /* XCRemoteSwiftPackageReference "swift-async-algorithms" */;
 			productName = AsyncAlgorithms;
 		};
-		6CC17B4E2C432AE000834E2C /* CodeEditSourceEditor */ = {
+		6CC00A8A2CBEF150004E8134 /* CodeEditSourceEditor */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = CodeEditSourceEditor;
 		};
-		6CD26C842C8F907800ADBA38 /* CodeEditSourceEditor */ = {
+		6CC17B4E2C432AE000834E2C /* CodeEditSourceEditor */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6CD26C832C8F907800ADBA38 /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */;
 			productName = CodeEditSourceEditor;
 		};
 		6CD3CA542C8B508200D83DCD /* CodeEditSourceEditor */ = {

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -357,6 +357,7 @@
 		66F370342BEE537B00D3B823 /* NonTextFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F370332BEE537B00D3B823 /* NonTextFileView.swift */; };
 		6C049A372A49E2DB00D42923 /* DirectoryEventStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C049A362A49E2DB00D42923 /* DirectoryEventStream.swift */; };
 		6C05A8AF284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */; };
+		6C05CF9E2CDE8699006AAECD /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6C05CF9D2CDE8699006AAECD /* CodeEditSourceEditor */; };
 		6C0617D62BDB4432008C9C42 /* LogStream in Frameworks */ = {isa = PBXBuildFile; productRef = 6C0617D52BDB4432008C9C42 /* LogStream */; };
 		6C08249C2C556F7400A0751E /* TerminalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C08249B2C556F7400A0751E /* TerminalCache.swift */; };
 		6C08249E2C55768400A0751E /* UtilityAreaTerminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C08249D2C55768400A0751E /* UtilityAreaTerminal.swift */; };
@@ -1318,6 +1319,7 @@
 				6C6BD6F429CD142C00235D17 /* CollectionConcurrencyKit in Frameworks */,
 				6C85BB442C210EFD00EB5DEF /* SwiftUIIntrospect in Frameworks */,
 				6CB446402B6DFF3A00539ED0 /* CodeEditSourceEditor in Frameworks */,
+				6C05CF9E2CDE8699006AAECD /* CodeEditSourceEditor in Frameworks */,
 				2816F594280CF50500DD548B /* CodeEditSymbols in Frameworks */,
 				30CB64942C16CA9100CC8A9E /* LanguageClient in Frameworks */,
 				6C6BD6F829CD14D100235D17 /* CodeEditKit in Frameworks */,
@@ -3715,6 +3717,7 @@
 				6CD3CA542C8B508200D83DCD /* CodeEditSourceEditor */,
 				6CB94D022CA1205100E8651C /* AsyncAlgorithms */,
 				6CC00A8A2CBEF150004E8134 /* CodeEditSourceEditor */,
+				6C05CF9D2CDE8699006AAECD /* CodeEditSourceEditor */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -3812,7 +3815,7 @@
 				303E88462C276FD600EEA8D9 /* XCRemoteSwiftPackageReference "LanguageServerProtocol" */,
 				6C4E37FA2C73E00700AEE7B5 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
 				6CB94D012CA1205100E8651C /* XCRemoteSwiftPackageReference "swift-async-algorithms" */,
-				6CC00A892CBEF150004E8134 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */,
+				6C05CF9C2CDE8699006AAECD /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */,
 			);
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
 			projectDirPath = "";
@@ -5582,13 +5585,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		6CC00A892CBEF150004E8134 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../CodeEditSourceEditor;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -5652,6 +5648,14 @@
 			requirement = {
 				kind = exactVersion;
 				version = 2.3.0;
+			};
+		};
+		6C05CF9C2CDE8699006AAECD /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.8.1;
 			};
 		};
 		6C0617D42BDB4432008C9C42 /* XCRemoteSwiftPackageReference "LogStream" */ = {
@@ -5745,6 +5749,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 58F2EB1C292FB954004A9BDE /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		6C05CF9D2CDE8699006AAECD /* CodeEditSourceEditor */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6C05CF9C2CDE8699006AAECD /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */;
+			productName = CodeEditSourceEditor;
 		};
 		6C0617D52BDB4432008C9C42 /* LogStream */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5c4a5d433333474763817b9804d7f1856ab3b416ed87b190a2bd6e86c0c9834c",
+  "originHash" : "454498edc6f3f47f3616318caf54005bbbfd026d4f4355edda503b072bfe9814",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -26,15 +26,6 @@
       "state" : {
         "revision" : "5b27f139269e1ea49ceae5e56dca44a3ccad50a1",
         "version" : "0.1.19"
-      }
-    },
-    {
-      "identity" : "codeeditsourceeditor",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
-      "state" : {
-        "revision" : "033b68d3e3e845984fbc3d405720d5cc6ce61f71",
-        "version" : "0.8.1"
       }
     },
     {

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "454498edc6f3f47f3616318caf54005bbbfd026d4f4355edda503b072bfe9814",
+  "originHash" : "aef43d6aa0c467418565c574c33495a50d6e24057eb350c17704ab4ae2aead6c",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "5b27f139269e1ea49ceae5e56dca44a3ccad50a1",
         "version" : "0.1.19"
+      }
+    },
+    {
+      "identity" : "codeeditsourceeditor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
+      "state" : {
+        "revision" : "033b68d3e3e845984fbc3d405720d5cc6ce61f71",
+        "version" : "0.8.1"
       }
     },
     {

--- a/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
@@ -41,10 +41,6 @@ final class CodeEditDocumentController: NSDocumentController {
         return panel.url
     }
 
-    override func noteNewRecentDocument(_ document: NSDocument) {
-        // The super method is run manually when opening new documents.
-    }
-
     override func openDocument(_ sender: Any?) {
         self.openDocument(onCompletion: { document, documentWasAlreadyOpen in
             // TODO: handle errors
@@ -63,17 +59,16 @@ final class CodeEditDocumentController: NSDocumentController {
         display displayDocument: Bool,
         completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void
     ) {
-        super.noteNewRecentDocumentURL(url)
         super.openDocument(withContentsOf: url, display: displayDocument) { document, documentWasAlreadyOpen, error in
 
             if let document {
                 self.addDocument(document)
-                self.updateRecent(url)
             } else {
                 let errorMessage = error?.localizedDescription ?? "unknown error"
                 print("Unable to open document '\(url)': \(errorMessage)")
             }
 
+            RecentProjectsStore.documentOpened(at: url)
             completionHandler(document, documentWasAlreadyOpen, error)
         }
     }
@@ -138,7 +133,6 @@ extension NSDocumentController {
                         alert.runModal()
                         return
                     }
-                    self.updateRecent(url)
                     onCompletion(document, documentWasAlreadyOpen)
                     print("Document:", document)
                     print("Was already open?", documentWasAlreadyOpen)
@@ -147,17 +141,5 @@ extension NSDocumentController {
                 onCancel()
             }
         }
-    }
-
-    final func updateRecent(_ url: URL) {
-        var recentProjectPaths: [String] = UserDefaults.standard.array(
-            forKey: "recentProjectPaths"
-        ) as? [String] ?? []
-        if let containedIndex = recentProjectPaths.firstIndex(of: url.path) {
-            recentProjectPaths.move(fromOffsets: IndexSet(integer: containedIndex), toOffset: 0)
-        } else {
-            recentProjectPaths.insert(url.path, at: 0)
-        }
-        UserDefaults.standard.set(recentProjectPaths, forKey: "recentProjectPaths")
     }
 }

--- a/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
@@ -93,11 +93,6 @@ final class CodeEditDocumentController: NSDocumentController {
         }
     }
 
-    override func clearRecentDocuments(_ sender: Any?) {
-        super.clearRecentDocuments(sender)
-        UserDefaults.standard.set([Any](), forKey: "recentProjectPaths")
-    }
-
     override func addDocument(_ document: NSDocument) {
         super.addDocument(document)
         if let document = document as? CodeFileDocument {

--- a/CodeEdit/Features/Welcome/Model/RecentProjectsStore.swift
+++ b/CodeEdit/Features/Welcome/Model/RecentProjectsStore.swift
@@ -39,7 +39,7 @@ enum RecentProjectsStore {
         }
 
         // Limit list to to 100 items after de-duplication
-        UserDefaults.standard.setValue(paths.prefix(100), forKey: defaultsKey)
+        UserDefaults.standard.setValue(Array(paths.prefix(100)), forKey: defaultsKey)
         donateSearchableItems()
         NotificationCenter.default.post(name: Self.didUpdateNotification, object: nil)
     }

--- a/CodeEdit/Features/Welcome/Model/RecentProjectsStore.swift
+++ b/CodeEdit/Features/Welcome/Model/RecentProjectsStore.swift
@@ -80,7 +80,7 @@ enum RecentProjectsStore {
             CodeEditDocumentController.shared.noteNewRecentDocumentURL(path)
         }
     }
-    
+
     /// Donates all recent URLs to Core Search, making them searchable in Spotlight
     private static func donateSearchableItems() {
         let searchableItems = recentProjectURLs().map { entity in

--- a/CodeEdit/Features/Welcome/Model/RecentProjectsStore.swift
+++ b/CodeEdit/Features/Welcome/Model/RecentProjectsStore.swift
@@ -40,6 +40,7 @@ enum RecentProjectsStore {
 
         // Limit list to to 100 items after de-duplication
         UserDefaults.standard.setValue(Array(paths.prefix(100)), forKey: defaultsKey)
+        setDocumentControllerRecents()
         donateSearchableItems()
         NotificationCenter.default.post(name: Self.didUpdateNotification, object: nil)
     }
@@ -72,6 +73,15 @@ enum RecentProjectsStore {
         setPaths([])
     }
 
+    /// Syncs AppKit's recent documents list with ours, keeping the dock menu and other lists up-to-date.
+    private static func setDocumentControllerRecents() {
+        CodeEditDocumentController.shared.clearRecentDocuments(nil)
+        for path in recentProjectURLs().prefix(10) {
+            CodeEditDocumentController.shared.noteNewRecentDocumentURL(path)
+        }
+    }
+    
+    /// Donates all recent URLs to Core Search, making them searchable in Spotlight
     private static func donateSearchableItems() {
         let searchableItems = recentProjectURLs().map { entity in
             let attributeSet = CSSearchableItemAttributeSet(contentType: .content)

--- a/CodeEdit/Features/Welcome/Model/RecentProjectsStore.swift
+++ b/CodeEdit/Features/Welcome/Model/RecentProjectsStore.swift
@@ -1,0 +1,92 @@
+//
+//  RecentProjectsUtil.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 10/22/24.
+//
+
+import AppKit
+import CoreSpotlight
+
+/// Helper methods for managing the recent projects list and donating list items to CoreSpotlight.
+///
+/// Limits the number of remembered projects to 100 items.
+///
+/// If a UI element needs to listen to changes in this list, listen for the
+/// ``RecentProjectsStore/didUpdateNotification`` notification.
+enum RecentProjectsStore {
+    private static let defaultsKey = "recentProjectPaths"
+    static let didUpdateNotification = Notification.Name("RecentProjectsStore.didUpdate")
+
+    static func recentProjectPaths() -> [String] {
+        UserDefaults.standard.array(forKey: defaultsKey) as? [String] ?? []
+    }
+
+    static func recentProjectURLs() -> [URL] {
+        recentProjectPaths().map { URL(filePath: $0) }
+    }
+
+    private static func setPaths(_ paths: [String]) {
+        var paths = paths
+        // Remove duplicates
+        var foundPaths = Set<String>()
+        for (idx, path) in paths.enumerated().reversed() {
+            if foundPaths.contains(path) {
+                paths.remove(at: idx)
+            } else {
+                foundPaths.insert(path)
+            }
+        }
+
+        // Limit list to to 100 items after de-duplication
+        UserDefaults.standard.setValue(paths.prefix(100), forKey: defaultsKey)
+        donateSearchableItems()
+        NotificationCenter.default.post(name: Self.didUpdateNotification, object: nil)
+    }
+
+    /// Notify the store that a url was opened.
+    /// Moves the path to the front if it was in the list already, or prepends it.
+    /// Saves the list to defaults when called.
+    /// - Parameter url: The url that was opened. Any url is accepted. File, directory, https.
+    static func documentOpened(at url: URL) {
+        var paths = recentProjectURLs()
+        if let containedIndex = paths.firstIndex(where: { $0.componentCompare(url) }) {
+            paths.move(fromOffsets: IndexSet(integer: containedIndex), toOffset: 0)
+        } else {
+            paths.insert(url, at: 0)
+        }
+        setPaths(paths.map { $0.path(percentEncoded: false) })
+    }
+
+    /// Remove all paths in the set.
+    /// - Parameter paths: The paths to remove.
+    /// - Returns: The remaining urls in the recent projects list.
+    static func removeRecentProjects(_ paths: Set<URL>) -> [URL] {
+        var recentProjectPaths = recentProjectURLs()
+        recentProjectPaths.removeAll(where: { paths.contains($0) })
+        setPaths(recentProjectPaths.map { $0.path(percentEncoded: false) })
+        return recentProjectURLs()
+    }
+
+    static func clearList() {
+        setPaths([])
+    }
+
+    private static func donateSearchableItems() {
+        let searchableItems = recentProjectURLs().map { entity in
+            let attributeSet = CSSearchableItemAttributeSet(contentType: .content)
+            attributeSet.title = entity.lastPathComponent
+            attributeSet.relatedUniqueIdentifier = entity.path()
+            return CSSearchableItem(
+                uniqueIdentifier: entity.path(),
+                domainIdentifier: "app.codeedit.CodeEdit.ProjectItem",
+                attributeSet: attributeSet
+            )
+        }
+        CSSearchableIndex.default().indexSearchableItems(searchableItems) { error in
+            if let error = error {
+                print(error)
+            }
+        }
+    }
+}

--- a/CodeEdit/Features/Welcome/Views/RecentProjectListItem.swift
+++ b/CodeEdit/Features/Welcome/Views/RecentProjectListItem.swift
@@ -1,5 +1,5 @@
 //
-//  RecentProjectItem.swift
+//  RecentProjectListItem.swift
 //  CodeEditModules/WelcomeModule
 //
 //  Created by Ziyuan Zhao on 2022/3/18.
@@ -13,7 +13,7 @@ extension String {
     }
 }
 
-struct RecentProjectItem: View {
+struct RecentProjectListItem: View {
     let projectPath: URL
 
     init(projectPath: URL) {

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -30,9 +30,9 @@ struct FileCommands: Commands {
                 }
                 .keyboardShortcut("o")
 
-                Menu("Open Recent") {
-//                    RecentProjectsMenu()
-                }
+                // Leave this empty, is done through a hidden API in WindowCommands/Utils/CommandsFixes.swift
+                // We set this with a custom NSMenu. See WindowCommands/Utils/RecentProjectsMenu.swift
+                Menu("Open Recent") { }
 
                 Button("Open Quickly") {
                     NSApp.sendAction(#selector(CodeEditWindowController.openQuickly(_:)), to: nil, from: nil)

--- a/CodeEdit/Features/WindowCommands/FileCommands.swift
+++ b/CodeEdit/Features/WindowCommands/FileCommands.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct FileCommands: Commands {
+    static let recentProjectsMenu = RecentProjectsMenu()
+
     @Environment(\.openWindow)
     private var openWindow
 
@@ -28,9 +30,9 @@ struct FileCommands: Commands {
                 }
                 .keyboardShortcut("o")
 
-                // Leave this empty, is done through a hidden API in WindowCommands/Utils/CommandsFixes.swift
-                // This can't be done in SwiftUI Commands yet, as they don't support images in menu items.
-                Menu("Open Recent") {}
+                Menu("Open Recent") {
+//                    RecentProjectsMenu()
+                }
 
                 Button("Open Quickly") {
                     NSApp.sendAction(#selector(CodeEditWindowController.openQuickly(_:)), to: nil, from: nil)

--- a/CodeEdit/Features/WindowCommands/Utils/CommandsFixes.swift
+++ b/CodeEdit/Features/WindowCommands/Utils/CommandsFixes.swift
@@ -14,7 +14,6 @@ extension EventModifiers {
 extension NSMenuItem {
     @objc
     fileprivate func fixAlternate(_ newValue: NSEvent.ModifierFlags) {
-
         if newValue.contains(.numericPad) {
             isAlternate = true
             fixAlternate(newValue.subtracting(.numericPad))
@@ -23,10 +22,7 @@ extension NSMenuItem {
         fixAlternate(newValue)
 
         if self.title == "Open Recent" {
-            let openRecentMenu = NSMenu(title: "Open Recent")
-            openRecentMenu.perform(NSSelectorFromString("_setMenuName:"), with: "NSRecentDocumentsMenu")
-            self.submenu = openRecentMenu
-            NSDocumentController.shared.value(forKey: "_installOpenRecentMenus")
+            self.submenu = FileCommands.recentProjectsMenu.makeMenu()
         }
 
         if self.title == "OpenWindowAction" || self.title.isEmpty {

--- a/CodeEdit/Features/WindowCommands/Utils/RecentProjectsMenu.swift
+++ b/CodeEdit/Features/WindowCommands/Utils/RecentProjectsMenu.swift
@@ -11,7 +11,9 @@ class RecentProjectsMenu: NSObject {
     func makeMenu() -> NSMenu {
         let menu = NSMenu(title: NSLocalizedString("Open Recent", comment: "Open Recent menu title"))
 
-        for projectPath in RecentProjectsStore.recentProjectURLs().prefix(10) {
+        let paths = RecentProjectsStore.recentProjectURLs().prefix(10)
+
+        for projectPath in paths {
             let icon = NSWorkspace.shared.icon(forFile: projectPath.path())
             icon.size = NSSize(width: 16, height: 16)
 
@@ -24,7 +26,14 @@ class RecentProjectsMenu: NSObject {
             primaryItem.image = icon
             primaryItem.representedObject = projectPath
 
-            let parentPath = projectPath.deletingLastPathComponent().path(percentEncoded: false).abbreviatingWithTildeInPath()
+            let containsDuplicate = paths.contains { url in
+                url != projectPath && url.lastPathComponent == projectPath.lastPathComponent
+            }
+
+            let parentPath = projectPath
+                .deletingLastPathComponent()
+                .path(percentEncoded: false)
+                .abbreviatingWithTildeInPath()
             let alternateTitle = NSMutableAttributedString(
                 string: projectPath.lastPathComponent + " ", attributes: [.foregroundColor: NSColor.labelColor]
             )
@@ -32,6 +41,11 @@ class RecentProjectsMenu: NSObject {
                 string: parentPath,
                 attributes: [.foregroundColor: NSColor.secondaryLabelColor]
             ))
+
+            // If there's a duplicate, add the path.
+            if containsDuplicate {
+                primaryItem.attributedTitle = alternateTitle
+            }
 
             let alternateItem = NSMenuItem(
                 title: "",

--- a/CodeEdit/Features/WindowCommands/Utils/RecentProjectsMenu.swift
+++ b/CodeEdit/Features/WindowCommands/Utils/RecentProjectsMenu.swift
@@ -1,0 +1,156 @@
+//
+//  RecentProjectsMenu.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 10/22/24.
+//
+
+import AppKit
+
+class RecentProjectsMenu: NSObject {
+    func makeMenu() -> NSMenu {
+        let menu = NSMenu(title: NSLocalizedString("Open Recent", comment: "Open Recent menu title"))
+
+        for projectPath in RecentProjectsStore.recentProjectURLs().prefix(10) {
+            let icon = NSWorkspace.shared.icon(forFile: projectPath.path())
+            icon.size = NSSize(width: 16, height: 16)
+
+            let primaryItem = NSMenuItem(
+                title: projectPath.lastPathComponent,
+                action: #selector(recentProjectItemClicked(_:)),
+                keyEquivalent: ""
+            )
+            primaryItem.target = self
+            primaryItem.image = icon
+            primaryItem.representedObject = projectPath
+
+//            let alternateTitle = NSMutableAttributedString(
+//                string: projectPath.lastPathComponent + " ", attributes: [.foregroundColor: NSColor.labelColor]
+//            )
+//            alternateTitle.append(NSAttributedString(
+//                string: path,
+//                attributes: [.foregroundColor: NSColor.secondaryLabelColor]
+//            ))
+//
+//            let alternateItem = NSMenuItem(
+//                title: "",
+//                action: #selector(recentProjectItemClicked(_:)),
+//                keyEquivalent: ""
+//            )
+//            alternateItem.attributedTitle = alternateTitle
+//            alternateItem.target = self
+//            alternateItem.image = icon
+//            alternateItem.representedObject = projectPath
+//            alternateItem.isAlternate = true
+//            alternateItem.keyEquivalentModifierMask = [.option]
+
+            menu.addItem(primaryItem)
+//            menu.addItem(alternateItem)
+        }
+
+        menu.addItem(NSMenuItem.separator())
+
+        let clearMenuItem = NSMenuItem(
+            title: NSLocalizedString("Clear Menu", comment: "Recent project menu clear button"),
+            action: #selector(clearMenuItemClicked(_:)),
+            keyEquivalent: ""
+        )
+        clearMenuItem.target = self
+        menu.addItem(clearMenuItem)
+
+        return menu
+    }
+
+    @objc
+    func recentProjectItemClicked(_ sender: NSMenuItem) {
+        guard let projectURL = sender.representedObject as? URL else {
+            return
+        }
+        CodeEditDocumentController.shared.openDocument(
+            withContentsOf: projectURL,
+            display: true,
+            completionHandler: { _, _, _ in }
+        )
+    }
+
+    @objc
+    func clearMenuItemClicked(_ sender: NSMenuItem) {
+        RecentProjectsStore.clearList()
+    }
+
+    private func duplicateProjectMenuItem(_ projectPath: URL) -> NSMenuItem {
+        let item = NSMenuItem()
+        let stack = NSStackView()
+        stack.orientation = .horizontal
+        stack.spacing = 8
+
+        let icon = NSImageView(image: NSWorkspace.shared.icon(forFile: projectPath.path()))
+        icon.frame.size = NSSize(width: 16, height: 16)
+        let title = NSTextField(labelWithString: projectPath.lastPathComponent)
+
+        let separator = NSTextField(labelWithString: "⎯")
+
+        let projectParent = projectPath.deletingLastPathComponent()
+
+        let secondaryIcon = NSImageView(image: NSWorkspace.shared.icon(forFile: projectParent.path()))
+        secondaryIcon.frame.size = NSSize(width: 16, height: 16)
+        let secondaryTitle = NSTextField(
+            labelWithString: projectParent.path(percentEncoded: false).abbreviatingWithTildeInPath()
+        )
+
+        stack.addArrangedSubview(icon)
+        stack.addArrangedSubview(title)
+        stack.addArrangedSubview(secondaryIcon)
+        stack.addArrangedSubview(secondaryTitle)
+
+        item.view = stack
+
+        return item
+    }
+}
+
+//struct RecentProjectsMenu: View {
+//    @State private var recentProjects: [URL] = []
+//    @State private var controlKeyPressed: Bool = false
+//
+//    var body: some View {
+//        Group {
+//            ForEach(recentProjects, id: \.self) { url in
+//                Button {
+//                    NSDocumentController.shared.openDocument(
+//                        withContentsOf: url,
+//                        display: true,
+//                        completionHandler: { _, _, _ in }
+//                    )
+//                } label: {
+//                    RecentProjectMenuItem(
+//                        projectPath: url,
+//                        controlKeyPressed: controlKeyPressed
+////                        hasDuplicate: recentProjects.contains(where: {
+////                            $0 != url && $0.lastPathComponent == url.lastPathComponent
+////                        })
+//                    )
+//                }
+//            }
+//            Divider()
+//            Button {
+//                RecentProjectsStore.clearList()
+//            } label: {
+//                Text("Clear Recent Menu")
+//            }
+//        }
+//        .onAppear {
+//            updateProjects()
+//        }
+//        .onReceive(NotificationCenter.default.publisher(for: RecentProjectsStore.didUpdateNotification)) { _ in
+//            updateProjects()
+//        }
+//        .onReceive(NSEvent.publisher(scope: .local, matching: .flagsChanged)) { output in
+//            controlKeyPressed = output.modifierFlags.contains(.control)
+//        }
+//    }
+//
+//    private func updateProjects() {
+//        recentProjects = Array(RecentProjectsStore.recentProjectURLs().prefix(10))
+//    }
+//}

--- a/CodeEdit/Features/WindowCommands/Utils/RecentProjectsMenu.swift
+++ b/CodeEdit/Features/WindowCommands/Utils/RecentProjectsMenu.swift
@@ -24,28 +24,29 @@ class RecentProjectsMenu: NSObject {
             primaryItem.image = icon
             primaryItem.representedObject = projectPath
 
-//            let alternateTitle = NSMutableAttributedString(
-//                string: projectPath.lastPathComponent + " ", attributes: [.foregroundColor: NSColor.labelColor]
-//            )
-//            alternateTitle.append(NSAttributedString(
-//                string: path,
-//                attributes: [.foregroundColor: NSColor.secondaryLabelColor]
-//            ))
-//
-//            let alternateItem = NSMenuItem(
-//                title: "",
-//                action: #selector(recentProjectItemClicked(_:)),
-//                keyEquivalent: ""
-//            )
-//            alternateItem.attributedTitle = alternateTitle
-//            alternateItem.target = self
-//            alternateItem.image = icon
-//            alternateItem.representedObject = projectPath
-//            alternateItem.isAlternate = true
-//            alternateItem.keyEquivalentModifierMask = [.option]
+            let parentPath = projectPath.deletingLastPathComponent().path(percentEncoded: false).abbreviatingWithTildeInPath()
+            let alternateTitle = NSMutableAttributedString(
+                string: projectPath.lastPathComponent + " ", attributes: [.foregroundColor: NSColor.labelColor]
+            )
+            alternateTitle.append(NSAttributedString(
+                string: parentPath,
+                attributes: [.foregroundColor: NSColor.secondaryLabelColor]
+            ))
+
+            let alternateItem = NSMenuItem(
+                title: "",
+                action: #selector(recentProjectItemClicked(_:)),
+                keyEquivalent: ""
+            )
+            alternateItem.attributedTitle = alternateTitle
+            alternateItem.target = self
+            alternateItem.image = icon
+            alternateItem.representedObject = projectPath
+            alternateItem.isAlternate = true
+            alternateItem.keyEquivalentModifierMask = [.option]
 
             menu.addItem(primaryItem)
-//            menu.addItem(alternateItem)
+            menu.addItem(alternateItem)
         }
 
         menu.addItem(NSMenuItem.separator())
@@ -77,80 +78,4 @@ class RecentProjectsMenu: NSObject {
     func clearMenuItemClicked(_ sender: NSMenuItem) {
         RecentProjectsStore.clearList()
     }
-
-    private func duplicateProjectMenuItem(_ projectPath: URL) -> NSMenuItem {
-        let item = NSMenuItem()
-        let stack = NSStackView()
-        stack.orientation = .horizontal
-        stack.spacing = 8
-
-        let icon = NSImageView(image: NSWorkspace.shared.icon(forFile: projectPath.path()))
-        icon.frame.size = NSSize(width: 16, height: 16)
-        let title = NSTextField(labelWithString: projectPath.lastPathComponent)
-
-        let separator = NSTextField(labelWithString: "⎯")
-
-        let projectParent = projectPath.deletingLastPathComponent()
-
-        let secondaryIcon = NSImageView(image: NSWorkspace.shared.icon(forFile: projectParent.path()))
-        secondaryIcon.frame.size = NSSize(width: 16, height: 16)
-        let secondaryTitle = NSTextField(
-            labelWithString: projectParent.path(percentEncoded: false).abbreviatingWithTildeInPath()
-        )
-
-        stack.addArrangedSubview(icon)
-        stack.addArrangedSubview(title)
-        stack.addArrangedSubview(secondaryIcon)
-        stack.addArrangedSubview(secondaryTitle)
-
-        item.view = stack
-
-        return item
-    }
 }
-
-//struct RecentProjectsMenu: View {
-//    @State private var recentProjects: [URL] = []
-//    @State private var controlKeyPressed: Bool = false
-//
-//    var body: some View {
-//        Group {
-//            ForEach(recentProjects, id: \.self) { url in
-//                Button {
-//                    NSDocumentController.shared.openDocument(
-//                        withContentsOf: url,
-//                        display: true,
-//                        completionHandler: { _, _, _ in }
-//                    )
-//                } label: {
-//                    RecentProjectMenuItem(
-//                        projectPath: url,
-//                        controlKeyPressed: controlKeyPressed
-////                        hasDuplicate: recentProjects.contains(where: {
-////                            $0 != url && $0.lastPathComponent == url.lastPathComponent
-////                        })
-//                    )
-//                }
-//            }
-//            Divider()
-//            Button {
-//                RecentProjectsStore.clearList()
-//            } label: {
-//                Text("Clear Recent Menu")
-//            }
-//        }
-//        .onAppear {
-//            updateProjects()
-//        }
-//        .onReceive(NotificationCenter.default.publisher(for: RecentProjectsStore.didUpdateNotification)) { _ in
-//            updateProjects()
-//        }
-//        .onReceive(NSEvent.publisher(scope: .local, matching: .flagsChanged)) { output in
-//            controlKeyPressed = output.modifierFlags.contains(.control)
-//        }
-//    }
-//
-//    private func updateProjects() {
-//        recentProjects = Array(RecentProjectsStore.recentProjectURLs().prefix(10))
-//    }
-//}

--- a/CodeEdit/Features/WindowCommands/Utils/RecentProjectsMenu.swift
+++ b/CodeEdit/Features/WindowCommands/Utils/RecentProjectsMenu.swift
@@ -16,6 +16,7 @@ class RecentProjectsMenu: NSObject {
         for projectPath in paths {
             let icon = NSWorkspace.shared.icon(forFile: projectPath.path())
             icon.size = NSSize(width: 16, height: 16)
+            let alternateTitle = alternateTitle(for: projectPath)
 
             let primaryItem = NSMenuItem(
                 title: projectPath.lastPathComponent,
@@ -29,18 +30,6 @@ class RecentProjectsMenu: NSObject {
             let containsDuplicate = paths.contains { url in
                 url != projectPath && url.lastPathComponent == projectPath.lastPathComponent
             }
-
-            let parentPath = projectPath
-                .deletingLastPathComponent()
-                .path(percentEncoded: false)
-                .abbreviatingWithTildeInPath()
-            let alternateTitle = NSMutableAttributedString(
-                string: projectPath.lastPathComponent + " ", attributes: [.foregroundColor: NSColor.labelColor]
-            )
-            alternateTitle.append(NSAttributedString(
-                string: parentPath,
-                attributes: [.foregroundColor: NSColor.secondaryLabelColor]
-            ))
 
             // If there's a duplicate, add the path.
             if containsDuplicate {
@@ -74,6 +63,21 @@ class RecentProjectsMenu: NSObject {
         menu.addItem(clearMenuItem)
 
         return menu
+    }
+
+    private func alternateTitle(for projectPath: URL) -> NSAttributedString {
+        let parentPath = projectPath
+            .deletingLastPathComponent()
+            .path(percentEncoded: false)
+            .abbreviatingWithTildeInPath()
+        let alternateTitle = NSMutableAttributedString(
+            string: projectPath.lastPathComponent + " ", attributes: [.foregroundColor: NSColor.labelColor]
+        )
+        alternateTitle.append(NSAttributedString(
+            string: parentPath,
+            attributes: [.foregroundColor: NSColor.secondaryLabelColor]
+        ))
+        return alternateTitle
     }
 
     @objc

--- a/CodeEdit/Features/WindowCommands/Utils/WindowControllerPropertyWrapper.swift
+++ b/CodeEdit/Features/WindowCommands/Utils/WindowControllerPropertyWrapper.swift
@@ -42,7 +42,9 @@ struct UpdatingWindowController: DynamicProperty {
         private var activeEditorCancellable: AnyCancellable?
 
         init() {
-            windowCancellable = NSApp.publisher(for: \.keyWindow).sink { [weak self] window in
+            windowCancellable = NSApp.publisher(for: \.keyWindow).receive(on: RunLoop.main).sink { [weak self] window in
+                // Fix an issue where NSMenuItems with custom views would trigger this callback.
+                guard window?.className != "NSPopupMenuWindow" else { return }
                 self?.setNewController(window?.windowController as? CodeEditWindowController)
             }
         }

--- a/CodeEdit/Utils/Extensions/URL/URL+componentCompare.swift
+++ b/CodeEdit/Utils/Extensions/URL/URL+componentCompare.swift
@@ -1,0 +1,18 @@
+//
+//  URL+componentCompare.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 10/22/24.
+//
+
+import Foundation
+
+extension URL {
+    /// Compare a URL using its path components.
+    /// - Parameter other: The URL to compare to
+    /// - Returns: `true` if the URL points to the same path on disk. Regardless of query parameters, trailing
+    ///            slashes, etc.
+    func componentCompare(_ other: URL) -> Bool {
+        return self.pathComponents == other.pathComponents
+    }
+}


### PR DESCRIPTION
### Description

- Fixes the recently opened submenu
- Moves the recently opened logic to it's own space.
- Limits the recently opened list to 100 items.
- Syncs AppKit's recent list with ours, keeping the dock menu and other lists up-to-date.

There's been some discussion for the design here. I think after a lot of discussion, this design keeps a lot of what everyone wanted. Not too much information, and information is not hidden behind the option key when it's useful. In my version, we show the path if there's duplicates and show all paths if the option key is pressed.

### Related Issues

* closes #1835
* closes #1927

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/398dd007-855a-4cca-8b48-b82fe297fea3


