### PR TITLE
Fix Task Dropdown Crash

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 		6C05A8AF284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */; };
 		6C05CF9E2CDE8699006AAECD /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6C05CF9D2CDE8699006AAECD /* CodeEditSourceEditor */; };
 		6C0617D62BDB4432008C9C42 /* LogStream in Frameworks */ = {isa = PBXBuildFile; productRef = 6C0617D52BDB4432008C9C42 /* LogStream */; };
+		6C07383B2D284ECA0025CBE3 /* TasksMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C07383A2D284ECA0025CBE3 /* TasksMenuUITests.swift */; };
 		6C08249C2C556F7400A0751E /* TerminalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C08249B2C556F7400A0751E /* TerminalCache.swift */; };
 		6C08249E2C55768400A0751E /* UtilityAreaTerminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C08249D2C55768400A0751E /* UtilityAreaTerminal.swift */; };
 		6C0824A12C5C0C9700A0751E /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 6C0824A02C5C0C9700A0751E /* SwiftTerm */; };
@@ -1051,6 +1052,7 @@
 		66F370332BEE537B00D3B823 /* NonTextFileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonTextFileView.swift; sourceTree = "<group>"; };
 		6C049A362A49E2DB00D42923 /* DirectoryEventStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryEventStream.swift; sourceTree = "<group>"; };
 		6C05A8AE284D0CA3007F4EAA /* WorkspaceDocument+Listeners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkspaceDocument+Listeners.swift"; sourceTree = "<group>"; };
+		6C07383A2D284ECA0025CBE3 /* TasksMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksMenuUITests.swift; sourceTree = "<group>"; };
 		6C08249B2C556F7400A0751E /* TerminalCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCache.swift; sourceTree = "<group>"; };
 		6C08249D2C55768400A0751E /* UtilityAreaTerminal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityAreaTerminal.swift; sourceTree = "<group>"; };
 		6C092ED92A53A58600489202 /* EditorLayout+StateRestoration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditorLayout+StateRestoration.swift"; sourceTree = "<group>"; };
@@ -2838,6 +2840,22 @@
 			name = "Recovered References";
 			sourceTree = "<group>";
 		};
+		6C0738382D284EA20025CBE3 /* ActivityViewer */ = {
+			isa = PBXGroup;
+			children = (
+				6C0738392D284EAE0025CBE3 /* Tasks */,
+			);
+			path = ActivityViewer;
+			sourceTree = "<group>";
+		};
+		6C0738392D284EAE0025CBE3 /* Tasks */ = {
+			isa = PBXGroup;
+			children = (
+				6C07383A2D284ECA0025CBE3 /* TasksMenuUITests.swift */,
+			);
+			path = Tasks;
+			sourceTree = "<group>";
+		};
 		6C092EDC2A53A63E00489202 /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -3004,6 +3022,7 @@
 		6C96191E2C3F27E3009733CE /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				6C0738382D284EA20025CBE3 /* ActivityViewer */,
 				6C96191D2C3F27E3009733CE /* NavigatorArea */,
 			);
 			path = Features;
@@ -4581,6 +4600,7 @@
 				6CFBA54B2C4E168A00E3A914 /* App.swift in Sources */,
 				6CFBA54D2C4E16C900E3A914 /* WindowCloseCommandTests.swift in Sources */,
 				6C9619222C3F27F1009733CE /* Query.swift in Sources */,
