### PR TITLE
Added copy path and copy relative path options in project navigator menu

### DIFF
--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarContextMenu.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarContextMenu.swift
@@ -5,8 +5,8 @@
 //  Created by Khan Winter on 6/4/22.
 //
 
-import Foundation
 import SwiftUI
+import Foundation
 
 extension View {
     func tabBarContextMenu(item: CEWorkspaceFile, isTemporary: Bool) -> some View {
@@ -149,24 +149,21 @@ struct EditorTabBarContextMenu: ViewModifier {
         guard let rootPath = workspace.workspaceFileManager?.folderUrl else {
             return
         }
-        // Calculate the relative path
-        var rootComponents = rootPath.standardizedFileURL.pathComponents
-        var destinationComponents = item.url.standardizedFileURL.pathComponents
+        let destinationComponents = item.url.standardizedFileURL.pathComponents
+        let baseComponents = rootPath.standardizedFileURL.pathComponents
 
-        // Remove any same path components
-        while !rootComponents.isEmpty && !destinationComponents.isEmpty
-                && rootComponents.first == destinationComponents.first {
-            rootComponents.remove(at: 0)
-            destinationComponents.remove(at: 0)
+        // Find common prefix length
+        var prefixCount = 0
+        while prefixCount < min(destinationComponents.count, baseComponents.count)
+                && destinationComponents[prefixCount] == baseComponents[prefixCount] {
+            prefixCount += 1
         }
-
-        // Make a "../" for each remaining component in the root URL
-        var relativePath: String = String(repeating: "../", count: rootComponents.count)
-        // Add the remaining components for the destination url.
-        relativePath += destinationComponents.joined(separator: "/")
+        // Build the relative path
+        let upPath = String(repeating: "../", count: baseComponents.count - prefixCount)
+        let downPath = destinationComponents[prefixCount...].joined(separator: "/")
 
         // Copy it to the clipboard
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(relativePath, forType: .string)
+        NSPasteboard.general.setString(upPath + downPath, forType: .string)
     }
 }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorMenu.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorMenu.swift
@@ -55,6 +55,9 @@ final class ProjectNavigatorMenu: NSMenu {
         let openExternalEditor = menuItem("Open with External Editor", action: #selector(openWithExternalEditor))
         let openAs = menuItem("Open As", action: nil)
 
+        let copyPath = menuItem("Copy Path", action: #selector(copyPath))
+        let copyRelativePath = menuItem("Copy Relative Path", action: #selector(copyRelativePath))
+
         let showFileInspector = menuItem("Show File Inspector", action: nil)
 
         let newFile = menuItem("New File...", action: #selector(newFile))
@@ -90,6 +93,9 @@ final class ProjectNavigatorMenu: NSMenu {
             openInNewWindow,
             openExternalEditor,
             openAs,
+            NSMenuItem.separator(),
+            copyPath,
+            copyRelativePath,
             NSMenuItem.separator(),
             showFileInspector,
             NSMenuItem.separator(),

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorMenuActions.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorMenuActions.swift
@@ -222,6 +222,42 @@ extension ProjectNavigatorMenu {
         }
     }
 
+    /// Copies the absolute path of the selected files
+    @objc
+    func copyPath() {
+        let paths = selectedItems().map {
+            $0.url.standardizedFileURL.path
+        }.sorted().joined(separator: "\n")
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(paths, forType: .string)
+    }
+
+    /// Copies the relative path of the selected files
+    @objc
+    func copyRelativePath() {
+        guard let rootPath = workspace?.workspaceFileManager?.folderUrl else {
+            return
+        }
+        let paths = selectedItems().map {
+            let destinationComponents = $0.url.standardizedFileURL.pathComponents
+            let baseComponents = rootPath.standardizedFileURL.pathComponents
+
+            // Find common prefix length
+            var prefixCount = 0
+            while prefixCount < min(destinationComponents.count, baseComponents.count)
+                    && destinationComponents[prefixCount] == baseComponents[prefixCount] {
+                prefixCount += 1
+            }
+            // Build the relative path
+            let upPath = String(repeating: "../", count: baseComponents.count - prefixCount)
+            let downPath = destinationComponents[prefixCount...].joined(separator: "/")
+            return upPath + downPath
+        }.sorted().joined(separator: "\n")
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(paths, forType: .string)
+    }
+
     private func reloadData() {
         sender.outlineView.reloadData()
         sender.filteredContentChildren.removeAll()


### PR DESCRIPTION
### Description

The project navigator didn't have the option to copy the path and relative path of a file, if you right click a file. This option currently only exists when right clicking the tab directly.

### Related Issues

Closes #2012 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/user-attachments/assets/7caf48f1-4121-4450-a9a5-046cf8ea84a5

