### PR TITLE
Add A Minimap

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				303E88462C276FD600EEA8D9 /* XCRemoteSwiftPackageReference "LanguageServerProtocol" */,
 				6C4E37FA2C73E00700AEE7B5 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
 				6CB94D012CA1205100E8651C /* XCRemoteSwiftPackageReference "swift-async-algorithms" */,
-				6CFE18222DA59C9F00A7B796 /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */,
+				6C7638E22DB1665800BA6353 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */,
 			);
 			preferredProjectObjectVersion = 55;
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
@@ -1616,6 +1616,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		6C7638E22DB1665800BA6353 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../CodeEditSourceEditor;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1743,14 +1750,6 @@
 			requirement = {
 				kind = exactVersion;
 				version = 1.0.1;
-			};
-		};
-		6CFE18222DA59C9F00A7B796 /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.11.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				303E88462C276FD600EEA8D9 /* XCRemoteSwiftPackageReference "LanguageServerProtocol" */,
 				6C4E37FA2C73E00700AEE7B5 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
 				6CB94D012CA1205100E8651C /* XCRemoteSwiftPackageReference "swift-async-algorithms" */,
-				6C7638E22DB1665800BA6353 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */,
+				6CF368562DBBD274006A77FD /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */,
 			);
 			preferredProjectObjectVersion = 55;
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
@@ -1616,13 +1616,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		6C7638E22DB1665800BA6353 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../CodeEditSourceEditor;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1750,6 +1743,14 @@
 			requirement = {
 				kind = exactVersion;
 				version = 1.0.1;
+			};
+		};
+		6CF368562DBBD274006A77FD /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.12.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "124bcede2a81c31eed29e7b08d1f4b5324339e73b7fc32fa7eb70ef33058a6ca",
+  "originHash" : "ac57a6899925c3e4ac6d43aed791c845c6fc24a4441b6a10297a207d951b7836",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -29,12 +29,30 @@
       }
     },
     {
+      "identity" : "codeeditsourceeditor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
+      "state" : {
+        "revision" : "412b0a26cbeb3f3148a1933dd598c976defe92a6",
+        "version" : "0.12.0"
+      }
+    },
+    {
       "identity" : "codeeditsymbols",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditSymbols",
       "state" : {
         "revision" : "a794528172314f9be5d838f8579c4435895e0988",
         "version" : "0.2.2"
+      }
+    },
+    {
+      "identity" : "codeedittextview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
+      "state" : {
+        "revision" : "a5912e60f6bac25cd1cdf8bb532e1125b21cf7f7",
+        "version" : "0.10.1"
       }
     },
     {

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ac57a6899925c3e4ac6d43aed791c845c6fc24a4441b6a10297a207d951b7836",
+  "originHash" : "124bcede2a81c31eed29e7b08d1f4b5324339e73b7fc32fa7eb70ef33058a6ca",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -29,30 +29,12 @@
       }
     },
     {
-      "identity" : "codeeditsourceeditor",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
-      "state" : {
-        "revision" : "f444927ab70015f4b76f119f6fc5d0e358fcd77a",
-        "version" : "0.11.0"
-      }
-    },
-    {
       "identity" : "codeeditsymbols",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditSymbols",
       "state" : {
         "revision" : "a794528172314f9be5d838f8579c4435895e0988",
         "version" : "0.2.2"
-      }
-    },
-    {
-      "identity" : "codeedittextview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
-      "state" : {
-        "revision" : "47faec9fb571c9c695897e69f0a4f08512ae682e",
-        "version" : "0.8.2"
       }
     },
     {

--- a/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarView.swift
+++ b/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarView.swift
@@ -21,15 +21,19 @@ struct EditorJumpBarView: View {
     @Environment(\.controlActiveState)
     private var activeState
 
+    @Binding var codeFile: CodeFileDocument?
+
     static let height = 28.0
 
     init(
         file: CEWorkspaceFile?,
         shouldShowTabBar: Bool,
+        codeFile: Binding<CodeFileDocument?>,
         tappedOpenFile: @escaping (CEWorkspaceFile) -> Void
     ) {
         self.file = file ?? nil
         self.shouldShowTabBar = shouldShowTabBar
+        self._codeFile = codeFile
         self.tappedOpenFile = tappedOpenFile
     }
 
@@ -75,7 +79,7 @@ struct EditorJumpBarView: View {
         }
         .safeAreaInset(edge: .trailing, spacing: 0) {
             if !shouldShowTabBar {
-                EditorTabBarTrailingAccessories()
+                EditorTabBarTrailingAccessories(codeFile: $codeFile)
             }
         }
         .frame(height: Self.height, alignment: .center)

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarTrailingAccessories.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarTrailingAccessories.swift
@@ -26,14 +26,12 @@ struct EditorTabBarTrailingAccessories: View {
 
     @EnvironmentObject private var editor: Editor
 
-    /// Because this view isn't invalidated with the `editor.selectedTab?.file.fileDocument` changes, this allows us
-    /// to refresh relevant views when settings change.
-    @State private var refreshToggleBool: Bool = false
+    @Binding var codeFile: CodeFileDocument?
 
     var body: some View {
         HStack(spacing: 6) {
             // Once more options are implemented that are available for non-code documents, remove this if statement
-            if let codeFile = editor.selectedTab?.file.fileDocument {
+            if let codeFile {
                 editorOptionsMenu(codeFile: codeFile)
                 Divider()
                     .padding(.vertical, 10)
@@ -62,17 +60,12 @@ struct EditorTabBarTrailingAccessories: View {
                             get: { codeFile.wrapLines ?? wrapLinesToEditorWidth },
                             set: {
                                 codeFile.wrapLines = $0
-                                refreshToggleBool.toggle()
                             }
                         )
                     )
-                    .tag(refreshToggleBool)
                 } label: {}
                     .menuStyle(.borderlessButton)
                     .menuIndicator(.hidden)
-            }
-            .onReceive(codeFile.$wrapLines) { _ in // This is annoying but it works
-                refreshToggleBool.toggle()
             }
     }
 
@@ -116,6 +109,6 @@ struct EditorTabBarTrailingAccessories: View {
 
 struct TabBarTrailingAccessories_Previews: PreviewProvider {
     static var previews: some View {
-        EditorTabBarTrailingAccessories()
+        EditorTabBarTrailingAccessories(codeFile: .constant(nil))
     }
 }

--- a/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarView.swift
+++ b/CodeEdit/Features/Editor/TabBar/Views/EditorTabBarView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct EditorTabBarView: View {
     let hasTopInsets: Bool
+    @Binding var codeFile: CodeFileDocument?
     /// The height of tab bar.
     /// I am not making it a private variable because it may need to be used in outside views.
     static let height = 28.0
@@ -21,7 +22,7 @@ struct EditorTabBarView: View {
                 .accessibilityElement(children: .contain)
                 .accessibilityLabel("Tab Bar")
                 .accessibilityIdentifier("TabBar")
-            EditorTabBarTrailingAccessories()
+            EditorTabBarTrailingAccessories(codeFile: $codeFile)
                 .padding(.top, hasTopInsets ? -1 : 0)
         }
         .frame(height: EditorTabBarView.height - (hasTopInsets ? 1 : 0))

--- a/CodeEdit/Features/Editor/Views/CodeFileView.swift
+++ b/CodeEdit/Features/Editor/Views/CodeFileView.swift
@@ -44,6 +44,8 @@ struct CodeFileView: View {
     var bracketEmphasis
     @AppSettings(\.textEditing.useSystemCursor)
     var useSystemCursor
+    @AppSettings(\.textEditing.showMinimap)
+    var showMinimap
 
     @Environment(\.colorScheme)
     private var colorScheme
@@ -125,7 +127,8 @@ struct CodeFileView: View {
             bracketPairEmphasis: getBracketPairEmphasis(),
             useSystemCursor: useSystemCursor,
             undoManager: undoManager,
-            coordinators: textViewCoordinators
+            coordinators: textViewCoordinators,
+            showMinimap: showMinimap
         )
         .id(codeFile.fileURL)
         .background {

--- a/CodeEdit/Features/Editor/Views/EditorAreaView.swift
+++ b/CodeEdit/Features/Editor/Views/EditorAreaView.swift
@@ -104,7 +104,7 @@ struct EditorAreaView: View {
                             .background(.clear)
                     }
                     if shouldShowTabBar {
-                        EditorTabBarView(hasTopInsets: topSafeArea > 0)
+                        EditorTabBarView(hasTopInsets: topSafeArea > 0, codeFile: $codeFile)
                             .id("TabBarView" + editor.id.uuidString)
                             .environmentObject(editor)
                         Divider()
@@ -112,7 +112,8 @@ struct EditorAreaView: View {
                     if showEditorJumpBar {
                         EditorJumpBarView(
                             file: editor.selectedTab?.file,
-                            shouldShowTabBar: shouldShowTabBar
+                            shouldShowTabBar: shouldShowTabBar,
+                            codeFile: $codeFile
                         ) { [weak editor] newFile in
                             if let file = editor?.selectedTab, let index = editor?.tabs.firstIndex(of: file) {
                                 editor?.openTab(file: newFile, at: index)

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
@@ -27,7 +27,8 @@ extension SettingsData {
                 "Autocomplete braces",
                 "Enable type-over completion",
                 "Bracket Pair Emphasis",
-                "Bracket Pair Highlight"
+                "Bracket Pair Highlight",
+                "Show Minimap",
             ]
             if #available(macOS 14.0, *) {
                 keys.append("System Cursor")
@@ -69,6 +70,9 @@ extension SettingsData {
 
         /// Use the system cursor for the source editor.
         var useSystemCursor: Bool = true
+
+        /// Toggle the minimap in the editor.
+        var showMinimap: Bool = true
 
         /// Default initializer
         init() {
@@ -118,6 +122,8 @@ extension SettingsData {
                 self.useSystemCursor = false
             }
 
+            self.showMinimap = try container.decodeIfPresent(Bool.self, forKey: .showMinimap) ?? true
+
             self.populateCommands()
         }
 
@@ -130,7 +136,7 @@ extension SettingsData {
                 title: "Toggle Type-Over Completion",
                 id: "prefs.text_editing.type_over_completion",
                 command: {
-                    Settings.shared.preferences.textEditing.enableTypeOverCompletion.toggle()
+                    Settings[\.textEditing].enableTypeOverCompletion.toggle()
                 }
             )
 
@@ -139,7 +145,7 @@ extension SettingsData {
                 title: "Toggle Autocomplete Braces",
                 id: "prefs.text_editing.autocomplete_braces",
                 command: {
-                    Settings.shared.preferences.textEditing.autocompleteBraces.toggle()
+                    Settings[\.textEditing].autocompleteBraces.toggle()
                 }
             )
 
@@ -151,6 +157,14 @@ extension SettingsData {
                     Settings[\.textEditing].wrapLinesToEditorWidth.toggle()
                 }
             )
+
+            mgr.addCommand(
+                name: "Toggle Minimap",
+                title: "Toggle Minimap",
+                id: "prefs.text_editing.toggle_minimap"
+            ) {
+                Settings[\.textEditing].showMinimap.toggle()
+            }
         }
 
         struct IndentOption: Codable, Hashable {

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -20,6 +20,7 @@ struct TextEditingSettingsView: View {
                 wrapLinesToEditorWidth
                 useSystemCursor
                 overscroll
+                showMinimap
             }
             Section {
                 fontSelector
@@ -198,5 +199,11 @@ private extension TextEditingSettingsView {
                 .disabled(!textEditing.bracketEmphasis.useCustomColor)
             }
         }
+    }
+
+    @ViewBuilder private var showMinimap: some View {
+        Toggle("Show Minimap", isOn: $textEditing.showMinimap)
+            // swiftlint:disable:next line_length
+            .help("The minimap gives you a high-level summary of your source code, with controls to quickly navigate your document.")
     }
 }


### PR DESCRIPTION
### Description

Adds a minimap to CodeEdit's editor, as well as a new trailing editor accessory (that only appears when the selected document is a code document), a command to toggle the minimap, and a setting to toggle the minimap.

### Related Issues

* https://github.com/CodeEditApp/CodeEditSourceEditor/issues/33

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/07f21d48-23cf-42dc-b39a-02ba395956cb
