### PR TITLE
Theme export and theme details flicker fix when duplicating and then canceling

### DIFF
--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel+CRUD.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel+CRUD.swift
@@ -246,16 +246,6 @@ extension ThemeModel {
             try filemanager.moveItem(at: oldURL, to: finalURL)
 
             try self.loadThemes()
-
-            if let index = themes.firstIndex(where: { $0.fileURL == finalURL }) {
-                themes[index].displayName = finalName
-                themes[index].fileURL = finalURL
-                themes[index].name = finalName.lowercased().replacingOccurrences(of: " ", with: "-")
-                if isActive {
-                    self.activateTheme(themes[index])
-                }
-            }
-
         } catch {
             print("Error renaming theme: \(error.localizedDescription)")
         }

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel+CRUD.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel+CRUD.swift
@@ -208,9 +208,12 @@ extension ThemeModel {
                     self.save(self.themes[index])
                 }
 
+                self.previousTheme = self.selectedTheme
+
                 activateTheme(self.themes[index])
 
                 self.detailsTheme = self.themes[index]
+                self.detailsIsPresented = true
             }
         } catch {
             print("Error adding theme: \(error.localizedDescription)")
@@ -238,6 +241,8 @@ extension ThemeModel {
                 iterator += 1
             }
 
+            let isActive = self.getThemeActive(theme)
+
             try filemanager.moveItem(at: oldURL, to: finalURL)
 
             try self.loadThemes()
@@ -246,6 +251,9 @@ extension ThemeModel {
                 themes[index].displayName = finalName
                 themes[index].fileURL = finalURL
                 themes[index].name = finalName.lowercased().replacingOccurrences(of: " ", with: "-")
+                if isActive {
+                    self.activateTheme(themes[index])
+                }
             }
 
         } catch {

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// The Theme View Model. Accessible via the singleton "``ThemeModel/shared``".
 ///
@@ -153,4 +154,55 @@ final class ThemeModel: ObservableObject {
             selectedDarkTheme = theme
         }
     }