+				6C07383B2D284ECA0025CBE3 /* TasksMenuUITests.swift in Sources */,
 				6C9619202C3F27E3009733CE /* ProjectNavigatorUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -2705,14 +2705,14 @@
 		618725A22C29EFE200987354 /* Tasks */ = {
 			isa = PBXGroup;
 			children = (
+				B69D3EE22C5F536B005CF43A /* ActiveTaskView.swift */,
+				618725A52C29F02500987354 /* DropdownMenuItemStyleModifier.swift */,
+				618725A72C29F05500987354 /* OptionMenuItemView.swift */,
 				618725A02C29EFCC00987354 /* SchemeDropDownView.swift */,
 				618725AA2C29F2C000987354 /* TaskDropDownView.swift */,
-				B69D3EE02C5F5357005CF43A /* TaskView.swift */,
-				B69D3EE22C5F536B005CF43A /* ActiveTaskView.swift */,
 				B69D3EE42C5F54B3005CF43A /* TasksPopoverMenuItem.swift */,
+				B69D3EE02C5F5357005CF43A /* TaskView.swift */,
 				618725A32C29F00400987354 /* WorkspaceMenuItemView.swift */,
-				618725A72C29F05500987354 /* OptionMenuItemView.swift */,
-				618725A52C29F02500987354 /* DropdownMenuItemStyleModifier.swift */,
 			);
 			path = Tasks;
 			sourceTree = "<group>";

--- a/CodeEdit/Features/ActivityViewer/ActivityViewer.swift
+++ b/CodeEdit/Features/ActivityViewer/ActivityViewer.swift
@@ -59,5 +59,7 @@ struct ActivityViewer: View {
                     .opacity(0.1)
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Activity Viewer")
     }
 }

--- a/CodeEdit/Features/ActivityViewer/Notifications/CECircularProgressView.swift
+++ b/CodeEdit/Features/ActivityViewer/Notifications/CECircularProgressView.swift
@@ -50,6 +50,11 @@ struct CECircularProgressView: View {
                         .font(.caption)
                 }
             }
+            .accessibilityElement()
+            .accessibilityAddTraits(.updatesFrequently)
+            .accessibilityValue(
+                progress != nil ? Text(progress!, format: .percent) : Text("working")
+            )
     }
 }
 

--- a/CodeEdit/Features/ActivityViewer/Notifications/TaskNotificationView.swift
+++ b/CodeEdit/Features/ActivityViewer/Notifications/TaskNotificationView.swift
@@ -51,7 +51,8 @@ struct TaskNotificationView: View {
                 .padding(.trailing, 3)
                 .popover(isPresented: $isPresented, arrowEdge: .bottom) {
                     TaskNotificationsDetailView(taskNotificationHandler: taskNotificationHandler)
-                }.onTapGesture {
+                }
+                .onTapGesture {
                     self.isPresented.toggle()
                 }
             }

