### PR TITLE
Clean Up File Management

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -480,6 +480,7 @@
 		6CD26C8A2C8F91ED00ADBA38 /* LanguageServer+DocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD26C892C8F91ED00ADBA38 /* LanguageServer+DocumentTests.swift */; };
 		6CD3CA552C8B508200D83DCD /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6CD3CA542C8B508200D83DCD /* CodeEditSourceEditor */; };
 		6CDA84AD284C1BA000C1CC3A /* EditorTabBarContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AC284C1BA000C1CC3A /* EditorTabBarContextMenu.swift */; };
+		6CDAFDDD2D35B2A0002B2D47 /* CEWorkspaceFileManager+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDAFDDC2D35B2A0002B2D47 /* CEWorkspaceFileManager+Error.swift */; };
 		6CE21E812C643D8F0031B056 /* CETerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE21E802C643D8F0031B056 /* CETerminalView.swift */; };
 		6CE21E872C650D2C0031B056 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 6CE21E862C650D2C0031B056 /* SwiftTerm */; };
 		6CE622692A2A174A0013085C /* InspectorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE622682A2A174A0013085C /* InspectorTab.swift */; };
@@ -1161,6 +1162,7 @@
 		6CD26C802C8F8A4400ADBA38 /* LanguageIdentifier+CodeLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LanguageIdentifier+CodeLanguage.swift"; sourceTree = "<group>"; };
 		6CD26C892C8F91ED00ADBA38 /* LanguageServer+DocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LanguageServer+DocumentTests.swift"; sourceTree = "<group>"; };
 		6CDA84AC284C1BA000C1CC3A /* EditorTabBarContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabBarContextMenu.swift; sourceTree = "<group>"; };
+		6CDAFDDC2D35B2A0002B2D47 /* CEWorkspaceFileManager+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CEWorkspaceFileManager+Error.swift"; sourceTree = "<group>"; };
 		6CE21E802C643D8F0031B056 /* CETerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CETerminalView.swift; sourceTree = "<group>"; };
 		6CE622682A2A174A0013085C /* InspectorTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorTab.swift; sourceTree = "<group>"; };
 		6CE6226A2A2A1C730013085C /* UtilityAreaTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityAreaTab.swift; sourceTree = "<group>"; };
@@ -2425,6 +2427,7 @@
 				58A2E40629C3975D005CB615 /* CEWorkspaceFileIcon.swift */,
 				58710158298EB80000951BA4 /* CEWorkspaceFileManager.swift */,
 				77EF6C0C2C60E23400984B69 /* CEWorkspaceFileManager+DirectoryEvents.swift */,
+				6CDAFDDC2D35B2A0002B2D47 /* CEWorkspaceFileManager+Error.swift */,
 				6CB52DC82AC8DC3E002E75B3 /* CEWorkspaceFileManager+FileManagement.swift */,
 				6C049A362A49E2DB00D42923 /* DirectoryEventStream.swift */,
 			);
@@ -4136,6 +4139,7 @@
 				D7012EE827E757850001E1EF /* FindNavigatorView.swift in Sources */,
 				58A5DF8029325B5A00D1BD5D /* GitClient.swift in Sources */,
 				D7E201AE27E8B3C000CB86D0 /* String+Ranges.swift in Sources */,
+				6CDAFDDD2D35B2A0002B2D47 /* CEWorkspaceFileManager+Error.swift in Sources */,
 				6CE6226E2A2A1CDE0013085C /* NavigatorTab.swift in Sources */,
 				041FC6AD2AE437CE00C1F65A /* SourceControlNewBranchView.swift in Sources */,
 				77A01E432BBC3A2800F0EA38 /* CETask.swift in Sources */,

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -481,6 +481,7 @@
 		6CD3CA552C8B508200D83DCD /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6CD3CA542C8B508200D83DCD /* CodeEditSourceEditor */; };
 		6CDA84AD284C1BA000C1CC3A /* EditorTabBarContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDA84AC284C1BA000C1CC3A /* EditorTabBarContextMenu.swift */; };
 		6CDAFDDD2D35B2A0002B2D47 /* CEWorkspaceFileManager+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDAFDDC2D35B2A0002B2D47 /* CEWorkspaceFileManager+Error.swift */; };
+		6CDAFDDF2D35DADD002B2D47 /* String+ValidFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDAFDDE2D35DADD002B2D47 /* String+ValidFileName.swift */; };
 		6CE21E812C643D8F0031B056 /* CETerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE21E802C643D8F0031B056 /* CETerminalView.swift */; };
 		6CE21E872C650D2C0031B056 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 6CE21E862C650D2C0031B056 /* SwiftTerm */; };
 		6CE622692A2A174A0013085C /* InspectorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE622682A2A174A0013085C /* InspectorTab.swift */; };
@@ -489,6 +490,8 @@
 		6CED16E42A3E660D000EC962 /* String+Lines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CED16E32A3E660D000EC962 /* String+Lines.swift */; };
 		6CFBA54B2C4E168A00E3A914 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFBA54A2C4E168A00E3A914 /* App.swift */; };
 		6CFBA54D2C4E16C900E3A914 /* WindowCloseCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFBA54C2C4E16C900E3A914 /* WindowCloseCommandTests.swift */; };
+		6CFC0C3C2D381D2000F09CD0 /* ProjectNavigatorFileManagementUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFC0C3B2D381D2000F09CD0 /* ProjectNavigatorFileManagementUITests.swift */; };
+		6CFC0C3E2D382B3F00F09CD0 /* UI TESTING.md in Resources */ = {isa = PBXBuildFile; fileRef = 6CFC0C3D2D382B3900F09CD0 /* UI TESTING.md */; };
 		6CFF967429BEBCC300182D6F /* FindCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFF967329BEBCC300182D6F /* FindCommands.swift */; };
 		6CFF967629BEBCD900182D6F /* FileCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFF967529BEBCD900182D6F /* FileCommands.swift */; };
 		6CFF967829BEBCF600182D6F /* MainCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFF967729BEBCF600182D6F /* MainCommands.swift */; };
