### PR TITLE
Fix Getting Stuck in Sub-View within Settings

### DIFF
--- a/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsView.swift
@@ -15,34 +15,39 @@ struct AccountsSettingsView: View {
     @State private var selectedProvider: SourceControlAccount.Provider?
 
     var body: some View {
-        SettingsForm {
-            Section {
-                if $gitAccounts.isEmpty {
-                    Text("No accounts")
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                } else {
-                    ForEach($gitAccounts, id: \.self) { $account in
-                        AccountsSettingsAccountLink($account)
-                    }
-                }
-            } footer: {
-                HStack {
-                    Spacer()
-                    Button("Add Account...") { addAccountSheetPresented.toggle() }
-                    .sheet(isPresented: $addAccountSheetPresented, content: {
-                        AccountSelectionView(selectedProvider: $selectedProvider)
-                    })
-                    .sheet(item: $selectedProvider, content: { provider in
-                        switch provider {
-                        case .github, .githubEnterprise, .gitlab, .gitlabSelfHosted:
-                            AccountsSettingsSigninView(provider, addAccountSheetPresented: $addAccountSheetPresented)
-                        default:
-                            implementationNeeded
+        NavigationStack {
+            SettingsForm {
+                Section {
+                    if $gitAccounts.isEmpty {
+                        Text("No accounts")
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    } else {
+                        ForEach($gitAccounts, id: \.self) { $account in
+                            AccountsSettingsAccountLink($account)
                         }
-                    })
+                    }
+                } footer: {
+                    HStack {
+                        Spacer()
+                        Button("Add Account...") { addAccountSheetPresented.toggle() }
+                            .sheet(isPresented: $addAccountSheetPresented, content: {
+                                AccountSelectionView(selectedProvider: $selectedProvider)
+                            })
+                            .sheet(item: $selectedProvider, content: { provider in
+                                switch provider {
+                                case .github, .githubEnterprise, .gitlab, .gitlabSelfHosted:
+                                    AccountsSettingsSigninView(
+                                        provider,
+                                        addAccountSheetPresented: $addAccountSheetPresented
+                                    )
+                                default:
+                                    implementationNeeded
+                                }
+                            })
+                    }
+                    .padding(.top, 10)
                 }
-                .padding(.top, 10)
             }
         }
     }

--- a/CodeEdit/Features/Settings/SettingsView.swift
+++ b/CodeEdit/Features/Settings/SettingsView.swift
@@ -156,6 +156,7 @@ struct SettingsView: View {
                 }
             }
             .navigationSplitViewColumnWidth(215)
+            .hideSidebarToggle()
         } detail: {
             Group {
                 switch selectedPage.name {
@@ -184,7 +185,6 @@ struct SettingsView: View {
                 }
             }
             .navigationSplitViewColumnWidth(500)
-            .hideSidebarToggle()
             .onAppear {
                 model.backButtonVisible = false
             }

--- a/CodeEdit/Features/Settings/Views/View+HideSidebarToggle.swift
+++ b/CodeEdit/Features/Settings/Views/View+HideSidebarToggle.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftUIIntrospect
 
 extension View {
     func hideSidebarToggle() -> some View {
@@ -15,14 +16,19 @@ extension View {
 
 struct HideSidebarToggleViewModifier: ViewModifier {
     func body(content: Content) -> some View {
-        content
-            .task {
-                let window = NSApp.windows.first { $0.identifier?.rawValue == SceneID.settings.rawValue }!
-                let sidebaritem = "com.apple.SwiftUI.navigationSplitView.toggleSidebar"
-                let index = window.toolbar?.items.firstIndex { $0.itemIdentifier.rawValue == sidebaritem }
-                if let index {
-                    window.toolbar?.removeItem(at: index)
+        if #available(macOS 14, *) {
+            content
+                .toolbar(removing: .sidebarToggle)
+        } else {
+            content
+                .task {
+                    let window = NSApp.windows.first { $0.identifier?.rawValue == SceneID.settings.rawValue }!
+                    let sidebaritem = "com.apple.SwiftUI.navigationSplitView.toggleSidebar"
+                    let index = window.toolbar?.items.firstIndex { $0.itemIdentifier.rawValue == sidebaritem }
+                    if let index {
+                        window.toolbar?.removeItem(at: index)
+                    }
                 }
-            }
+        }
     }
 }

--- a/CodeEdit/Features/Settings/Views/View+NavigationBarBackButtonVisible.swift
+++ b/CodeEdit/Features/Settings/Views/View+NavigationBarBackButtonVisible.swift
@@ -24,9 +24,12 @@ struct NavigationBarBackButtonVisible: ViewModifier {
                 }
             }
         }
-        .hideSidebarToggle()
+        .navigationBarBackButtonHidden()
         .onAppear {
             model.backButtonVisible = true
+        }
+        .onDisappear {
+            model.backButtonVisible = false
         }
     }
 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This is an initial attempt at resolving the below issue. There are a few things of note here before this can be merged. The first is that the introduction of a NavigationStack within individual tab views inadvertently causes the sidebar toggle to remain visible on versions of macOS 13 and below. I have addressed this issue in macOS 14+ by using the new toolbar remove API. The other thing is that I have only fixed this in one area thus far, inside account settings. I did not make a universal solution yet as I wanted to get feedback as to how we would handle this. Ideally, we would have an automatic way to handle subviews.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #1923 

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] The issues this PR addresses are related to each other
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots

https://github.com/user-attachments/assets/f92bcc49-b397-4e33-85c5-06d0873e6b10

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
