### PR TITLE
Fixed editor tabs from being non-interactive

### DIFF
--- a/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabView.swift
+++ b/CodeEdit/Features/Editor/TabBar/Tabs/Tab/EditorTabView.swift
@@ -226,8 +226,6 @@ struct EditorTabView: View {
                         }
                     }
             )
-            // This padding is to avoid background color overlapping with top divider.
-            .padding(.top, 1)
             .zIndex(isActive ? 2 : (isDragging ? 3 : (isPressing ? 1 : 0)))
             .id(item.id)
             .tabBarContextMenu(item: item, isTemporary: isTemporary)

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarView.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct EditorTabBarView: View {
+    let hasTopInsets: Bool
     /// The height of tab bar.
     /// I am not making it a private variable because it may need to be used in outside views.
     static let height = 28.0
@@ -15,11 +16,13 @@ struct EditorTabBarView: View {
     var body: some View {
         HStack(alignment: .center, spacing: 0) {
             EditorTabBarLeadingAccessories()
+                .padding(.top, hasTopInsets ? -1 : 0)
             EditorTabs()
                 .accessibilityElement(children: .contain)
                 .accessibilityLabel("Tab Bar")
                 .accessibilityIdentifier("TabBar")
             EditorTabBarTrailingAccessories()
+                .padding(.top, hasTopInsets ? -1 : 0)
         }
         .frame(height: EditorTabBarView.height)
         .padding(.leading, -1)

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarView.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarView.swift
@@ -24,7 +24,8 @@ struct EditorTabBarView: View {
             EditorTabBarTrailingAccessories()
                 .padding(.top, hasTopInsets ? -1 : 0)
         }
-        .frame(height: EditorTabBarView.height)
+        .frame(height: EditorTabBarView.height - (hasTopInsets ? 1 : 0))
+        .clipped()
         .padding(.leading, -1)
     }
 }

--- a/CodeEdit/Features/Editor/Views/EditorAreaView.swift
+++ b/CodeEdit/Features/Editor/Views/EditorAreaView.swift
@@ -94,29 +94,38 @@ struct EditorAreaView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .ignoresSafeArea(.all)
         .safeAreaInset(edge: .top, spacing: 0) {
-            VStack(spacing: 0) {
-                if shouldShowTabBar {
-                    EditorTabBarView()
-                        .id("TabBarView" + editor.id.uuidString)
-                        .environmentObject(editor)
-                    Divider()
-                }
-                if showEditorJumpBar {
-                    EditorJumpBarView(
-                        file: editor.selectedTab?.file,
-                        shouldShowTabBar: shouldShowTabBar
-                    ) { [weak editor] newFile in
-                        if let file = editor?.selectedTab, let index = editor?.tabs.firstIndex(of: file) {
-                            editor?.openTab(file: newFile, at: index)
-                        }
+            GeometryReader { geometry in
+                let topSafeArea = geometry.safeAreaInsets.top
+                VStack(spacing: 0) {
+                    if topSafeArea > 0 {
+                        Rectangle()
+                            .fill(.clear)
+                            .frame(height: 1)
+                            .background(.clear)
                     }
-                    .environmentObject(editor)
-                    .padding(.top, shouldShowTabBar ? -1 : 0)
-                    Divider()
+                    if shouldShowTabBar {
+                        EditorTabBarView(hasTopInsets: topSafeArea > 0)
+                            .id("TabBarView" + editor.id.uuidString)
+                            .environmentObject(editor)
+                        Divider()
+                    }
+                    if showEditorJumpBar {
+                        EditorJumpBarView(
+                            file: editor.selectedTab?.file,
+                            shouldShowTabBar: shouldShowTabBar
+                        ) { [weak editor] newFile in
+                            if let file = editor?.selectedTab, let index = editor?.tabs.firstIndex(of: file) {
+                                editor?.openTab(file: newFile, at: index)
+                            }
+                        }
+                        .environmentObject(editor)
+                        .padding(.top, shouldShowTabBar ? -1 : 0)
+                        Divider()
+                    }
                 }
+                .environment(\.isActiveEditor, editor == editorManager.activeEditor)
+                .background(EffectView(.headerView))
             }
-            .environment(\.isActiveEditor, editor == editorManager.activeEditor)
-            .background(EffectView(.headerView))
         }
         .focused($focus, equals: editor)
         // Fixing this is causing a malloc exception when a file is edited & closed. See #1886


### PR DESCRIPTION
> [!IMPORTANT]
> This is a temporary fix for a bug introduced in the latest version of macOS. This should be periodically checked to see if it is fixed and when it is, revert this fix.

### Description

Restored editor tabs interactivity. It seems like the topmost item loses interactivity so we fix this by placing a 1pt Rectangle at the top, effectively tricking the system. We then apply negative top padding inside to correct spacing issues.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