@@ -1163,6 +1166,7 @@
 		6CD26C892C8F91ED00ADBA38 /* LanguageServer+DocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LanguageServer+DocumentTests.swift"; sourceTree = "<group>"; };
 		6CDA84AC284C1BA000C1CC3A /* EditorTabBarContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabBarContextMenu.swift; sourceTree = "<group>"; };
 		6CDAFDDC2D35B2A0002B2D47 /* CEWorkspaceFileManager+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CEWorkspaceFileManager+Error.swift"; sourceTree = "<group>"; };
+		6CDAFDDE2D35DADD002B2D47 /* String+ValidFileName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ValidFileName.swift"; sourceTree = "<group>"; };
 		6CE21E802C643D8F0031B056 /* CETerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CETerminalView.swift; sourceTree = "<group>"; };
 		6CE622682A2A174A0013085C /* InspectorTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorTab.swift; sourceTree = "<group>"; };
 		6CE6226A2A2A1C730013085C /* UtilityAreaTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityAreaTab.swift; sourceTree = "<group>"; };
@@ -1170,6 +1174,8 @@
 		6CED16E32A3E660D000EC962 /* String+Lines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Lines.swift"; sourceTree = "<group>"; };
 		6CFBA54A2C4E168A00E3A914 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		6CFBA54C2C4E16C900E3A914 /* WindowCloseCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCloseCommandTests.swift; sourceTree = "<group>"; };
+		6CFC0C3B2D381D2000F09CD0 /* ProjectNavigatorFileManagementUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectNavigatorFileManagementUITests.swift; sourceTree = "<group>"; };
+		6CFC0C3D2D382B3900F09CD0 /* UI TESTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "UI TESTING.md"; sourceTree = "<group>"; };
 		6CFF967329BEBCC300182D6F /* FindCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindCommands.swift; sourceTree = "<group>"; };
 		6CFF967529BEBCD900182D6F /* FileCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCommands.swift; sourceTree = "<group>"; };
 		6CFF967729BEBCF600182D6F /* MainCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCommands.swift; sourceTree = "<group>"; };
@@ -2505,18 +2511,18 @@
 			children = (
 				588847672992AAB800996D95 /* Array */,
 				5831E3C72933E7F700D5A6D2 /* Bundle */,
-				5831E3C62933E7E600D5A6D2 /* Color */,
 				669A504F2C380BFD00304CD8 /* Collection */,
+				5831E3C62933E7E600D5A6D2 /* Color */,
 				5831E3C82933E80500D5A6D2 /* Date */,
 				6CB94D002C9F1CF900E8651C /* LanguageIdentifier */,
 				6C82D6C429C0129E00495C54 /* NSApplication */,
 				5831E3D02934036D00D5A6D2 /* NSTableView */,
 				77A01E922BCA9C0400F0EA38 /* NSWindow */,
-				6CB94CFF2C9F1CB600E8651C /* TextView */,
-				77EF6C042C57DE4B00984B69 /* URL */,
 				58D01C8B293167DC00C5B6B4 /* String */,
 				5831E3CB2933E89A00D5A6D2 /* SwiftTerm */,
 				6CBD1BC42978DE3E006639D5 /* Text */,
+				6CB94CFF2C9F1CB600E8651C /* TextView */,
+				77EF6C042C57DE4B00984B69 /* URL */,
 				6CD26C752C8EA80000ADBA38 /* URL */,
 				5831E3CA2933E86F00D5A6D2 /* View */,
 			);
@@ -2535,6 +2541,7 @@
 				D7E201AD27E8B3C000CB86D0 /* String+Ranges.swift */,
 				58D01C8D293167DC00C5B6B4 /* String+RemoveOccurrences.swift */,
 				58D01C8C293167DC00C5B6B4 /* String+SHA256.swift */,
+				6CDAFDDE2D35DADD002B2D47 /* String+ValidFileName.swift */,
 			);
 			path = String;
 			sourceTree = "<group>";
