### PR TITLE
Added editor overscroll setting

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				303E88462C276FD600EEA8D9 /* XCRemoteSwiftPackageReference "LanguageServerProtocol" */,
 				6C4E37FA2C73E00700AEE7B5 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
 				6CB94D012CA1205100E8651C /* XCRemoteSwiftPackageReference "swift-async-algorithms" */,
-				30E4D51A2D9A2F3B00B94EB6 /* XCLocalSwiftPackageReference "../CodeEditSourceEditorOverscroll" */,
+				30597BCA2D9AA5BE004BC2CC /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */,
 			);
 			preferredProjectObjectVersion = 55;
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
@@ -1616,13 +1616,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		30E4D51A2D9A2F3B00B94EB6 /* XCLocalSwiftPackageReference "../CodeEditSourceEditorOverscroll" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../CodeEditSourceEditorOverscroll;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1654,6 +1647,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.13.2;
+			};
+		};
+		30597BCA2D9AA5BE004BC2CC /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.10.0;
 			};
 		};
 		30CB648F2C16CA8100CC8A9E /* XCRemoteSwiftPackageReference "LanguageServerProtocol" */ = {

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -28,7 +28,6 @@
 		6C81916B29B41DD300B75C92 /* DequeModule in Frameworks */ = {isa = PBXBuildFile; productRef = 6C81916A29B41DD300B75C92 /* DequeModule */; };
 		6C85BB402C2105ED00EB5DEF /* CodeEditKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6C85BB3F2C2105ED00EB5DEF /* CodeEditKit */; };
 		6C85BB442C210EFD00EB5DEF /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = 6C85BB432C210EFD00EB5DEF /* SwiftUIIntrospect */; };
-		6C9DB9E42D55656300ACD86E /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6C9DB9E32D55656300ACD86E /* CodeEditSourceEditor */; };
 		6CAAF68A29BC9C2300A1F48A /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6CAAF69229BCC71C00A1F48A /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6CAAF69429BCD78600A1F48A /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -185,7 +184,6 @@
 				6C0824A12C5C0C9700A0751E /* SwiftTerm in Frameworks */,
 				6C81916B29B41DD300B75C92 /* DequeModule in Frameworks */,
 				6CB94D032CA1205100E8651C /* AsyncAlgorithms in Frameworks */,
-				6C9DB9E42D55656300ACD86E /* CodeEditSourceEditor in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -319,7 +317,6 @@
 				6CB94D022CA1205100E8651C /* AsyncAlgorithms */,
 				6CC00A8A2CBEF150004E8134 /* CodeEditSourceEditor */,
 				6C73A6D22D4F1E550012D95C /* CodeEditSourceEditor */,
-				6C9DB9E32D55656300ACD86E /* CodeEditSourceEditor */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -422,7 +419,7 @@
 				303E88462C276FD600EEA8D9 /* XCRemoteSwiftPackageReference "LanguageServerProtocol" */,
 				6C4E37FA2C73E00700AEE7B5 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
 				6CB94D012CA1205100E8651C /* XCRemoteSwiftPackageReference "swift-async-algorithms" */,
-				6C9DB9E22D55656300ACD86E /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */,
+				30E4D51A2D9A2F3B00B94EB6 /* XCLocalSwiftPackageReference "../CodeEditSourceEditorOverscroll" */,
 			);
 			preferredProjectObjectVersion = 55;
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
@@ -1619,6 +1616,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		30E4D51A2D9A2F3B00B94EB6 /* XCLocalSwiftPackageReference "../CodeEditSourceEditorOverscroll" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../CodeEditSourceEditorOverscroll;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1740,14 +1744,6 @@
 				minimumVersion = 1.2.0;
 			};
 		};
-		6C9DB9E22D55656300ACD86E /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.10.0;
-			};
-		};
 		6CB94D012CA1205100E8651C /* XCRemoteSwiftPackageReference "swift-async-algorithms" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-async-algorithms.git";
@@ -1840,11 +1836,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6C85BB422C210EFD00EB5DEF /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
 			productName = SwiftUIIntrospect;
-		};
-		6C9DB9E32D55656300ACD86E /* CodeEditSourceEditor */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6C9DB9E22D55656300ACD86E /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */;
-			productName = CodeEditSourceEditor;
 		};
 		6CB4463F2B6DFF3A00539ED0 /* CodeEditSourceEditor */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ac57a6899925c3e4ac6d43aed791c845c6fc24a4441b6a10297a207d951b7836",
