### PR TITLE
Replace deprecated appendingPathComponent calls

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFile.swift
@@ -258,7 +258,7 @@ final class CEWorkspaceFile: Codable, Comparable, Hashable, Identifiable, Editor
                 !newName.isEmpty &&
                 newName.isValidFilename &&
                 !FileManager.default.fileExists(
-                    atPath: self.url.deletingLastPathComponent().appendingPathComponent(newName).path
+                    atPath: self.url.deletingLastPathComponent().appending(path: newName).path
                 ) else {
             return false
         }

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
@@ -18,15 +18,15 @@ extension CEWorkspaceFileManager {
     func addFolder(folderName: String, toFile file: CEWorkspaceFile) throws -> CEWorkspaceFile {
         // Check if folder, if it is create folder under self, else create on same level.
         var folderUrl = (
-            file.isFolder ? file.url.appendingPathComponent(folderName)
-            : file.url.deletingLastPathComponent().appendingPathComponent(folderName)
+            file.isFolder ? file.url.appending(path: folderName)
+            : file.url.deletingLastPathComponent().appending(path: folderName)
         )
 
         // If a file/folder with the same name exists, add a number to the end.
         var fileNumber = 0
         while fileManager.fileExists(atPath: folderUrl.path) {
             fileNumber += 1
-            folderUrl = folderUrl.deletingLastPathComponent().appendingPathComponent("\(folderName)\(fileNumber)")
+            folderUrl = folderUrl.deletingLastPathComponent().appending(path: "\(folderName)\(fileNumber)")
         }
 
         // Create the folder
@@ -79,13 +79,13 @@ extension CEWorkspaceFileManager {
                 }
             }
 
-            var fileUrl = file.nearestFolder.appendingPathComponent("\(fileName)\(fileExtension)")
+            var fileUrl = file.nearestFolder.appending(path: "\(fileName)\(fileExtension)")
             // If a file/folder with the same name exists, add a number to the end.
             var fileNumber = 0
             while fileManager.fileExists(atPath: fileUrl.path) {
                 fileNumber += 1
                 fileUrl = fileUrl.deletingLastPathComponent()
-                    .appendingPathComponent("\(fileName)\(fileNumber)\(fileExtension)")
+                    .appending(path: "\(fileName)\(fileNumber)\(fileExtension)")
             }
 
             guard fileUrl.fileName.isValidFilename else {
@@ -227,7 +227,7 @@ extension CEWorkspaceFileManager {
             let fileExtension = fileUrl.pathExtension.isEmpty ? "" : ".\(fileUrl.pathExtension)"
             let fileName = fileExtension.isEmpty ? previousName :
             previousName.replacingOccurrences(of: fileExtension, with: "")
-            fileUrl = fileUrl.deletingLastPathComponent().appendingPathComponent("\(fileName) copy\(fileExtension)")
+            fileUrl = fileUrl.deletingLastPathComponent().appending(path: "\(fileName) copy\(fileExtension)")
         }
 
         if fileManager.fileExists(atPath: file.url.path) {

--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
@@ -198,7 +198,7 @@ final class CEWorkspaceFileManager {
     /// - Parameter file: The parent element.
     /// - Returns: A child element with an associated parent.
     func createChild(_ url: URL, forParent file: CEWorkspaceFile) -> CEWorkspaceFile {
-        let relativeURL = URL(filePath: file.id).appendingPathComponent(url.lastPathComponent)
+        let relativeURL = URL(filePath: file.id).appending(path: url.lastPathComponent)
         let childId = relativeURL.relativePath
         let newFileItem = CEWorkspaceFile(id: childId, url: relativeURL)
         newFileItem.parent = file

--- a/CodeEdit/Features/CEWorkspaceSettings/Models/CEWorkspaceSettings.swift
+++ b/CodeEdit/Features/CEWorkspaceSettings/Models/CEWorkspaceSettings.swift
@@ -18,11 +18,11 @@ final class CEWorkspaceSettings: ObservableObject {
     private(set) var folderURL: URL
 
     private var settingsURL: URL {
-        folderURL.appendingPathComponent("settings").appendingPathExtension("json")
+        folderURL.appending(path: "settings").appending(path: "json")
     }
 
     init(workspaceURL: URL) {
-        folderURL = workspaceURL.appendingPathComponent(".codeedit", isDirectory: true)
+        folderURL = workspaceURL.appending(path: ".codeedit", directoryHint: .isDirectory)
         loadSettings()
 
         storeTask = $settings

--- a/CodeEdit/Features/InspectorArea/FileInspector/FileInspectorView.swift
+++ b/CodeEdit/Features/InspectorArea/FileInspector/FileInspectorView.swift
@@ -91,7 +91,7 @@ struct FileInspectorView: View {
                     if file.validateFileName(for: fileName) {
                         let destinationURL = file.url
                             .deletingLastPathComponent()
-                            .appendingPathComponent(fileName)
+                            .appending(path: fileName)
                         DispatchQueue.main.async { [weak workspace] in
                             do {
                                 if let newItem = try workspace?.workspaceFileManager?.move(

--- a/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/OutlineView/FileSystemTableViewCell.swift
@@ -164,7 +164,7 @@ extension FileSystemTableViewCell: NSTextFieldDelegate {
             if fileItem.validateFileName(for: textField?.stringValue ?? "") {
                 let newURL = fileItem.url
                     .deletingLastPathComponent()
-                    .appendingPathComponent(textField?.stringValue ?? "")
+                    .appending(path: textField?.stringValue ?? "")
                 try workspace?.workspaceFileManager?.move(file: fileItem, to: newURL)
             } else {
                 textField?.stringValue = fileItem.labelFileName()

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorMenuActions.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorMenuActions.swift
@@ -127,7 +127,7 @@ extension ProjectNavigatorMenu {
         var folderNumber = 0
         while workspaceFileManager.fileManager.fileExists(atPath: newFolderURL.path) {
             folderNumber += 1
-            newFolderURL = parent.url.appendingPathComponent("New Folder With Items \(folderNumber)")
+            newFolderURL = parent.url.appending(path: "New Folder With Items \(folderNumber)")
         }
 
         do {

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorTableViewCell.swift
@@ -59,7 +59,7 @@ final class ProjectNavigatorTableViewCell: FileSystemTableViewCell {
         if fileItem.validateFileName(for: textField?.stringValue ?? "") {
             let destinationURL = fileItem.url
                 .deletingLastPathComponent()
-                .appendingPathComponent(textField?.stringValue ?? "")
+                .appending(path: textField?.stringValue ?? "")
             delegate?.moveFile(file: fileItem, to: destinationURL)
         } else {
             textField?.stringValue = fileItem.labelFileName()

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDataSource.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+NSOutlineViewDataSource.swift
@@ -86,7 +86,7 @@ extension ProjectNavigatorViewController: NSOutlineViewDataSource {
         let destParentURL = fileItemDestination.url
 
         for fileItemURL in fileItemURLS {
-            let destURL = destParentURL.appendingPathComponent(fileItemURL.lastPathComponent)
+            let destURL = destParentURL.appending(path: fileItemURL.lastPathComponent)
             // cancel dropping file item on self or in parent directory
             if fileItemURL == destURL || fileItemURL == destParentURL {
                 return false

--- a/CodeEdit/Features/Settings/Models/Settings.swift
+++ b/CodeEdit/Features/Settings/Models/Settings.swift
@@ -80,7 +80,7 @@ final class Settings: ObservableObject {
     internal var baseURL: URL {
         filemanager
             .homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Application Support/CodeEdit", isDirectory: true)
+            .appending(path: "Library/Application Support/CodeEdit", directoryHint: .isDirectory)
     }
 
     /// The URL of the `settings.json` settings file.
@@ -88,7 +88,7 @@ final class Settings: ObservableObject {
     /// Points to `~/Library/Application Support/CodeEdit/settings.json`
     private var settingsURL: URL {
         baseURL
-            .appendingPathComponent("settings")
+            .appending(path: "settings")
             .appendingPathExtension("json")
     }
 }

--- a/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsDetailsView.swift
+++ b/CodeEdit/Features/Settings/Pages/AccountsSettings/AccountsSettingsDetailsView.swift
@@ -80,15 +80,15 @@ struct AccountsSettingsDetailsView: View {
                         Text("None")
                             .tag("")
                         Divider()
-                        if let sshPath = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(
-                            ".ssh",
-                            isDirectory: true
+                        if let sshPath = FileManager.default.homeDirectoryForCurrentUser.appending(
+                            path: ".ssh",
+                            directoryHint: .isDirectory
                         ) as URL? {
                             if let files = try? FileManager.default.contentsOfDirectory(
                                 atPath: sshPath.path
                             ) {
                                 ForEach(files, id: \.self) { filename in
-                                    let fileURL = sshPath.appendingPathComponent(filename)
+                                    let fileURL = sshPath.appending(path: filename)
                                     if let contents = try? String(contentsOf: fileURL) {
                                         if isPublicSSHKey(contents) {
                                             Text(filename.replacingOccurrences(of: ".pub", with: ""))

--- a/CodeEdit/Features/Settings/Pages/SearchSettings/Models/SearchSettingsModel.swift
+++ b/CodeEdit/Features/Settings/Pages/SearchSettings/Models/SearchSettingsModel.swift
@@ -29,22 +29,22 @@ final class SearchSettingsModel: ObservableObject {
 
     /// The base folder url `~/Library/Application Support/CodeEdit/`
     private var baseURL: URL {
-        filemanager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support/CodeEdit")
+        filemanager.homeDirectoryForCurrentUser.appending(path: "Library/Application Support/CodeEdit")
     }
 
     /// The URL of the `search` folder
     internal var searchURL: URL {
-        baseURL.appendingPathComponent("search", isDirectory: true)
+        baseURL.appending(path: "search", directoryHint: .isDirectory)
     }
 
     /// The URL of the `Extensions` folder
     internal var extensionsURL: URL {
-        baseURL.appendingPathComponent("Extensions", isDirectory: true)
+        baseURL.appending(path: "Extensions", directoryHint: .isDirectory)
     }
 
     /// The URL of the `settings.json` file
     internal var settingsURL: URL {
-        baseURL.appendingPathComponent("settings.json", isDirectory: true)
+        baseURL.appending(path: "settings.json", directoryHint: .isDirectory)
     }
 
     /// Selected patterns

--- a/CodeEdit/Features/Settings/Pages/SourceControlSettings/Models/IgnorePatternModel.swift
+++ b/CodeEdit/Features/Settings/Pages/SourceControlSettings/Models/IgnorePatternModel.swift
@@ -56,15 +56,15 @@ class IgnorePatternModel: ObservableObject {
         if !excludesFile.isEmpty {
             if excludesFile.starts(with: "~/") {
                 let relativePath = String(excludesFile.dropFirst(2)) // Remove "~/"
-                return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(relativePath)
+                return FileManager.default.homeDirectoryForCurrentUser.appending(path: relativePath)
             } else if excludesFile.starts(with: "/") {
                 return URL(fileURLWithPath: excludesFile) // Absolute path
             } else {
-                return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(excludesFile)
+                return FileManager.default.homeDirectoryForCurrentUser.appending(path: excludesFile)
             }
         } else {
             let defaultPath = ".gitignore_global"
-            let fileURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(defaultPath)
+            let fileURL = FileManager.default.homeDirectoryForCurrentUser.appending(path: defaultPath)
             await gitConfig.set(key: "core.excludesfile", value: "~/\(defaultPath)", global: true)
             return fileURL
         }

--- a/CodeEdit/Features/Settings/Pages/SourceControlSettings/SourceControlGitView.swift
+++ b/CodeEdit/Features/Settings/Pages/SourceControlSettings/SourceControlGitView.swift
@@ -170,15 +170,15 @@ private extension SourceControlGitView {
             ), !excludesfile.isEmpty {
                 if excludesfile.starts(with: "~/") {
                     let relativePath = String(excludesfile.dropFirst(2))
-                    return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(relativePath)
+                    return FileManager.default.homeDirectoryForCurrentUser.appending(path: relativePath)
                 } else if excludesfile.starts(with: "/") {
                     return URL(fileURLWithPath: excludesfile)
                 } else {
-                    return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(excludesfile)
+                    return FileManager.default.homeDirectoryForCurrentUser.appending(path: excludesfile)
                 }
             } else {
-                let defaultURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(
-                    ".gitignore_global"
+                let defaultURL = FileManager.default.homeDirectoryForCurrentUser.appending(
+                    path: ".gitignore_global"
                 )
                 await gitConfig.set(key: "core.excludesfile", value: "~/\(defaultURL.lastPathComponent)", global: true)
                 return defaultURL
@@ -196,7 +196,7 @@ private extension SourceControlGitView {
     }
 
     private func openGitConfigFile() {
-        let fileURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".gitconfig")
+        let fileURL = FileManager.default.homeDirectoryForCurrentUser.appending(path: ".gitconfig")
 
         if !FileManager.default.fileExists(atPath: fileURL.path) {
             FileManager.default.createFile(atPath: fileURL.path, contents: nil)

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel+CRUD.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel+CRUD.swift
@@ -50,7 +50,7 @@ extension ThemeModel {
                 $0.contains(".cetheme")
             }
             let userDefinedThemeURLs = userDefinedThemeFilenames.map {
-                themesURL.appendingPathComponent($0)
+                themesURL.appending(path: $0)
             }
 
             // get all bundled theme URLs
@@ -58,7 +58,7 @@ extension ThemeModel {
                 $0.contains(".cetheme")
             }
             let bundledThemeURLs = bundledThemeFilenames.map {
-                bundledThemesURL.appendingPathComponent($0)
+                bundledThemesURL.appending(path: $0)
             }
 
             // combine user theme URLs with bundled theme URLs
@@ -154,7 +154,7 @@ extension ThemeModel {
         do {
             self.isAdding = true
             // Construct the destination file URL
-            var destinationFileURL = self.themesURL.appendingPathComponent(url.lastPathComponent)
+            var destinationFileURL = self.themesURL.appending(path: url.lastPathComponent)
 
             // Extract the base filename and extension
             let fileExtension = destinationFileURL.pathExtension
@@ -172,7 +172,7 @@ extension ThemeModel {
             if isBundled {
                 newFileName = "\(fileName) \(iterator)"
                 destinationFileURL = self.themesURL
-                    .appendingPathComponent(newFileName)
+                    .appending(path: newFileName)
                     .appendingPathExtension(fileExtension)
             }
 
@@ -188,7 +188,7 @@ extension ThemeModel {
                 // Generate a new filename with an iterator
                 newFileName = "\(fileName) \(iterator)"
                 destinationFileURL = self.themesURL
-                    .appendingPathComponent(newFileName)
+                    .appending(path: newFileName)
                     .appendingPathExtension(fileExtension)
 
                 iterator += 1
@@ -231,17 +231,17 @@ extension ThemeModel {
             }
 
             var finalName = newName
-            var finalURL = themesURL.appendingPathComponent(finalName).appendingPathExtension("cetheme")
+            var finalURL = themesURL.appending(path: finalName).appendingPathExtension("cetheme")
             var iterator = 1
 
             // Check for existing display names in themes
             while themes.contains(where: { theme != $0 && $0.displayName == finalName }) {
                 finalName = "\(newName) \(iterator)"
-                finalURL = themesURL.appendingPathComponent(finalName).appendingPathExtension("cetheme")
+                finalURL = themesURL.appending(path: finalName).appendingPathExtension("cetheme")
                 iterator += 1
             }
 
-            let isActive = self.getThemeActive(theme)
+            _ = self.getThemeActive(theme)
 
             try filemanager.moveItem(at: oldURL, to: finalURL)
 

--- a/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel.swift
+++ b/CodeEdit/Features/Settings/Pages/ThemeSettings/Models/ThemeModel.swift
@@ -26,26 +26,26 @@ final class ThemeModel: ObservableObject {
 
     /// The base folder url `~/Library/Application Support/CodeEdit/`
     private var baseURL: URL {
-        filemanager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support/CodeEdit")
+        filemanager.homeDirectoryForCurrentUser.appending(path: "Library/Application Support/CodeEdit")
     }
 
     var bundledThemesURL: URL? {
-        Bundle.main.resourceURL?.appendingPathComponent("DefaultThemes", isDirectory: true) ?? nil
+        Bundle.main.resourceURL?.appending(path: "DefaultThemes", directoryHint: .isDirectory) ?? nil
     }
 
     /// The URL of the `Themes` folder
     internal var themesURL: URL {
-        baseURL.appendingPathComponent("Themes", isDirectory: true)
+        baseURL.appending(path: "Themes", directoryHint: .isDirectory)
     }
 
     /// The URL of the `Extensions` folder
     internal var extensionsURL: URL {
-        baseURL.appendingPathComponent("Extensions", isDirectory: true)
+        baseURL.appending(path: "Extensions", directoryHint: .isDirectory)
     }
 
     /// The URL of the `settings.json` file
     internal var settingsURL: URL {
-        baseURL.appendingPathComponent("settings.json", isDirectory: true)
+        baseURL.appending(path: "settings.json", directoryHint: .isDirectory)
     }
 
     /// System color scheme
@@ -193,7 +193,7 @@ final class ThemeModel: ObservableObject {
                     for theme in customThemes {
                         guard let sourceURL = theme.fileURL else { continue }
 
-                        let destinationURL = exportDirectory.appendingPathComponent("\(theme.displayName).cetheme")
+                        let destinationURL = exportDirectory.appending(path: "\(theme.displayName).cetheme")
 
                         do {
                             try FileManager.default.copyItem(at: sourceURL, to: destinationURL)

--- a/CodeEdit/Features/SourceControl/Models/GitCommit.swift
+++ b/CodeEdit/Features/SourceControl/Models/GitCommit.swift
@@ -48,7 +48,7 @@ struct GitCommit: Equatable, Hashable, Identifiable {
             formattedRemote = URL.init(fileURLWithPath: "\(domain)/\(parts[parts.count - 1])")
         }
 
-        return formattedRemote.deletingPathExtension().appendingPathComponent("commit")
+        return formattedRemote.deletingPathExtension().appending(path: "commit")
     }
 
     var remoteString: String {

--- a/CodeEditTests/Features/CodeFile/CodeFileTests.swift
+++ b/CodeEditTests/Features/CodeFile/CodeFileTests.swift
@@ -20,10 +20,10 @@ final class CodeFileUnitTests: XCTestCase {
             appropriateFor: nil,
             create: true
         )
-            .appendingPathComponent("CodeEdit", isDirectory: true)
-            .appendingPathComponent("WorkspaceClientTests", isDirectory: true)
+            .appending(path: "CodeEdit", directoryHint: .isDirectory)
+            .appending(path: "WorkspaceClientTests", directoryHint: .isDirectory)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        fileURL = directory.appendingPathComponent("fakeFile.swift")
+        fileURL = directory.appending(path: "fakeFile.swift")
     }
 
     func testLoadUTF8Encoding() throws {

--- a/CodeEditTests/Features/Documents/Indexer/TemporaryFile.swift
+++ b/CodeEditTests/Features/Documents/Indexer/TemporaryFile.swift
@@ -52,7 +52,7 @@ class TempFolderManager {
 
     init() {
         self.temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory())
-        self.customFolderURL = temporaryDirectoryURL.appendingPathComponent("TestingFolder")
+        self.customFolderURL = temporaryDirectoryURL.appending(path: "TestingFolder")
     }
 
     deinit {
@@ -72,8 +72,8 @@ class TempFolderManager {
     }
 
     func createFiles() {
-        let file1URL = customFolderURL.appendingPathComponent("file1.txt")
-        let file2URL = customFolderURL.appendingPathComponent("file2.txt")
+        let file1URL = customFolderURL.appending(path: "file1.txt")
+        let file2URL = customFolderURL.appending(path: "file2.txt")
 
         let file1Content = "This is file 1"
         let file2Content = "This is file 2"
@@ -88,8 +88,8 @@ class TempFolderManager {
 
     func cleanup() {
         do {
-            let file1URL = customFolderURL.appendingPathComponent("file1.txt")
-            let file2URL = customFolderURL.appendingPathComponent("file2.txt")
+            let file1URL = customFolderURL.appending(path: "file1.txt")
+            let file2URL = customFolderURL.appending(path: "file2.txt")
 
             try FileManager.default.removeItem(at: file1URL)
             try FileManager.default.removeItem(at: file2URL)

--- a/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+FindAndReplaceTests.swift
+++ b/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+FindAndReplaceTests.swift
@@ -29,8 +29,8 @@ final class FindAndReplaceTests: XCTestCase {
             appropriateFor: nil,
             create: true
         )
-        .appendingPathComponent("CodeEdit", isDirectory: true)
-        .appendingPathComponent("WorkspaceClientTests", isDirectory: true)
+        .appending(path: "CodeEdit", directoryHint: .isDirectory)
+        .appending(path: "WorkspaceClientTests", directoryHint: .isDirectory)
         try? FileManager.default.removeItem(at: directory)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 

--- a/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+FindTests.swift
+++ b/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+FindTests.swift
@@ -25,8 +25,8 @@ final class FindTests: XCTestCase {
             appropriateFor: nil,
             create: true
         )
-        .appendingPathComponent("CodeEdit", isDirectory: true)
-        .appendingPathComponent("WorkspaceClientTests", isDirectory: true)
+        .appending(path: "CodeEdit", directoryHint: .isDirectory)
+        .appending(path: "WorkspaceClientTests", directoryHint: .isDirectory)
         try? FileManager.default.removeItem(at: directory)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 

--- a/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+IndexTests.swift
+++ b/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+IndexTests.swift
@@ -28,8 +28,8 @@ final class WorkspaceDocumentIndexTests: XCTestCase {
             appropriateFor: nil,
             create: true
         )
-        .appendingPathComponent("CodeEdit", isDirectory: true)
-        .appendingPathComponent("WorkspaceClientTests", isDirectory: true)
+        .appending(path: "CodeEdit", directoryHint: .isDirectory)
+        .appending(path: "WorkspaceClientTests", directoryHint: .isDirectory)
         try? FileManager.default.removeItem(at: directory)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 

--- a/CodeEditTests/Utils/CEWorkspaceFileManager/CEWorkspaceFileManagerTests.swift
+++ b/CodeEditTests/Utils/CEWorkspaceFileManager/CEWorkspaceFileManagerTests.swift
@@ -32,8 +32,8 @@ final class CEWorkspaceFileManagerUnitTests: XCTestCase {
             appropriateFor: nil,
             create: true
         )
-        .appendingPathComponent("CodeEdit", isDirectory: true)
-        .appendingPathComponent("WorkspaceClientTests", isDirectory: true)
+        .appending(path: "CodeEdit", directoryHint: .isDirectory)
+        .appending(path: "WorkspaceClientTests", directoryHint: .isDirectory)
         try? FileManager.default.removeItem(at: directory)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     }
@@ -48,7 +48,7 @@ final class CEWorkspaceFileManagerUnitTests: XCTestCase {
         try files.forEach {
             let fakeData = Data("fake string".utf8)
             let fileUrl = directory
-                .appendingPathComponent($0)
+                .appending(path: $0)
             try fakeData.write(to: fileUrl)
         }
         let client = CEWorkspaceFileManager(
@@ -85,7 +85,7 @@ final class CEWorkspaceFileManagerUnitTests: XCTestCase {
         try files.forEach {
             let fakeData = Data("fake string".utf8)
             let fileUrl = directory
-                .appendingPathComponent($0)
+                .appending(path: $0)
             try fakeData.write(to: fileUrl)
         }
 
@@ -144,7 +144,7 @@ final class CEWorkspaceFileManagerUnitTests: XCTestCase {
 
     func testDuplicateFile() throws {
         let testFileURL = directory.appending(path: "file.txt")
-        let testDuplicatedFileURL = directory.appendingPathComponent("file copy.txt")
+        let testDuplicatedFileURL = directory.appending(path: "file copy.txt")
         try "😄".write(to: testFileURL, atomically: true, encoding: .utf8)
 
         let fileManager = CEWorkspaceFileManager(


### PR DESCRIPTION
### Description

The `appendingPathComponent` function is deprecated and was replaced with just the `appending(path: )` function.

### Related Issues

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