--- a/CodeEdit/Features/ActivityViewer/Tasks/OptionMenuItemView.swift
+++ b/CodeEdit/Features/ActivityViewer/Tasks/OptionMenuItemView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct OptionMenuItemView: View {
     var label: String
     var action: () -> Void
+
     var body: some View {
         HStack {
             Text(label)
@@ -22,6 +23,11 @@ struct OptionMenuItemView: View {
         .onTapGesture {
             action()
         }
+        .accessibilityElement()
+        .accessibilityAction {
+            action()
+        }
+        .accessibilityLabel(label)
     }
 }
 

--- a/CodeEdit/Features/ActivityViewer/Tasks/SchemeDropDownView.swift
+++ b/CodeEdit/Features/ActivityViewer/Tasks/SchemeDropDownView.swift
@@ -21,15 +21,18 @@ struct SchemeDropDownView: View {
         workspaceSettingsManager.settings.project.projectName
     }
 
+    /// Resolves the name one step further than `workspaceName`.
+    var workspaceDisplayName: String {
+        workspaceName.isEmpty
+        ? (workspaceFileManager?.workspaceItem.fileName() ?? "No Project found")
+        : workspaceName
+    }
+
     var body: some View {
         HStack(spacing: 6) {
             Image(systemName: "folder.badge.gearshape")
                 .imageScale(.medium)
-            Text(
-                workspaceName.isEmpty
-                ? (workspaceFileManager?.workspaceItem.fileName() ?? "No Project found")
-                : workspaceName
-            )
+            Text(workspaceDisplayName)
         }
         .font(.subheadline)
         .padding(.trailing, 11.5)
@@ -54,31 +57,18 @@ struct SchemeDropDownView: View {
             self.isHoveringScheme = hovering
         })
         .instantPopover(isPresented: $isSchemePopOverPresented, arrowEdge: .bottom) {
-            VStack(alignment: .leading, spacing: 0) {
-                WorkspaceMenuItemView(
-                    workspaceFileManager: workspaceFileManager,
-                    item: workspaceFileManager?.workspaceItem
-                )
-                Divider()
-                    .padding(.vertical, 5)
-                Group {
-                    OptionMenuItemView(label: "Add Folder...") {
-                        // TODO: Implment Add Folder
-                        print("NOT IMPLEMENTED")
-                    }
-                    OptionMenuItemView(label: "Workspace Settings...") {
-                        NSApp.sendAction(
-                            #selector(CodeEditWindowController.openWorkspaceSettings(_:)), to: nil, from: nil
-                        )
-                    }
-                }
-            }
-            .font(.subheadline)
-            .padding(5)
-            .frame(minWidth: 215)
+            popoverContent
         }
         .onTapGesture {
-            self.isSchemePopOverPresented.toggle()
+            isSchemePopOverPresented.toggle()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityIdentifier("SchemeDropdown")
+        .accessibilityValue(workspaceDisplayName)
+        .accessibilityLabel("Active Scheme")
+        .accessibilityAction(named: "show menu") {
+            isSchemePopOverPresented.toggle()
         }
     }
 
@@ -96,6 +86,33 @@ struct SchemeDropDownView: View {
         }
         .font(.system(size: 8, weight: .semibold, design: .default))
         .padding(.top, 0.5)
+    }
+
+    @ViewBuilder
+    var popoverContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            WorkspaceMenuItemView(
+                workspaceFileManager: workspaceFileManager,
+                item: workspaceFileManager?.workspaceItem
+            )
+            Divider()
+                .padding(.vertical, 5)
+            Group {
+                OptionMenuItemView(label: "Add Folder...") {
+                    // TODO: Implment Add Folder
+                    print("NOT IMPLEMENTED")
+                }
+                .disabled(true)
+                OptionMenuItemView(label: "Workspace Settings...") {
+                    NSApp.sendAction(
+                        #selector(CodeEditWindowController.openWorkspaceSettings(_:)), to: nil, from: nil
+                    )
+                }
+            }
+        }
+        .font(.subheadline)
+        .padding(5)
+        .frame(minWidth: 215)
     }
 }
 