@@ -3034,6 +3041,7 @@
 		6C96191C2C3F27E3009733CE /* ProjectNavigator */ = {
 			isa = PBXGroup;
 			children = (
+				6CFC0C3B2D381D2000F09CD0 /* ProjectNavigatorFileManagementUITests.swift */,
 				6C96191B2C3F27E3009733CE /* ProjectNavigatorUITests.swift */,
 			);
 			path = ProjectNavigator;
@@ -3059,6 +3067,7 @@
 		6C96191F2C3F27E3009733CE /* CodeEditUITests */ = {
 			isa = PBXGroup;
 			children = (
+				6CFC0C3D2D382B3900F09CD0 /* UI TESTING.md */,
 				6CFBA54A2C4E168A00E3A914 /* App.swift */,
 				6C510CB62D2E462D006EBE85 /* Extensions */,
 				6C96191E2C3F27E3009733CE /* Features */,
@@ -3980,6 +3989,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6CFC0C3E2D382B3F00F09CD0 /* UI TESTING.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4076,6 +4086,7 @@
 				EC0870F72A455F6400EB8692 /* ProjectNavigatorViewController+NSMenuDelegate.swift in Sources */,
 				B60718202B0C6CE7009CDAB4 /* GitStashEntry.swift in Sources */,
 				6CAAF69429BCD78600A1F48A /* (null) in Sources */,
+				6CDAFDDF2D35DADD002B2D47 /* String+ValidFileName.swift in Sources */,
 				3026F50F2AC006C80061227E /* InspectorAreaViewModel.swift in Sources */,
 				6C82D6C629C012AD00495C54 /* NSApp+openWindow.swift in Sources */,
 				6C14CEB028777D3C001468FE /* FindNavigatorListViewController.swift in Sources */,
@@ -4636,6 +4647,7 @@
 				6CFBA54D2C4E16C900E3A914 /* WindowCloseCommandTests.swift in Sources */,
 				6C9619222C3F27F1009733CE /* Query.swift in Sources */,
 				6C07383B2D284ECA0025CBE3 /* TasksMenuUITests.swift in Sources */,
+				6CFC0C3C2D381D2000F09CD0 /* ProjectNavigatorFileManagementUITests.swift in Sources */,
 				6C9619202C3F27E3009733CE /* ProjectNavigatorUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -253,13 +253,15 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
     }
 
     func validateFileName(for newName: String) -> Bool {
-        guard newName != labelFileName() else { return true }
-
-        guard !newName.isEmpty && newName.isValidFilename &&
+        // Name must be: new, nonempty, valid characters, and not exist in the filesystem.
+        guard newName != labelFileName() &&
+                !newName.isEmpty &&
+                newName.isValidFilename &&
                 !FileManager.default.fileExists(
                     atPath: self.url.deletingLastPathComponent().appendingPathComponent(newName).path
-                )
-        else { return false }
+                ) else {
+            return false
+        }
 
         return true
     }

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+DirectoryEvents.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+DirectoryEvents.swift
@@ -19,11 +19,10 @@ extension CEWorkspaceFileManager {
             var files: Set<CEWorkspaceFile> = []
             for event in events {
                 // Event returns file/folder that was changed, but in tree we need to update it's parent
-                let parentUrl = "/" + event.path.split(separator: "/").dropLast().joined(separator: "/")
-                // Find all folders pointing to the parent's file url.
-                let fileItems = self.flattenedFileItems.filter({
-                    $0.value.resolvedURL.path == parentUrl
-                }).map { $0.value }
+                guard let parentUrl = URL(string: event.path, relativeTo: self.folderUrl)?.deletingLastPathComponent(),
+                      let parentFileItem = self.flattenedFileItems[parentUrl.path] else {
+                    continue
+                }
 
                 switch event.eventType {
                 case .changeInDirectory, .itemChangedOwner, .itemModified:
@@ -33,15 +32,13 @@ extension CEWorkspaceFileManager {
                     // TODO: #1880 - Handle workspace root changing.
                     continue
                 case .itemCreated, .itemCloned, .itemRemoved, .itemRenamed:
-                    for fileItem in fileItems {
-                        do {
-                            try self.rebuildFiles(fromItem: fileItem)
-                        } catch {
-                            // swiftlint:disable:next line_length
-                            self.logger.error("Failed to rebuild files for event: \(event.eventType.rawValue), path: \(event.path, privacy: .sensitive)")
-                        }
-                        files.insert(fileItem)
+                    do {
+                        try self.rebuildFiles(fromItem: parentFileItem)
+                    } catch {
+                        // swiftlint:disable:next line_length
+                        self.logger.error("Failed to rebuild files for event: \(event.eventType.rawValue), path: \(event.path, privacy: .sensitive)")
                     }
+                    files.insert(parentFileItem)
                 }
             }
             if !files.isEmpty {

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+Error.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+Error.swift
@@ -8,10 +8,14 @@
 import Foundation
 
 extension CEWorkspaceFileManager {
+    /// Localized errors related to actions in the file manager.
+    /// These errors are suitable for presentation using `NSAlert(error:)`.
     enum FileManagerError: LocalizedError {
         case fileNotFound
         case fileNotIndexed
         case originFileNotFound
+        case destinationFileExists
+        case invalidFileName
 
         var errorDescription: String? {
             switch self {
@@ -21,15 +25,23 @@ extension CEWorkspaceFileManager {
                 return "File not found in CodeEdit"
             case .originFileNotFound:
                 return "Failed to find origin file"
+            case .destinationFileExists:
+                return "Destination already exists"
+            case .invalidFileName:
+                return "Invalid file name"
             }
         }
 
-        var helpAnchor: String? {
+        var recoverySuggestion: String? {
             switch self {
             case .fileNotIndexed:
                 return "Reopen the workspace to reindex the file system."
             case .fileNotFound, .originFileNotFound:
                 return "The file may have moved during the operation, try again."
+            case .destinationFileExists:
+                return "Use a different file name or remove the conflicting file."
+            case .invalidFileName:
+                return "File names must not contain the : character and be less than 256 characters."
             }
         }
     }

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+Error.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+Error.swift
@@ -1,0 +1,36 @@
+//
+//  CEWorkspaceFileManager+Error.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 1/13/25.
+//
+
+import Foundation
+
+extension CEWorkspaceFileManager {
+    enum FileManagerError: LocalizedError {
+        case fileNotFound
+        case fileNotIndexed
+        case originFileNotFound
+
+        var errorDescription: String? {
+            switch self {
+            case .fileNotFound:
+                return "File not found"
+            case .fileNotIndexed:
+                return "File not found in CodeEdit"
+            case .originFileNotFound:
+                return "Failed to find origin file"
+            }
+        }
+
+        var helpAnchor: String? {
+            switch self {
+            case .fileNotIndexed:
+                return "Reopen the workspace to reindex the file system."
+            case .fileNotFound, .originFileNotFound:
+                return "The file may have moved during the operation, try again."
+            }
+        }
+    }
+}

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
@@ -13,6 +13,7 @@ extension CEWorkspaceFileManager {
     /// - Parameters:
     ///   - folderName: The name of the new folder
     ///   - file: The file to add the new folder to.
+    /// - Returns: The ``CEWorkspaceFile`` representing the folder in the file manager's cache.
     /// - Authors: Mattijs Eikelenboom, KaiTheRedNinja. *Moved from 7c27b1e*
     func addFolder(folderName: String, toFile file: CEWorkspaceFile) throws -> CEWorkspaceFile {
         // Check if folder, if it is create folder under self, else create on same level.

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
@@ -200,7 +200,7 @@ extension CEWorkspaceFileManager {
             }
         }
     }
-    
+
     /// Delete a file from the file system.
     /// - Note: Use ``trash(file:)`` if the file should be moved to the trash. This is irreversible.
     /// - Parameter url: The file URL to delete.

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
@@ -58,7 +58,7 @@ extension CEWorkspaceFileManager {
     /// - Authors: Mattijs Eikelenboom, KaiTheRedNinja. *Moved from 7c27b1e*
     /// - Throws: Throws a `CocoaError.fileWriteUnknown` with the file url if creating the file fails, and calls
     ///           ``rebuildFiles(fromItem:deep:)`` which throws other `FileManager` errors.
-    /// - Returns: The newly created file.
+    /// - Returns: The ``CEWorkspaceFile`` representing the new file in the file manager's cache.  
     func addFile(
         fileName: String,
         toFile file: CEWorkspaceFile,

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
@@ -58,7 +58,7 @@ extension CEWorkspaceFileManager {
     /// - Authors: Mattijs Eikelenboom, KaiTheRedNinja. *Moved from 7c27b1e*
     /// - Throws: Throws a `CocoaError.fileWriteUnknown` with the file url if creating the file fails, and calls
     ///           ``rebuildFiles(fromItem:deep:)`` which throws other `FileManager` errors.
-    /// - Returns: The ``CEWorkspaceFile`` representing the new file in the file manager's cache.  
+    /// - Returns: The ``CEWorkspaceFile`` representing the new file in the file manager's cache.
     func addFile(
         fileName: String,
         toFile file: CEWorkspaceFile,
@@ -200,7 +200,10 @@ extension CEWorkspaceFileManager {
             }
         }
     }
-
+    
+    /// Delete a file from the file system.
+    /// - Note: Use ``trash(file:)`` if the file should be moved to the trash. This is irreversible.
+    /// - Parameter url: The file URL to delete.
     private func deleteFile(at url: URL) throws {
         do {
             guard fileManager.fileExists(atPath: url.path) else {

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
@@ -80,6 +80,7 @@ final class CEWorkspaceFileManager {
 
         Task {
             try await self.sourceControlManager?.validate()
+            await sourceControlManager?.refreshAllChangedFiles()
         }
     }
 

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
@@ -80,7 +80,6 @@ final class CEWorkspaceFileManager {
 
         Task {
             try await self.sourceControlManager?.validate()
-            await sourceControlManager?.refreshAllChangedFiles()
         }
     }
 

--- a/CodeEdit/Features/CEWorkspace/Models/DirectoryEventStream.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/DirectoryEventStream.swift
@@ -92,6 +92,8 @@ class DirectoryEventStream {
                 // it is useful when file renamed, because it's firing to separate events with old and new path,
                 // but they can be linked by file id
                 | kFSEventStreamCreateFlagUseExtendedData
+                // Useful for us, always sends after the debounce duration.
+                | kFSEventStreamCreateFlagNoDefer
             )
         ) {
             self.streamRef = ref

--- a/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
@@ -176,11 +176,3 @@ extension FileSystemTableViewCell: NSTextFieldDelegate {
         }
     }
 }
-
-extension String {
-    var isValidFilename: Bool {
-        let regex = "[^:]"
-        let testString = NSPredicate(format: "SELF MATCHES %@", regex)
-        return !testString.evaluate(with: self)
-    }
-}

--- a/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
@@ -159,12 +159,20 @@ extension FileSystemTableViewCell: NSTextFieldDelegate {
 
     func controlTextDidEndEditing(_ obj: Notification) {
         guard let fileItem else { return }
-        textField?.backgroundColor = fileItem.validateFileName(for: textField?.stringValue ?? "") ? .none : errorRed
-        if fileItem.validateFileName(for: textField?.stringValue ?? "") {
-            let newURL = fileItem.url.deletingLastPathComponent().appendingPathComponent(textField?.stringValue ?? "")
-            workspace?.workspaceFileManager?.move(file: fileItem, to: newURL)
-        } else {
-            textField?.stringValue = fileItem.labelFileName()
+        do {
+            textField?.backgroundColor = fileItem.validateFileName(for: textField?.stringValue ?? "") ? .none : errorRed
+            if fileItem.validateFileName(for: textField?.stringValue ?? "") {
+                let newURL = fileItem.url
+                    .deletingLastPathComponent()
+                    .appendingPathComponent(textField?.stringValue ?? "")
+                try workspace?.workspaceFileManager?.move(file: fileItem, to: newURL)
+            } else {
+                textField?.stringValue = fileItem.labelFileName()
+            }
+        } catch {
+            let alert = NSAlert(error: error)
+            alert.addButton(withTitle: "Dismiss")
+            alert.runModal()
         }
     }
 }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
@@ -75,10 +75,17 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
 
         func fileManagerUpdated(updatedItems: Set<CEWorkspaceFile>) {
             guard let outlineView = controller?.outlineView else { return }
+            let selectedRows = outlineView.selectedRowIndexes.compactMap({ outlineView.item(atRow: $0) })
 
             for item in updatedItems {
                 outlineView.reloadItem(item, reloadChildren: true)
             }
+
+            // Restore selected items where the files still exist.
+            let selectedIndexes = selectedRows.compactMap({ outlineView.row(forItem: $0) }).filter({ $0 >= 0 })
+            controller?.shouldSendSelectionUpdate = false
+            outlineView.selectRowIndexes(IndexSet(selectedIndexes), byExtendingSelection: false)
+            controller?.shouldSendSelectionUpdate = true
         }
 
         deinit {

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDataSource.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDataSource.swift
@@ -15,9 +15,13 @@ extension ProjectNavigatorViewController: NSOutlineViewDataSource {
         }
 
         if let children = workspace?.workspaceFileManager?.childrenOfFile(item) {
-            let filteredChildren = children.filter { fileSearchMatches(workspace?.navigatorFilter ?? "", for: $0) }
-            filteredContentChildren[item] = filteredChildren
-            return filteredChildren
+            if let filter = workspace?.navigatorFilter, !filter.isEmpty {
+                let filteredChildren = children.filter { fileSearchMatches(filter, for: $0) }
+                filteredContentChildren[item] = filteredChildren
+                return filteredChildren
+            }
+
+            return children
         }
 
         return []

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
@@ -115,7 +115,6 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
             outlineView.deselectRow(outlineView.selectedRow)
         }
         shouldSendSelectionUpdate = false
-        print("Selecting", id.id)
         outlineView.selectRowIndexes(.init(integer: row), byExtendingSelection: false)
         shouldSendSelectionUpdate = true
     }
@@ -129,7 +128,6 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
         }
         let row = outlineView.row(forItem: fileItem)
         shouldSendSelectionUpdate = false
-        print("Revealing", fileItem.url.relativePath)
         outlineView.selectRowIndexes(.init(integer: row), byExtendingSelection: false)
         shouldSendSelectionUpdate = true
 

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDelegate.swift
@@ -45,13 +45,11 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
         guard let item = outlineView.item(atRow: selectedIndex) as? CEWorkspaceFile else { return }
 
         if !item.isFolder && shouldSendSelectionUpdate {
-            DispatchQueue.main.async { [weak self] in
-                self?.shouldSendSelectionUpdate = false
-                if self?.workspace?.editorManager?.activeEditor.selectedTab?.file != item {
-                    self?.workspace?.editorManager?.activeEditor.openTab(file: item, asTemporary: true)
-                }
-                self?.shouldSendSelectionUpdate = true
+            shouldSendSelectionUpdate = false
+            if workspace?.editorManager?.activeEditor.selectedTab?.file != item {
+                workspace?.editorManager?.activeEditor.openTab(file: item, asTemporary: true)
             }
+            shouldSendSelectionUpdate = true
         }
     }
 
@@ -117,6 +115,7 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
             outlineView.deselectRow(outlineView.selectedRow)
         }
         shouldSendSelectionUpdate = false
+        print("Selecting", id.id)
         outlineView.selectRowIndexes(.init(integer: row), byExtendingSelection: false)
         shouldSendSelectionUpdate = true
     }
@@ -130,6 +129,7 @@ extension ProjectNavigatorViewController: NSOutlineViewDelegate {
         }
         let row = outlineView.row(forItem: fileItem)
         shouldSendSelectionUpdate = false
+        print("Revealing", fileItem.url.relativePath)
         outlineView.selectRowIndexes(.init(integer: row), byExtendingSelection: false)
         shouldSendSelectionUpdate = true
 

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+OutlineTableViewCellDelegate.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+OutlineTableViewCellDelegate.swift
@@ -21,8 +21,8 @@ extension ProjectNavigatorViewController: OutlineTableViewCellDelegate {
             if !file.isFolder {
                 workspace?.editorManager?.editorLayout.closeAllTabs(of: file)
             }
+            workspace?.listenerModel.highlightedFileItem = newFile
             workspace?.editorManager?.openTab(item: newFile)
-            select(by: file.tabID, forcesReveal: true)
         } catch {
             let alert = NSAlert(error: error)
             alert.addButton(withTitle: "Dismiss")

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+OutlineTableViewCellDelegate.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+OutlineTableViewCellDelegate.swift
@@ -6,35 +6,37 @@
 //
 
 import Foundation
+import AppKit
 
 // MARK: - OutlineTableViewCellDelegate
 
 extension ProjectNavigatorViewController: OutlineTableViewCellDelegate {
     func moveFile(file: CEWorkspaceFile, to destination: URL) {
-        if !file.isFolder {
-            workspace?.editorManager?.editorLayout.closeAllTabs(of: file)
-        }
-        workspace?.workspaceFileManager?.move(file: file, to: destination)
-        if let parent = file.parent {
-            do {
-                try workspace?.workspaceFileManager?.rebuildFiles(fromItem: parent)
-
-                // Grab the file connected to the rest of the cached file tree.
-                guard let newFile = workspace?.workspaceFileManager?.getFile(
-                    destination.absoluteURL.path(percentEncoded: false)
-                ),
-                      !newFile.isFolder else {
-                    return
-                }
-
-                workspace?.editorManager?.openTab(item: newFile)
-            } catch {
-                Self.logger.error("Failed to rebuild file item after moving: \(error)")
+        do {
+            guard let newFile = try workspace?.workspaceFileManager?.move(file: file, to: destination),
+                  !newFile.isFolder else {
+                return
             }
+            outlineView.reloadItem(file.parent, reloadChildren: true)
+            if !file.isFolder {
+                workspace?.editorManager?.editorLayout.closeAllTabs(of: file)
+            }
+            workspace?.editorManager?.openTab(item: newFile)
+            select(by: file.tabID, forcesReveal: true)
+        } catch {
+            let alert = NSAlert(error: error)
+            alert.addButton(withTitle: "Dismiss")
+            alert.runModal()
         }
     }
 
     func copyFile(file: CEWorkspaceFile, to destination: URL) {
-        workspace?.workspaceFileManager?.copy(file: file, to: destination)
+        do {
+            try workspace?.workspaceFileManager?.copy(file: file, to: destination)
+        } catch {
+            let alert = NSAlert(error: error)
+            alert.addButton(withTitle: "Dismiss")
+            alert.runModal()
+        }
     }
 }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
@@ -98,7 +98,13 @@ struct ProjectNavigatorToolbarBottom: View {
                 let filePathURL = activeTabURL()
                 guard let rootFile = workspace.workspaceFileManager?.getFile(filePathURL.path) else { return }
                 do {
-                    try workspace.workspaceFileManager?.addFile(fileName: "untitled", toFile: rootFile)
+                    if let newFile = try workspace.workspaceFileManager?.addFile(
+                        fileName: "untitled",
+                        toFile: rootFile
+                    ) {
+                        editorManager.openTab(item: newFile)
+                        NSApp.sendAction(#selector(ProjectNavigatorViewController.revealFile(_:)), to: nil, from: nil)
+                    }
                 } catch {
                     let alert = NSAlert(error: error)
                     alert.addButton(withTitle: "Dismiss")
@@ -108,7 +114,13 @@ struct ProjectNavigatorToolbarBottom: View {
             Button("Add Folder") {
                 let filePathURL = activeTabURL()
                 guard let rootFile = workspace.workspaceFileManager?.getFile(filePathURL.path) else { return }
-                workspace.workspaceFileManager?.addFolder(folderName: "untitled", toFile: rootFile)
+                do {
+                    try workspace.workspaceFileManager?.addFolder(folderName: "untitled", toFile: rootFile)
+                } catch {
+                    let alert = NSAlert(error: error)
+                    alert.addButton(withTitle: "Dismiss")
+                    alert.runModal()
+                }
             }
         } label: {}
         .background {

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
@@ -102,8 +102,8 @@ struct ProjectNavigatorToolbarBottom: View {
                         fileName: "untitled",
                         toFile: rootFile
                     ) {
-                        editorManager.openTab(item: newFile)
-                        NSApp.sendAction(#selector(ProjectNavigatorViewController.revealFile(_:)), to: nil, from: nil)
+                        workspace.listenerModel.highlightedFileItem = newFile
+                        workspace.editorManager?.openTab(item: newFile)
                     }
                 } catch {
                     let alert = NSAlert(error: error)
@@ -111,11 +111,17 @@ struct ProjectNavigatorToolbarBottom: View {
                     alert.runModal()
                 }
             }
+
             Button("Add Folder") {
                 let filePathURL = activeTabURL()
                 guard let rootFile = workspace.workspaceFileManager?.getFile(filePathURL.path) else { return }
                 do {
-                    try workspace.workspaceFileManager?.addFolder(folderName: "untitled", toFile: rootFile)
+                    if let newFolder = try workspace.workspaceFileManager?.addFolder(
+                        folderName: "untitled",
+                        toFile: rootFile
+                    ) {
+                        workspace.listenerModel.highlightedFileItem = newFolder
+                    }
                 } catch {
                     let alert = NSAlert(error: error)
                     alert.addButton(withTitle: "Dismiss")
@@ -125,11 +131,14 @@ struct ProjectNavigatorToolbarBottom: View {
         } label: {}
         .background {
             Image(systemName: "plus")
+                .accessibilityHidden(true)
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .frame(maxWidth: 18, alignment: .center)
         .opacity(activeState == .inactive ? 0.45 : 1)
+        .accessibilityLabel("Add Folder or File")
+        .accessibilityIdentifier("addButton")
     }
 
     /// We clear the text and remove the first responder which removes the cursor

--- a/CodeEdit/Utils/Extensions/String/String+ValidFileName.swift
+++ b/CodeEdit/Utils/Extensions/String/String+ValidFileName.swift
@@ -13,9 +13,9 @@ extension CharacterSet {
 }
 
 extension String {
-    /// On macOS, valid file names must not contain the `NULL` or `:` characters and must be less than
-    /// 256 UTF16 characters.
+    /// On macOS, valid file names must not contain the `NULL` or `:` characters, must be non-empty, and must be less
+    /// than 256 UTF16 characters.
     var isValidFilename: Bool {
-        CharacterSet(charactersIn: self).isDisjoint(with: .invalidFileNameCharacters) && utf16.count < 256
+        !isEmpty && CharacterSet(charactersIn: self).isDisjoint(with: .invalidFileNameCharacters) && utf16.count < 256
     }
 }

--- a/CodeEdit/Utils/Extensions/String/String+ValidFileName.swift
+++ b/CodeEdit/Utils/Extensions/String/String+ValidFileName.swift
@@ -1,0 +1,21 @@
+//
+//  String+ValidFileName.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 1/13/25.
+//
+
+import Foundation
+
+extension CharacterSet {
+    /// On macOS, valid file names must not contain the `NULL` or `:` characters.
+    static var invalidFileNameCharacters: CharacterSet = CharacterSet(charactersIn: "\0:")
+}
+
+extension String {
+    /// On macOS, valid file names must not contain the `NULL` or `:` characters and must be less than
+    /// 256 UTF16 characters.
+    var isValidFilename: Bool {
+        CharacterSet(charactersIn: self).isDisjoint(with: .invalidFileNameCharacters) && utf16.count < 256
+    }
+}

--- a/CodeEditTests/Utils/CEWorkspaceFileManager/CEWorkspaceFileManagerTests.swift
+++ b/CodeEditTests/Utils/CEWorkspaceFileManager/CEWorkspaceFileManagerTests.swift
@@ -63,38 +63,36 @@ final class CEWorkspaceFileManagerUnitTests: XCTestCase {
     }
 
     func testDirectoryChanges() throws {
-        // This test is flaky on CI. Right now, the mac runner can take hours to send the file system events that
-        // this relies on. Commenting out for now to make automated testing feasible.
-//        let client = CEWorkspaceFileManager(
-//            folderUrl: directory,
-//            ignoredFilesAndFolders: [],
-//            sourceControlManager: nil
-//        )
-//
-//        let newFile = generateRandomFiles(amount: 1)[0]
-//        let expectation = XCTestExpectation(description: "wait for files")
-//
-//        let observer = DummyObserver {
-//            let url = client.folderUrl.appending(path: newFile).path
-//            if client.flattenedFileItems[url] != nil {
-//                expectation.fulfill()
-//            }
-//        }
-//        client.addObserver(observer)
-//
-//        var files = client.flattenedFileItems.map { $0.value.name }
-//        files.append(newFile)
-//        try files.forEach {
-//            let fakeData = Data("fake string".utf8)
-//            let fileUrl = directory
-//                .appendingPathComponent($0)
-//            try fakeData.write(to: fileUrl)
-//        }
-//
-//        wait(for: [expectation], timeout: 2.0)
-//        XCTAssertEqual(files.count, client.flattenedFileItems.count - 1)
-//        try FileManager.default.removeItem(at: directory)
-//        client.removeObserver(observer)
+        let client = CEWorkspaceFileManager(
+            folderUrl: directory,
+            ignoredFilesAndFolders: [],
+            sourceControlManager: nil
+        )
+
+        let newFile = generateRandomFiles(amount: 1)[0]
+        let expectation = XCTestExpectation(description: "wait for files")
+
+        let observer = DummyObserver {
+            let url = client.folderUrl.appending(path: newFile).path
+            if client.flattenedFileItems[url] != nil {
+                expectation.fulfill()
+            }
+        }
+        client.addObserver(observer)
+
+        var files = client.flattenedFileItems.map { $0.value.name }
+        files.append(newFile)
+        try files.forEach {
+            let fakeData = Data("fake string".utf8)
+            let fileUrl = directory
+                .appendingPathComponent($0)
+            try fakeData.write(to: fileUrl)
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+        XCTAssertEqual(files.count, client.flattenedFileItems.count - 1)
+        try FileManager.default.removeItem(at: directory)
+        client.removeObserver(observer)
     }
 
     func generateRandomFiles(amount: Int) -> [String] {
@@ -117,30 +115,30 @@ final class CEWorkspaceFileManagerUnitTests: XCTestCase {
         try FileManager.default.createDirectory(at: testDirectoryURL, withIntermediateDirectories: true)
         try "".write(to: testFileURL, atomically: true, encoding: .utf8)
 
-        let fileManger = CEWorkspaceFileManager(
+        let fileManager = CEWorkspaceFileManager(
             folderUrl: directory,
             ignoredFilesAndFolders: [],
             sourceControlManager: nil
         )
 
-        XCTAssert(fileManger.getFile(testFileURL.path()) == nil)
-        XCTAssert(fileManger.childrenOfFile(CEWorkspaceFile(url: testFileURL)) == nil)
-        XCTAssert(fileManger.getFile(testFileURL.path(), createIfNotFound: true) != nil)
-        XCTAssert(fileManger.childrenOfFile(CEWorkspaceFile(url: testDirectoryURL)) != nil)
+        XCTAssert(fileManager.getFile(testFileURL.path()) == nil)
+        XCTAssert(fileManager.childrenOfFile(CEWorkspaceFile(url: testFileURL)) == nil)
+        XCTAssert(fileManager.getFile(testFileURL.path(), createIfNotFound: true) != nil)
+        XCTAssert(fileManager.childrenOfFile(CEWorkspaceFile(url: testDirectoryURL)) != nil)
     }
 
     func testDeleteFile() throws {
         let testFileURL = directory.appending(path: "file.txt")
         try "".write(to: testFileURL, atomically: true, encoding: .utf8)
 
-        let fileManger = CEWorkspaceFileManager(
+        let fileManager = CEWorkspaceFileManager(
             folderUrl: directory,
             ignoredFilesAndFolders: [],
             sourceControlManager: nil
         )
-        XCTAssert(fileManger.getFile(testFileURL.path()) != nil)
+        XCTAssert(fileManager.getFile(testFileURL.path()) != nil)
         XCTAssert(FileManager.default.fileExists(atPath: testFileURL.path()) == true)
-        fileManger.delete(file: CEWorkspaceFile(url: testFileURL), confirmDelete: false)
+        try fileManager.delete(file: CEWorkspaceFile(url: testFileURL), confirmDelete: false)
         XCTAssert(FileManager.default.fileExists(atPath: testFileURL.path()) == false)
     }
 
@@ -149,16 +147,54 @@ final class CEWorkspaceFileManagerUnitTests: XCTestCase {
         let testDuplicatedFileURL = directory.appendingPathComponent("file copy.txt")
         try "😄".write(to: testFileURL, atomically: true, encoding: .utf8)
 
-        let fileManger = CEWorkspaceFileManager(
+        let fileManager = CEWorkspaceFileManager(
             folderUrl: directory,
             ignoredFilesAndFolders: [],
             sourceControlManager: nil
         )
-        XCTAssert(fileManger.getFile(testFileURL.path()) != nil)
+        XCTAssert(fileManager.getFile(testFileURL.path()) != nil)
         XCTAssert(FileManager.default.fileExists(atPath: testFileURL.path()) == true)
-        fileManger.duplicate(file: CEWorkspaceFile(url: testFileURL))
+        try fileManager.duplicate(file: CEWorkspaceFile(url: testFileURL))
         XCTAssert(FileManager.default.fileExists(atPath: testFileURL.path()) == true)
         XCTAssert(FileManager.default.fileExists(atPath: testDuplicatedFileURL.path(percentEncoded: false)) == true)
         XCTAssert(try String(contentsOf: testDuplicatedFileURL) == "😄")
+    }
+
+    func testAddFile() throws {
+        let fileManager = CEWorkspaceFileManager(
+            folderUrl: directory,
+            ignoredFilesAndFolders: [],
+            sourceControlManager: nil
+        )
+
+        // This will throw if unsuccessful.
+        var file = try fileManager.addFile(fileName: "Test File.txt", toFile: fileManager.workspaceItem)
+
+        // Should not add a new file extension, it already has one. This adds a '.' at the end if incorrect.
+        XCTAssertEqual(file.name, "Test File.txt")
+
+        // Test the automatic file extension stuff
+        file = try fileManager.addFile(
+            fileName: "Test File Extension",
+            toFile: fileManager.workspaceItem,
+            useExtension: nil
+        )
+
+        // Should detect '.txt' with the previous file in the same directory.
+        XCTAssertEqual(file.name, "Test File Extension.txt")
+
+        // Test explicit file extension with both . and no period at the beginning of the given extension.
+        file = try fileManager.addFile(
+            fileName: "Explicit File Extension",
+            toFile: fileManager.workspaceItem,
+            useExtension: "xlsx"
+        )
+        XCTAssertEqual(file.name, "Explicit File Extension.xlsx")
+        file = try fileManager.addFile(
+            fileName: "PDF",
+            toFile: fileManager.workspaceItem,
+            useExtension: ".pdf"
+        )
+        XCTAssertEqual(file.name, "PDF.pdf")
     }
 }

--- a/CodeEditTests/Utils/CEWorkspaceFileManager/CEWorkspaceFileManagerTests.swift
+++ b/CodeEditTests/Utils/CEWorkspaceFileManager/CEWorkspaceFileManagerTests.swift
@@ -171,6 +171,7 @@ final class CEWorkspaceFileManagerUnitTests: XCTestCase {
         var file = try fileManager.addFile(fileName: "Test File.txt", toFile: fileManager.workspaceItem)
 
         // Should not add a new file extension, it already has one. This adds a '.' at the end if incorrect.
+        // See #1966
         XCTAssertEqual(file.name, "Test File.txt")
 
         // Test the automatic file extension stuff

--- a/CodeEditTests/Utils/UnitTests_Extensions.swift
+++ b/CodeEditTests/Utils/UnitTests_Extensions.swift
@@ -133,4 +133,49 @@ final class CodeEditUtilsExtensionsUnitTests: XCTestCase {
         XCTAssertEqual(result, withoutSpaces)
     }
 
+    // MARK: - STRING + VALID FILE NAME
+
+    func testValidFileName() {
+        let validCases = [
+            "hello world",
+            "newSwiftFile.swift",
+            "documento_español.txt",
+            "dokument_deutsch.pdf",
+            "rapport_français.docx",
+            "レポート_日本語.xlsx",
+            "отчет_русский.pptx",
+            "보고서_한국어.txt",
+            "文件_中文.pdf",
+            "dokument_svenska.txt",
+            "relatório_português.docx",
+            "relazione_italiano.pdf",
+            "file_with_emoji_😊.txt",
+            "emoji_report_📄.pdf",
+            "archivo_con_emoji_🌟.docx",
+            "文件和表情符号_🚀.txt",
+            "rapport_avec_emoji_🎨.pptx",
+            // 255 characters (exactly the maximum)
+            String((0..<255).map({ _ in "abcd".randomElement() ?? Character("") }))
+        ]
+
+        for validCase in validCases {
+            XCTAssertTrue(validCase.isValidFilename, "Detected invalid case \"\(validCase)\", should be valid.")
+        }
+    }
+
+    func testInvalidFileName() {
+        // The only limitations for macOS file extensions is no ':' and no NULL characters and 255 UTF16 char limit.
+        let invalidCases = [
+            ":",
+            "\0",
+            "Hell\0 World!",
+            "export:2024-04-12.txt",
+            // 256 characters (1 too long)
+            String((0..<256).map({ _ in "abcd".randomElement() ?? Character("") }))
+        ]
+
+        for invalidCase in invalidCases {
+            XCTAssertFalse(invalidCase.isValidFilename, "Detected valid case \"\(invalidCase)\", should be invalid.")
+        }
+    }
 }

--- a/CodeEditTests/Utils/UnitTests_Extensions.swift
+++ b/CodeEditTests/Utils/UnitTests_Extensions.swift
@@ -166,6 +166,7 @@ final class CodeEditUtilsExtensionsUnitTests: XCTestCase {
     func testInvalidFileName() {
         // The only limitations for macOS file extensions is no ':' and no NULL characters and 255 UTF16 char limit.
         let invalidCases = [
+            "",
             ":",
             "\0",
             "Hell\0 World!",

--- a/CodeEditUITests/App.swift
+++ b/CodeEditUITests/App.swift
@@ -15,12 +15,13 @@ enum App {
         return application
     }
 
-    // Launches CodeEdit in a new directory
-    static func launchWithTempDir() throws -> XCUIApplication {
+    // Launches CodeEdit in a new directory and returns the directory path.
+    static func launchWithTempDir() throws -> (XCUIApplication, String) {
+        let tempDirURL = try tempProjectPath()
         let application = XCUIApplication()
-        application.launchArguments = ["-ApplePersistenceIgnoreState", "YES", "--open", try tempProjectPath()]
+        application.launchArguments = ["-ApplePersistenceIgnoreState", "YES", "--open", tempDirURL]
         application.launch()
-        return application
+        return (application, tempDirURL)
     }
 
     static func launch() -> XCUIApplication {

--- a/CodeEditUITests/Features/ActivityViewer/Tasks/TasksMenuUITests.swift
+++ b/CodeEditUITests/Features/ActivityViewer/Tasks/TasksMenuUITests.swift
@@ -23,7 +23,7 @@ final class ActivityViewerTasksMenuTests: XCTestCase {
 
     @MainActor
     override func setUp() async throws {
-        app = try App.launchWithTempDir()
+        (app, _) = try App.launchWithTempDir()
         window = Query.getWindow(app)
         XCTAssertTrue(window.exists, "Window not found")
     }

--- a/CodeEditUITests/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorFileManagementUITests.swift
+++ b/CodeEditUITests/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorFileManagementUITests.swift
@@ -1,0 +1,100 @@
+//
+//  ProjectNavigatorFileManagementUITests.swift
+//  CodeEditUITests
+//
+//  Created by Khan Winter on 1/15/25.
+//
+
+import XCTest
+
+final class ProjectNavigatorFileManagementUITests: XCTestCase {
+
+    var app: XCUIApplication!
+    var window: XCUIElement!
+    var navigator: XCUIElement!
+    var path: String!
+
+    override func setUp() async throws {
+        // MainActor required for async compatibility which is required to make this method throwing
+        try await MainActor.run {
+            (app, path) = try App.launchWithTempDir()
+
+            window = Query.getWindow(app)
+            XCTAssertTrue(window.exists, "Window not found")
+            window.toolbars.firstMatch.click()
+
+            navigator = Query.Window.getProjectNavigator(window)
+            XCTAssertTrue(navigator.exists, "Navigator not found")
+            XCTAssertEqual(Query.Navigator.getRows(navigator).count, 1, "Found more than just the root file.")
+        }
+    }
+
+    func testNewFilesAppear() throws {
+        // Create a few files, one in the base path and one inside a new folder. They should all appear in the navigator
+
+        guard FileManager.default.createFile(atPath: path.appending("/newFile.txt"), contents: nil) else {
+            XCTFail("Failed to create test file")
+            return
+        }
+
+        try FileManager.default.createDirectory(
+            atPath: path.appending("/New Folder"),
+            withIntermediateDirectories: true
+        )
+
+        guard FileManager.default.createFile(
+            atPath: path.appending("/New Folder/My New JS File.jsx"),
+            contents: nil
+        ) else {
+            XCTFail("Failed to create second test file")
+            return
+        }
+
+        guard Query.Navigator.getProjectNavigatorRow(
+            fileTitle: "newFile.txt",
+            navigator
+        ).waitForExistence(timeout: 2.0) else {
+            XCTFail("newFile.txt did not appear")
+            return
+        }
+        guard Query.Navigator.getProjectNavigatorRow(
+            fileTitle: "New Folder",
+            navigator
+        ).waitForExistence(timeout: 2.0) else {
+            XCTFail("New Folder did not appear")
+            return
+        }
+
+        let folderRow = Query.Navigator.getProjectNavigatorRow(fileTitle: "New Folder", navigator)
+        folderRow.disclosureTriangles.element.click()
+
+        guard Query.Navigator.getProjectNavigatorRow(
+            fileTitle: "My New JS File.jsx",
+            navigator
+        ).waitForExistence(timeout: 2.0) else {
+            XCTFail("New file inside the folder did not appear when folder was opened.")
+            return
+        }
+    }
+
+    func testCreateNewFiles() throws {
+        // Add a few files with the navigator button
+        for idx in 0..<5 {
+            let addButton = window.popUpButtons["addButton"]
+            addButton.click()
+            let addMenu = addButton.menus.firstMatch
+            addMenu.menuItems["Add File"].click()
+
+            let selectedRows = Query.Navigator.getSelectedRows(navigator)
+            guard selectedRows.firstMatch.waitForExistence(timeout: 0.5) else {
+                XCTFail("No new selected rows appeared")
+                return
+            }
+
+            let title = idx > 0 ? "untitled\(idx)" : "untitled"
+
+            let newFileRow = selectedRows.firstMatch
+            XCTAssertEqual(newFileRow.descendants(matching: .textField).firstMatch.value as? String, title)
+        }
+    }
+}

--- a/CodeEditUITests/Query.swift
+++ b/CodeEditUITests/Query.swift
@@ -42,9 +42,16 @@ enum Query {
     }
 
     enum Navigator {
+        static func getRows(_ navigator: XCUIElement) -> XCUIElementQuery {
+            navigator.descendants(matching: .outlineRow)
+        }
+
+        static func getSelectedRows(_ navigator: XCUIElement) -> XCUIElementQuery {
+            getRows(navigator).matching(NSPredicate(format: "selected = true"))
+        }
+
         static func getProjectNavigatorRow(fileTitle: String, index: Int = 0, _ navigator: XCUIElement) -> XCUIElement {
-            return navigator
-                .descendants(matching: .outlineRow)
+            return getRows(navigator)
                 .containing(.textField, identifier: "ProjectNavigatorTableViewCell-\(fileTitle)")
                 .element(boundBy: index)
         }

--- a/CodeEditUITests/UI TESTING.md
+++ b/CodeEditUITests/UI TESTING.md
@@ -21,12 +21,14 @@ without having to read long XCUI queries. For instance
 ```swift
 let window = application.windows.element(matching: .window, identifier: "workspace")
 let navigator = window.descendants(matching: .any).matching(identifier: "ProjectNavigator").element
-let newFileCell = navigator.descendants(matching: .outlineRow)
+let newFileCell = navigator
+                .descendants(matching: .outlineRow)
                 .containing(.textField, identifier: "ProjectNavigatorTableViewCell-FileName")
-                .element(boundBy: index)
+                .element(boundBy: 0)
 ```
 
-Should be shortened to the following, which is much easier to read and intuit what the test is doing.
+Should be shortened to the following, which should be easier to read and intuit what the test is doing.
+
 ```swift
 let window = Query.getWindow(app)
 let navigator = Query.Window.getProjectNavigator(window)

--- a/CodeEditUITests/UI TESTING.md
+++ b/CodeEditUITests/UI TESTING.md
@@ -1,0 +1,37 @@
+# UI Testing in CodeEdit
+
+CodeEdit uses XCUITests for automating tests that require user interaction. Ideally, we have UI tests for every UI 
+component in CodeEdit, but right now (as of Jan, 2025) we have fewer tests than we'd like.
+
+## Test Application Setup
+
+To test workspaces with real files, launch the application with the `App` enum. To create a temporary test directory,
+use the `App.launchWithTempDir()` method. This will create a random directory in the temporary directory and return
+the created path. In tests you can add files to that directory and it will be cleaned up when the tests finish.
+
+There is a `App.launchWithCodeEditWorkspace` method, but please try not to use it. It exists for compatibility with a
+few existing tests and would be a pain to replace. It's more likely to be flaky, and can't test things like file
+modification, creation, or anything besides clicking around the workspace or you risk modifying the very project
+that's being tested!
+
+## Query Extensions
+
+For common, long, queries, add static methods to the `Query` enum. This enum should be used to help clarify tests
+without having to read long XCUI queries. For instance
+```swift
+let window = application.windows.element(matching: .window, identifier: "workspace")
+let navigator = window.descendants(matching: .any).matching(identifier: "ProjectNavigator").element
+let newFileCell = navigator.descendants(matching: .outlineRow)
+                .containing(.textField, identifier: "ProjectNavigatorTableViewCell-FileName")
+                .element(boundBy: index)
+```
+
+Should be shortened to the following, which is much easier to read and intuit what the test is doing.
+```swift
+let window = Query.getWindow(app)
+let navigator = Query.Window.getProjectNavigator(window)
+let newFileCell = Query.Navigator.getProjectNavigatorRow(fileTitle: "FileName", navigator)
+```
+
+This isn't necessary for all tests, but useful for querying common regions like the project navigator, window, or 
+utility area.


### PR DESCRIPTION
### Description

#### App changes:
- Creating a new file always selects it in the project navigator and selects or opens it in a tab.
- Creating a new folder always selects it.
- Renaming a file always selects it.
- Renaming a file no longer sometimes adds a trailing period to the file name.
- File system updates no longer clear the project navigator's selection.
- No longer attempts to save folders and files whose name was not changed when the name field is submitted.
- Fixes a case where the navigator filter was empty but files were still being filtered.
- Fixes 

#### Code changes:
- Cleans up the file management API for the `CEWorkspaceFileManager`.
  - Each method now throws, and if it creates a file or folder it returns it.
  - Errors are also logged by the file manager's own logger before being thrown, for better debugging output and standardization across the code base.
  - Introduced a `FileManagerError` enum that has meaningful error description and resolution messages. This type is now used in the file management methods where it makes sense. The type is suitable for presenting in an `NSAlert`.
- Standardizes up how the workspace is notified of new/moved/copied files. Changes include the project navigator and file inspector.
  - Always notifies the project navigator and other listeners using the `workspace.listenerModel`, as well as opening a tab if it's not a folder.
  - If file errors are thrown, presents an `NSAlert` with the error information.
- Removed a `DispatchQueue.async` call in the project navigator that caused a new selection received by the project navigator to be overwritten, causing a flashing selection when new files were created and subsequently selected, which also resulted in incorrect selections.
- Moved the `String.isValidFilename` to its own file, and made it check for more invalid cases.
- Added a flag to the `DirectoryEventStream` to receive more timely notifications.
- Added a check to see if the project navigator filter is empty before displaying filtered files.

#### Tests:
- Added UI tests to the project navigator.
- Added unit tests for the `isValidFilename` extension.
- Added a UI testing document.
- Uncommented the directory changes listener test after adding the new flag to the directory event stream.

### Related Issues

- Closes #1934 
- Closes #1966 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<details><summary>On main</summary>
<p>

https://github.com/user-attachments/assets/f2404f06-aa59-4486-95c2-8cf9432254b2

https://github.com/user-attachments/assets/af365adf-0704-475f-bd1e-347f66855114

</p>
</details> 

https://github.com/user-attachments/assets/4c3b7a3b-3c30-45fa-b7f3-6e428c10641e

https://github.com/user-attachments/assets/02967b41-409c-4bbc-bd86-0d12469852d6
