### PR TITLE
Fix Open in Tab not working issue

### DIFF
--- a/CodeEdit/Features/Editor/Models/Editor.swift
+++ b/CodeEdit/Features/Editor/Models/Editor.swift
@@ -186,6 +186,8 @@ final class Editor: ObservableObject, Identifiable {
 
         case (.some(let tab), false) where tab == item:
             temporaryTab = nil
+        case (.some(let tab), false) where tab != item:
+            openTab(file: item.file)
 
         case (.none, true):
             openTab(file: item.file)


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
Fixes- Selecting multiple files and clicking "Open In Tab" doesn't work

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues
closes, *#1933
<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

### Checklist

<!--- Add things that are not yet implemented above -->

- [x ] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/user-attachments/assets/bfa09ba6-d381-4486-b022-9f522cf77e9d


<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