+
+    func exportTheme(_ theme: Theme) {
+        guard let themeFileURL = theme.fileURL else {
+            print("Theme file URL not found.")
+            return
+        }
+
+        let savePanel = NSSavePanel()
+        savePanel.allowedContentTypes = [UTType(filenameExtension: "cetheme")!]
+        savePanel.nameFieldStringValue = theme.displayName
+        savePanel.prompt = "Export"
+        savePanel.canCreateDirectories = true
+
+        savePanel.begin { response in
+            if response == .OK, let destinationURL = savePanel.url {
+                do {
+                    try FileManager.default.copyItem(at: themeFileURL, to: destinationURL)
+                    print("Theme exported successfully to \(destinationURL.path)")
+                } catch {
+                    print("Failed to export theme: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    func exportAllCustomThemes() {
+            let openPanel = NSOpenPanel()
+            openPanel.prompt = "Export"
+            openPanel.canChooseFiles = false
+            openPanel.canChooseDirectories = true
+            openPanel.allowsMultipleSelection = false
+
+            openPanel.begin { result in
+                if result == .OK, let exportDirectory = openPanel.url {
+                    let customThemes = self.themes.filter { !$0.isBundled }
+
+                    for theme in customThemes {
+                        guard let sourceURL = theme.fileURL else { continue }
+
+                        let destinationURL = exportDirectory.appendingPathComponent("\(theme.displayName).cetheme")
+
+                        do {
+                            try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+                            print("Exported \(theme.displayName) to \(destinationURL.path)")
+                        } catch {
+                            print("Failed to export \(theme.displayName): \(error.localizedDescription)")
+                        }
+                    }
+                }
+            }
+        }
 }

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel.swift
@@ -72,7 +72,7 @@ final class ThemeModel: ObservableObject {
         }
     }
 
-    @Published var presentingDetails: Bool = false
+    @Published var detailsIsPresented: Bool = false
 
     @Published var isAdding: Bool = false
 
@@ -87,9 +87,10 @@ final class ThemeModel: ObservableObject {
             DispatchQueue.main.async {
                 Settings[\.theme].selectedTheme = self.selectedTheme?.name
             }
-            updateAppearanceTheme()
         }
     }
+
+    @Published var previousTheme: Theme?
 
     /// Only themes where ``Theme/appearance`` == ``Theme/ThemeType/dark``
     var darkThemes: [Theme] {
@@ -127,9 +128,9 @@ final class ThemeModel: ObservableObject {
     }
 
     /// Initialize to the app's current appearance.
-    @Published var selectedAppearance: ThemeSettingsAppearances = {
+    var selectedAppearance: ThemeSettingsAppearances {
         NSApp.effectiveAppearance.name == .darkAqua ? .dark : .light
-    }()
+    }
 
     enum ThemeSettingsAppearances: String, CaseIterable {
         case light = "Light Appearance"
@@ -137,13 +138,6 @@ final class ThemeModel: ObservableObject {
     }
 
     func getThemeActive(_ theme: Theme) -> Bool {
-        if settings.matchAppearance {
-            return selectedAppearance == .dark
-            ? selectedDarkTheme == theme
-            : selectedAppearance == .light
-                ? selectedLightTheme == theme
-                : selectedTheme == theme
-        }
         return selectedTheme == theme
     }
 
@@ -151,24 +145,12 @@ final class ThemeModel: ObservableObject {
     /// necessary.
     /// - Parameter theme: The theme to activate.
     func activateTheme(_ theme: Theme) {
-        if settings.matchAppearance {
-            if selectedAppearance == .dark {
-                selectedDarkTheme = theme
-            } else if selectedAppearance == .light {
-                selectedLightTheme = theme
-            }
-            if (selectedAppearance == .dark && colorScheme == .dark)
-                || (selectedAppearance == .light && colorScheme == .light) {
-                selectedTheme = theme
-            }
-        } else {
-            selectedTheme = theme
-            if colorScheme == .light {
-                selectedLightTheme = theme
-            }
-            if colorScheme == .dark {
-                selectedDarkTheme = theme
-            }
+        selectedTheme = theme
+        if colorScheme == .light {
+            selectedLightTheme = theme
+        }
+        if colorScheme == .dark {
+            selectedDarkTheme = theme
         }
     }
 }

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingThemeRow.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingThemeRow.swift
@@ -13,8 +13,6 @@ struct ThemeSettingsThemeRow: View {
 
     @ObservedObject private var themeModel: ThemeModel = .shared
 
-    @State private var presentingDetails: Bool = false
-
     @State private var isHovering = false
 
     var body: some View {
@@ -42,6 +40,7 @@ struct ThemeSettingsThemeRow: View {
             Menu {
                 Button("Details...") {
                     themeModel.detailsTheme = theme
+                    themeModel.detailsIsPresented = true
                 }
                 Button("Duplicate") {
                     if let fileURL = theme.fileURL {

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingThemeRow.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingThemeRow.swift
@@ -42,16 +42,15 @@ struct ThemeSettingsThemeRow: View {
                     themeModel.detailsTheme = theme
                     themeModel.detailsIsPresented = true
                 }
-                Button("Duplicate") {
+                Button("Duplicate...") {
                     if let fileURL = theme.fileURL {
                         themeModel.duplicate(fileURL)
                     }
                 }
-                Divider()
-                    Button("Export...") {
-                        themeModel.exportTheme(theme)
-                    }
-                    .disabled(theme.isBundled)
+                Button("Export...") {
+                    themeModel.exportTheme(theme)
+                }
+                .disabled(theme.isBundled)
                 Divider()
                 Button("Delete") {
                     themeModel.delete(theme)

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingThemeRow.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingThemeRow.swift
@@ -48,6 +48,11 @@ struct ThemeSettingsThemeRow: View {
                     }
                 }
                 Divider()
+                    Button("Export...") {
+                        themeModel.exportTheme(theme)
+                    }
+                    .disabled(theme.isBundled)
+                Divider()
                 Button("Delete") {
                     themeModel.delete(theme)
                 }

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingThemeRow.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingThemeRow.swift
@@ -15,6 +15,8 @@ struct ThemeSettingsThemeRow: View {
 
     @State private var isHovering = false
 
+    @State private var deleteConfirmationIsPresented = false
+
     var body: some View {
         HStack {
             Image(systemName: "checkmark")
@@ -52,8 +54,8 @@ struct ThemeSettingsThemeRow: View {
                 }
                 .disabled(theme.isBundled)
                 Divider()
-                Button("Delete") {
-                    themeModel.delete(theme)
+                Button("Delete...") {
+                    deleteConfirmationIsPresented = true
                 }
                 .disabled(theme.isBundled)
             } label: {
@@ -65,6 +67,19 @@ struct ThemeSettingsThemeRow: View {
         .padding(10)
         .onHover { hovering in
             isHovering = hovering
+        }
+        .alert(
+            Text("Are you sure you want to delete the theme “\(theme.displayName)”?"),
+            isPresented: $deleteConfirmationIsPresented
+        ) {
+            Button("Delete Theme") {
+                themeModel.delete(theme)
+            }
+            Button("Cancel") {
+                deleteConfirmationIsPresented = false
+            }
+        } message: {
+            Text("This action cannot be undone.")
         }
     }
 }

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsThemeDetails.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsThemeDetails.swift
@@ -22,6 +22,8 @@ struct ThemeSettingsThemeDetails: View {
 
     @State private var duplicatingTheme: Theme?
 
+    @State private var deleteConfirmationIsPresented = false
+
     var isActive: Bool {
         themeModel.getThemeActive(theme)
     }
@@ -174,10 +176,9 @@ struct ThemeSettingsThemeDetails: View {
                     .accessibilityLabel("Warning: Duplicate this theme to make changes.")
                 } else if !themeModel.isAdding {
                     Button(role: .destructive) {
-                        themeModel.delete(theme)
-                        dismiss()
+                        deleteConfirmationIsPresented = true
                     } label: {
-                        Text("Delete")
+                        Text("Delete...")
                             .foregroundStyle(.red)
                             .frame(minWidth: 56)
                     }
@@ -187,7 +188,7 @@ struct ThemeSettingsThemeDetails: View {
                             themeModel.duplicate(fileURL)
                         }
                     } label: {
-                        Text("Duplicate")
+                        Text("Duplicate...")
                             .frame(minWidth: 56)
                     }
                 }
@@ -247,5 +248,19 @@ struct ThemeSettingsThemeDetails: View {
             .padding()
         }
         .constrainHeightToWindow()
+        .alert(
+            Text("Are you sure you want to delete the theme “\(theme.displayName)”?"),
+            isPresented: $deleteConfirmationIsPresented
+        ) {
+            Button("Delete Theme") {
+                themeModel.delete(theme)
+                dismiss()
+            }
+            Button("Cancel") {
+                deleteConfirmationIsPresented = false
+            }
+        } message: {
+            Text("This action cannot be undone.")
+        }
     }
 }

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsThemeDetails.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsThemeDetails.swift
@@ -35,7 +35,6 @@ struct ThemeSettingsThemeDetails: View {
         VStack(spacing: 0) {
             Form {
                 Group {
-                    Text("Theme is\(isActive ? "" : " not") active")
                     Section {
                         TextField("Name", text: $theme.displayName)
                         TextField("Author", text: $theme.author)

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsView.swift
@@ -49,10 +49,10 @@ struct ThemeSettingsView: View {
                                     Text("Import Theme...")
                                 }
                                 Button {
-                                    // TODO: #1874
+                                    themeModel.exportAllCustomThemes()
                                 } label: {
                                     Text("Export All Custom Themes...")
-                                }.disabled(true)
+                                }
                             }
                         })
                         .padding(.horizontal, 5)

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/ThemeSettingsView.swift
@@ -90,28 +90,35 @@ struct ThemeSettingsView: View {
                     }
                     .padding(.top, 10)
                 }
-                .sheet(item: $themeModel.detailsTheme) {
-                    themeModel.isAdding = false
-                } content: { theme in
-                    if let index = themeModel.themes.firstIndex(where: {
+                .sheet(isPresented: $themeModel.detailsIsPresented, onDismiss: {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                        themeModel.isAdding = false
+                    }
+                }, content: {
+                    if let theme = themeModel.detailsTheme, let index = themeModel.themes.firstIndex(where: {
                         $0.fileURL?.absoluteString == theme.fileURL?.absoluteString
                     }) {
                         ThemeSettingsThemeDetails(theme: Binding(
                             get: { themeModel.themes[index] },
                             set: { newValue in
-                                themeModel.themes[index] = newValue
-                                themeModel.save(newValue)
-                                if settings.selectedTheme == theme.name {
-                                    themeModel.activateTheme(newValue)
+                                if themeModel.detailsIsPresented {
+                                    themeModel.themes[index] = newValue
+                                    themeModel.save(newValue)
+                                    if settings.selectedTheme == theme.name {
+                                        themeModel.activateTheme(newValue)
+                                    }
                                 }
                             }
                         ))
                     }
-                }
+                })
                 .onAppear {
                     updateFilteredThemes()
                 }
                 .onChange(of: themeSearchQuery) { _ in
+                    updateFilteredThemes()
+                }
+                .onChange(of: themeModel.themes) { _ in
                     updateFilteredThemes()
                 }
                 .onChange(of: colorScheme) { newColorScheme in


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

When the user went to Theme settings and duplicated an existing theme then closed the sheet, there was a flicker of the duplicated theme as it faded out. That flicker is no longer there.

This PR also includes the following improvements
- Fixed a few minor bugs introduced with theme search.
- Enabled custom theme export.
- Adds theme deletion confirmation alert

### Related Issues

* closes #1894
* closes #1874

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/2035244e-91ae-436c-abf0-5e5c48e7be4b