+  "originHash" : "607a8a782c013ecf6759bcf5703402a8f5d27e05189503e36b44278bf778bd39",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -26,15 +26,6 @@
       "state" : {
         "revision" : "331d5dbc5fc8513be5848fce8a2a312908f36a11",
         "version" : "0.1.20"
-      }
-    },
-    {
-      "identity" : "codeeditsourceeditor",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
-      "state" : {
-        "revision" : "6b2c945501f0a5c15d8aa6d159fb2550c391bdd0",
-        "version" : "0.10.0"
       }
     },
     {

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "607a8a782c013ecf6759bcf5703402a8f5d27e05189503e36b44278bf778bd39",
+  "originHash" : "3d134b350244fc51aaff618575f0cb6d754dbbef6fb05b12964d922d42ce960e",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "331d5dbc5fc8513be5848fce8a2a312908f36a11",
         "version" : "0.1.20"
+      }
+    },
+    {
+      "identity" : "codeeditsourceeditor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
+      "state" : {
+        "revision" : "6b2c945501f0a5c15d8aa6d159fb2550c391bdd0",
+        "version" : "0.10.0"
       }
     },
     {

--- a/CodeEdit/Features/Editor/Views/CodeFileView.swift
+++ b/CodeEdit/Features/Editor/Views/CodeFileView.swift
@@ -30,6 +30,8 @@ struct CodeFileView: View {
     var lineHeightMultiple
     @AppSettings(\.textEditing.wrapLinesToEditorWidth)
     var wrapLinesToEditorWidth
+    @AppSettings(\.textEditing.overscroll)
+    var overscroll
     @AppSettings(\.textEditing.font)
     var settingsFont
     @AppSettings(\.theme.useThemeBackground)
@@ -127,6 +129,7 @@ struct CodeFileView: View {
             indentOption: (codeFile.indentOption ?? indentOption).textViewOption(),
             lineHeight: lineHeightMultiple,
             wrapLines: codeFile.wrapLines ?? wrapLinesToEditorWidth,
+            editorOverscroll: overscroll.overscrollPercentage,
             cursorPositions: $cursorPositions,
             useThemeBackground: useThemeBackground,
             contentInsets: edgeInsets.nsEdgeInsets,

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
@@ -18,7 +18,7 @@ extension SettingsData {
                 "Prefer Indent Using",
                 "Tab Width",
                 "Wrap lines to editor width",
-                "Overscroll",
+                "Editor Overscroll",
                 "Font",
                 "Font Size",
                 "Font Weight",

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
@@ -14,10 +14,11 @@ extension SettingsData {
     struct TextEditingSettings: Codable, Hashable, SearchableSettingsPage {
 
         var searchKeys: [String] {
-            [
+            var keys = [
                 "Prefer Indent Using",
                 "Tab Width",
                 "Wrap lines to editor width",
+                "Overscroll",
                 "Font",
                 "Font Size",
                 "Font Weight",
@@ -27,7 +28,10 @@ extension SettingsData {
                 "Enable type-over completion",
                 "Bracket Pair Highlight"
             ]
-            .map { NSLocalizedString($0, comment: "") }
+            if #available(macOS 14.0, *) {
+                keys.append("System Cursor")
+            }
+            return keys.map { NSLocalizedString($0, comment: "") }
         }
 
         /// An integer indicating how many spaces a `tab` will appear as visually.
@@ -48,6 +52,9 @@ extension SettingsData {
 
         /// A flag indicating whether to wrap lines to editor width
         var wrapLinesToEditorWidth: Bool = true
+
+        /// The percentage of overscroll to apply to the text view
+        var overscroll: OverscrollOption = .medium
 
         /// A multiplier for setting the line height. Defaults to `1.2`
         var lineHeightMultiple: Double = 1.2
@@ -88,6 +95,10 @@ extension SettingsData {
                 Bool.self,
                 forKey: .wrapLinesToEditorWidth
             ) ?? true
+            self.overscroll = try container.decodeIfPresent(
+                OverscrollOption.self,
+                forKey: .overscroll
+            ) ?? .medium
             self.lineHeightMultiple = try container.decodeIfPresent(
                 Double.self,
                 forKey: .lineHeightMultiple
@@ -165,6 +176,22 @@ extension SettingsData {
                 case bordered
                 case flash
                 case underline
+            }
+        }
+
+        enum OverscrollOption: String, Codable {
+            case none
+            case small
+            case medium
+            case large
+
+            var overscrollPercentage: CGFloat {
+                switch self {
+                case .none: return 0
+                case .small: return 0.25
+                case .medium: return 0.5
+                case .large: return 0.75
+                }
             }
         }
     }

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -19,6 +19,7 @@ struct TextEditingSettingsView: View {
                 defaultTabWidth
                 wrapLinesToEditorWidth
                 useSystemCursor
+                overscroll
             }
             Section {
                 fontSelector
@@ -77,6 +78,31 @@ private extension TextEditingSettingsView {
             Toggle("Use System Cursor", isOn: $textEditing.useSystemCursor)
         } else {
             EmptyView()
+        }
+    }
+
+    @ViewBuilder private var overscroll: some View {
+        Group {
+            Picker(
+                "Editor Overscroll",
+                selection: $textEditing.overscroll
+            ) {
+                Text("None")
+                    .tag(SettingsData.TextEditingSettings.OverscrollOption.none)
+                Divider()
+                Text("Small")
+                    .tag(
+                        SettingsData.TextEditingSettings.OverscrollOption.small
+                    )
+                Text("Medium")
+                    .tag(
+                        SettingsData.TextEditingSettings.OverscrollOption.medium
+                    )
+                Text("Large")
+                    .tag(
+                        SettingsData.TextEditingSettings.OverscrollOption.large
+                    )
+            }
         }
     }
 


### PR DESCRIPTION
### Description

Added the option for editor overscroll like in Xcode.

### Related Issues

Closes #2011 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="827" alt="Screenshot 2025-03-30 at 6 29 32 PM" src="https://github.com/user-attachments/assets/61813c63-4316-4192-8cf2-1293038dc97e" />

Xcode:
<img width="942" alt="Screenshot 2025-03-30 at 6 33 10 PM" src="https://github.com/user-attachments/assets/b25f6acd-79b4-468d-adb1-a4c77ac9d3a1" />