--- a/CodeEdit/Features/ActivityViewer/Tasks/SchemeDropDownView.swift
+++ b/CodeEdit/Features/ActivityViewer/Tasks/SchemeDropDownView.swift
@@ -67,7 +67,8 @@ struct SchemeDropDownView: View {
         .accessibilityIdentifier("SchemeDropdown")
         .accessibilityValue(workspaceDisplayName)
         .accessibilityLabel("Active Scheme")
-        .accessibilityAction(named: "show menu") {
+        .accessibilityHint("Open the active scheme menu")
+        .accessibilityAction {
             isSchemePopOverPresented.toggle()
         }
     }

--- a/CodeEdit/Features/ActivityViewer/Tasks/TaskDropDownView.swift
+++ b/CodeEdit/Features/ActivityViewer/Tasks/TaskDropDownView.swift
@@ -44,6 +44,14 @@ struct TaskDropDownView: View {
         .onTapGesture {
             self.isTaskPopOverPresented.toggle()
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityIdentifier("TaskDropdown")
+        .accessibilityValue(taskManager.selectedTask?.name ?? "Create Tasks")
+        .accessibilityLabel("Active Task")
+        .accessibilityAction(named: "show menu") {
+            isTaskPopOverPresented = true
+        }
     }
 
     private var backgroundColor: some View {

--- a/CodeEdit/Features/ActivityViewer/Tasks/TaskDropDownView.swift
+++ b/CodeEdit/Features/ActivityViewer/Tasks/TaskDropDownView.swift
@@ -49,7 +49,8 @@ struct TaskDropDownView: View {
         .accessibilityIdentifier("TaskDropdown")
         .accessibilityValue(taskManager.selectedTask?.name ?? "Create Tasks")
         .accessibilityLabel("Active Task")
-        .accessibilityAction(named: "show menu") {
+        .accessibilityHint("Open the active task menu")
+        .accessibilityAction {
             isTaskPopOverPresented = true
         }
     }

--- a/CodeEdit/Features/ActivityViewer/Tasks/TaskDropDownView.swift
+++ b/CodeEdit/Features/ActivityViewer/Tasks/TaskDropDownView.swift
@@ -38,7 +38,7 @@ struct TaskDropDownView: View {
         .onHover { hovering in
             self.isHoveringTasks = hovering
         }
-        .instantPopover(isPresented: $isTaskPopOverPresented, arrowEdge: .bottom) {
+        .instantPopover(isPresented: $isTaskPopOverPresented, arrowEdge: .top) {
             taskPopoverContent
         }
         .onTapGesture {
@@ -71,7 +71,9 @@ struct TaskDropDownView: View {
         VStack(alignment: .leading, spacing: 0) {
             if !taskManager.availableTasks.isEmpty {
                 ForEach(taskManager.availableTasks, id: \.id) { task in
-                    TasksPopoverMenuItem(taskManager: taskManager, task: task)
+                    TasksPopoverMenuItem(taskManager: taskManager, task: task) {
+                        isTaskPopOverPresented = false
+                    }
                 }
                 Divider()
                     .padding(.vertical, 5)

--- a/CodeEdit/Features/ActivityViewer/Tasks/TaskView.swift
+++ b/CodeEdit/Features/ActivityViewer/Tasks/TaskView.swift
@@ -27,5 +27,7 @@ struct TaskView: View {
                 .frame(width: 5, height: 5)
                 .padding(.trailing, 2.5)
         }
+        .accessibilityElement()
+        .accessibilityLabel(task.name)
     }
 }

--- a/CodeEdit/Features/ActivityViewer/Tasks/TasksPopoverMenuItem.swift
+++ b/CodeEdit/Features/ActivityViewer/Tasks/TasksPopoverMenuItem.swift
@@ -23,11 +23,12 @@ struct TasksPopoverMenuItem: View {
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
         .modifier(DropdownMenuItemStyleModifier())
-        .onTapGesture {
-            taskManager.selectedTaskID = task.id
-            dismiss()
-        }
+        .onTapGesture(perform: selectAction)
         .clipShape(RoundedRectangle(cornerRadius: 5))
+        .accessibilityElement()
+        .accessibilityLabel(task.name)
+        .accessibilityAction(.default, selectAction)
+        .accessibilityAddTraits(taskManager.selectedTaskID == task.id ? [.isSelected] : [])
     }
 
     private var selectionIndicator: some View {
@@ -52,5 +53,10 @@ struct TasksPopoverMenuItem: View {
                 TaskView(task: task, status: taskManager.taskStatus(taskID: task.id))
             }
         }
+    }
+
+    private func selectAction() {
+        taskManager.selectedTaskID = task.id
+        dismiss()
     }
 }

--- a/CodeEdit/Features/ActivityViewer/Tasks/TasksPopoverMenuItem.swift
+++ b/CodeEdit/Features/ActivityViewer/Tasks/TasksPopoverMenuItem.swift
@@ -7,12 +7,13 @@
 
 import SwiftUI
 
+/// - Note: This view **cannot** use the `dismiss` environment value to dismiss the sheet. It has to negate the boolean
+///         value that presented it initially.
+///         See ``SwiftUI/View/instantPopover(isPresented:arrowEdge:content:)``
 struct TasksPopoverMenuItem: View {
-    @Environment(\.dismiss)
-    private var dismiss
-
     @ObservedObject var taskManager: TaskManager
     var task: CETask
+    var dismiss: () -> Void
 
     var body: some View {
         HStack(spacing: 5) {

--- a/CodeEdit/Features/ActivityViewer/Tasks/WorkspaceMenuItemView.swift
+++ b/CodeEdit/Features/ActivityViewer/Tasks/WorkspaceMenuItemView.swift
@@ -30,8 +30,10 @@ struct WorkspaceMenuItemView: View {
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
         .modifier(DropdownMenuItemStyleModifier())
-        .onTapGesture { }
+        .onTapGesture { } // add accessibility action when this is filled in
         .clipShape(RoundedRectangle(cornerRadius: 5))
+        .accessibilityElement()
+        .accessibilityLabel(item?.name ?? "")
     }
 }
 

--- a/CodeEdit/Features/CEWorkspaceSettings/Views/AddCETaskView.swift
+++ b/CodeEdit/Features/CEWorkspaceSettings/Views/AddCETaskView.swift
@@ -42,6 +42,7 @@ struct AddCETaskView: View {
             }
             .padding()
         }
+        .accessibilityIdentifier("AddTaskView")
     }
 
 }

--- a/CodeEdit/Features/CEWorkspaceSettings/Views/CETaskFormView.swift
+++ b/CodeEdit/Features/CEWorkspaceSettings/Views/CETaskFormView.swift
@@ -19,6 +19,7 @@ struct CETaskFormView: View {
                 TextField(text: $task.name) {
                     Text("Name")
                 }
+                .accessibilityLabel("Task Name")
                 Picker("Target", selection: $task.target) {
                     Text("My Mac")
                         .tag("My Mac")
@@ -32,12 +33,14 @@ struct CETaskFormView: View {
                     Text("Docker Compose")
                         .tag("Docker Compose")
                 }
+                .disabled(true)
             }
 
             Section {
                 TextField(text: $task.command) {
                     Text("Task")
                 }
+                .accessibilityLabel("Task Command")
                 TextField(text: $task.workingDirectory) {
                     Text("Working Directory")
                 }

--- a/CodeEdit/Features/CEWorkspaceSettings/Views/CEWorkspaceSettingsTaskListView.swift
+++ b/CodeEdit/Features/CEWorkspaceSettings/Views/CEWorkspaceSettingsTaskListView.swift
@@ -15,6 +15,7 @@ struct CEWorkspaceSettingsTaskListView: View {
 
     @Binding var selectedTaskID: UUID?
     @Binding var showAddTaskSheet: Bool
+
     var body: some View {
         if settings.tasks.isEmpty {
             Text("No tasks")

--- a/CodeEdit/Features/CEWorkspaceSettings/Views/CEWorkspaceSettingsView.swift
+++ b/CodeEdit/Features/CEWorkspaceSettings/Views/CEWorkspaceSettingsView.swift
@@ -26,8 +26,10 @@ struct CEWorkspaceSettingsView: View {
                         "Name",
                         text: $workspaceSettingsManager.settings.project.projectName
                     )
+                    .accessibilityLabel("Workspace Name")
                 } header: {
                     Text("Workspace")
+                        .accessibilityHidden(true)
                 }
 
                 Section {

--- a/CodeEdit/Features/CodeEditUI/Views/InstantPopoverModifier.swift
+++ b/CodeEdit/Features/CodeEditUI/Views/InstantPopoverModifier.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 
+/// See ``SwiftUI/View/instantPopover(isPresented:arrowEdge:content:)``
+/// - Warning: Views presented using this sheet must be dismissed by negating the `isPresented` binding. Using
+///            SwiftUI's `dismiss` will likely cause a crash. See [FB16221871](rdar://FB16221871)
 struct InstantPopoverModifier<PopoverContent: View>: ViewModifier {
     @Binding var isPresented: Bool
     let arrowEdge: Edge
@@ -24,6 +27,9 @@ struct InstantPopoverModifier<PopoverContent: View>: ViewModifier {
     }
 }
 
+/// See ``SwiftUI/View/instantPopover(isPresented:arrowEdge:content:)``
+/// - Warning: Views presented using this sheet must be dismissed by negating the `isPresented` binding. Using
+///            SwiftUI's `dismiss` will likely cause a crash. See [FB16221871](rdar://FB16221871)
 struct PopoverPresenter<ContentView: View>: NSViewRepresentable {
     @Binding var isPresented: Bool
     let arrowEdge: Edge
@@ -32,7 +38,7 @@ struct PopoverPresenter<ContentView: View>: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView { NSView() }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        if isPresented, context.coordinator.popover == nil {
+        if isPresented && context.coordinator.popover == nil {
             let popover = NSPopover()
             popover.animates = false
             let hostingController = NSHostingController(rootView: contentView)
@@ -109,8 +115,9 @@ struct PopoverPresenter<ContentView: View>: NSViewRepresentable {
 }
 
 extension View {
-
     /// A custom view modifier that presents a popover attached to the view with no animation.
+    /// - Warning: Views presented using this sheet must be dismissed by negating the `isPresented` binding. Using
+    ///            SwiftUI's `dismiss` will likely cause a crash. See [FB16221871](rdar://FB16221871)
     /// - Parameters:
     ///   - isPresented: A binding to whether the popover is presented.
     ///   - arrowEdge: The edge of the view that the popover points to. Defaults to `.bottom`.

--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowControllerExtensions.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowControllerExtensions.swift
@@ -125,6 +125,7 @@ extension CodeEditWindowController {
             settingsWindow.contentView = NSHostingView(rootView: contentView)
             settingsWindow.titlebarAppearsTransparent = true
             settingsWindow.setContentSize(NSSize(width: 515, height: 515))
+            settingsWindow.setAccessibilityTitle("Workspace Settings")
 
             window.beginSheet(settingsWindow, completionHandler: nil)
         }

--- a/CodeEditUITests/App.swift
+++ b/CodeEditUITests/App.swift
@@ -10,13 +10,22 @@ import XCTest
 enum App {
     static func launchWithCodeEditWorkspace() -> XCUIApplication {
         let application = XCUIApplication()
-        application.launchArguments = ["--open", projectPath()]
+        application.launchArguments = ["-ApplePersistenceIgnoreState", "YES", "--open", projectPath()]
+        application.launch()
+        return application
+    }
+
+    // Launches CodeEdit in a new directory
+    static func launchWithTempDir() throws -> XCUIApplication {
+        let application = XCUIApplication()
+        application.launchArguments = ["-ApplePersistenceIgnoreState", "YES", "--open", try tempProjectPath()]
         application.launch()
         return application
     }
 
     static func launch() -> XCUIApplication {
         let application = XCUIApplication()
+        application.launchArguments = ["-ApplePersistenceIgnoreState", "YES"]
         application.launch()
         return application
     }

--- a/CodeEditUITests/Features/ActivityViewer/Tasks/TasksMenuUITests.swift
+++ b/CodeEditUITests/Features/ActivityViewer/Tasks/TasksMenuUITests.swift
@@ -1,0 +1,41 @@
+//
+//  ActivityViewerTasksMenuTests.swift
+//  CodeEditUITests
+//
+//  Created by Khan Winter on 1/3/25.
+//
+
+import XCTest
+
+final class ActivityViewerTasksMenuTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/CodeEditUITests/ProjectPath.swift
+++ b/CodeEditUITests/ProjectPath.swift
@@ -16,3 +16,27 @@ func projectPath() -> String {
             .dropFirst()
     )
 }
+
+private var tempProjectPathIds = Set<String>()
+
+private func makeTempID() -> String {
+    let id = String((0..<10).map { _ in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-".randomElement()! })
+    if tempProjectPathIds.contains(id) {
+        return makeTempID()
+    }
+    tempProjectPathIds.insert(id)
+    return id
+}
+
+func tempProjectPath() throws -> String {
+    let baseDir = FileManager.default.temporaryDirectory.appending(path: "CodeEditUITests")
+    let id = makeTempID()
+    let path = baseDir.appending(path: id)
+    try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true)
+    return path.path(percentEncoded: false)
+}
+
+func cleanUpTempProjectPaths() throws {
+    let baseDir = FileManager.default.temporaryDirectory.appending(path: "CodeEditUITests")
+    try FileManager.default.removeItem(at: baseDir)
+}


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

- Fixes a crash when opening the task dropdown menu.
- Improves accessibility in the activity viewer, dropdowns, and workspace settings window.
- Adds UI tests for the dropdown menu and the entire task creation workflow.

### Related Issues

- N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

One of the new UI Tests

https://github.com/user-attachments/assets/de6ce034-92b9-475d-b0d2-ddcf05e2518d

