### PR TITLE
Fix Find Navigator resizing delay, use line height from user settings

### DIFF
--- a/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/FindNavigator/FindNavigatorResultList/FindNavigatorListViewController.swift
@@ -209,26 +209,50 @@ extension FindNavigatorListViewController: NSOutlineViewDelegate {
     }
 
     func outlineView(_ outlineView: NSOutlineView, heightOfRowByItem item: Any) -> CGFloat {
-        if let item = item as? SearchResultMatchModel {
-            let columnWidth = outlineView.tableColumns.first?.width ?? outlineView.frame.width
+        if let matchItem = item as? SearchResultMatchModel {
+            guard let column = outlineView.tableColumns.first else {
+                return rowHeight
+            }
+            let columnWidth = column.width
             let indentationLevel = outlineView.level(forItem: item)
             let indentationSpace = CGFloat(indentationLevel) * outlineView.indentationPerLevel
-            let availableWidth = columnWidth - indentationSpace - 24
+            let horizontalPaddingAndFixedElements: CGFloat = 24.0
 
-            // Create a temporary text field for measurement
-            let tempView = NSTextField(wrappingLabelWithString: item.attributedLabel().string)
-            tempView.allowsDefaultTighteningForTruncation = false
-            tempView.cell?.truncatesLastVisibleLine = true
+            let availableWidth = columnWidth - indentationSpace - horizontalPaddingAndFixedElements
+
+            guard availableWidth > 0 else {
+                // Not enough space to display anything, return minimum height
+                return max(rowHeight, Settings.shared.preferences.general.projectNavigatorSize.rowHeight)
+            }
+
+            let attributedString = matchItem.attributedLabel()
+
+            let tempView = NSTextField()
+            tempView.allowsEditingTextAttributes = true
+            tempView.attributedStringValue = attributedString
+
+            tempView.isEditable = false
+            tempView.isBordered = false
+            tempView.drawsBackground = false
+            tempView.alignment = .natural
+
             tempView.cell?.wraps = true
+            tempView.cell?.usesSingleLineMode = false
+            tempView.lineBreakMode = .byWordWrapping
             tempView.maximumNumberOfLines = Settings.shared.preferences.general.findNavigatorDetail.rawValue
             tempView.preferredMaxLayoutWidth = availableWidth
 
-            let height = tempView.sizeThatFits(
-                NSSize(width: availableWidth, height: CGFloat.greatestFiniteMagnitude)
+            var calculatedHeight = tempView.sizeThatFits(
+                NSSize(width: availableWidth, height: .greatestFiniteMagnitude)
             ).height
-            return max(height + 8, rowHeight)
+
+            // Total vertical padding (top + bottom) within the cell around the text
+            let verticalPaddingInCell: CGFloat = 8.0
+            calculatedHeight += verticalPaddingInCell
+            return max(calculatedHeight, self.rowHeight)
         }
-        return rowHeight
+        // For parent items
+        return prefs.general.projectNavigatorSize.rowHeight
     }
 
     func outlineViewColumnDidResize(_ notification: Notification) {
@@ -236,8 +260,15 @@ extension FindNavigatorListViewController: NSOutlineViewDelegate {
         NSAnimationContext.beginGrouping()
         NSAnimationContext.current.duration = 0
 
-        let indexes = IndexSet(integersIn: 0..<searchItems.count)
-        outlineView.noteHeightOfRows(withIndexesChanged: indexes)
+        var rowsToUpdate = IndexSet()
+        for row in 0..<outlineView.numberOfRows {
+            if let item = outlineView.item(atRow: row), item is SearchResultMatchModel {
+                rowsToUpdate.insert(row)
+            }
+        }
+        if !rowsToUpdate.isEmpty {
+            outlineView.noteHeightOfRows(withIndexesChanged: rowsToUpdate)
+        }
 
         NSAnimationContext.endGrouping()
         outlineView.layoutSubtreeIfNeeded()


### PR DESCRIPTION
### Description

Fixes the resizing delay when resizing the Find Navigator.
The Find Navigator now uses the "Find Navigator Detail" user setting to set how many lines to show per search result.

### Related Issues

Closes #2017  #2016 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Before:


https://github.com/user-attachments/assets/66749097-edca-4df2-a378-70f083e90460


After:


https://github.com/user-attachments/assets/c8483368-dc5d-433a-b84f-0f0f3b0b821b


