### PR TITLE
Fix Getting Stuck in Sub-View within Settings

### DIFF
--- a/CodeEdit/Features/Settings/SettingsView.swift
+++ b/CodeEdit/Features/Settings/SettingsView.swift
@@ -184,11 +184,11 @@ struct SettingsView: View {
                 }
             }
             .navigationSplitViewColumnWidth(500)
-            .hideSidebarToggle()
             .onAppear {
                 model.backButtonVisible = false
             }
         }
+        .hideSidebarToggle()
         .navigationTitle(selectedPage.name.rawValue)
         .toolbar {
             ToolbarItem(placement: .navigation) {

--- a/CodeEdit/Features/Settings/Views/SettingsForm.swift
+++ b/CodeEdit/Features/Settings/Views/SettingsForm.swift
@@ -17,39 +17,41 @@ struct SettingsForm<Content: View>: View {
     @ViewBuilder var content: Content
 
     var body: some View {
-        Form {
-            Section {
-                EmptyView()
-            } footer: {
-                Rectangle()
-                    .frame(height: 0)
-                    .background(
-                        GeometryReader {
-                            Color.clear.preference(
-                                key: ViewOffsetKey.self,
-                                value: -$0.frame(in: .named("scroll")).origin.y
-                            )
-                        }
-                    )
-                    .onPreferenceChange(ViewOffsetKey.self) {
-                        if $0 <= -20.0 && !model.scrolledToTop {
-                            withAnimation {
-                                model.scrolledToTop = true
+        NavigationStack {
+            Form {
+                Section {
+                    EmptyView()
+                } footer: {
+                    Rectangle()
+                        .frame(height: 0)
+                        .background(
+                            GeometryReader {
+                                Color.clear.preference(
+                                    key: ViewOffsetKey.self,
+                                    value: -$0.frame(in: .named("scroll")).origin.y
+                                )
                             }
-                        } else if $0 > -20.0 && model.scrolledToTop {
-                            withAnimation {
-                                model.scrolledToTop = false
+                        )
+                        .onPreferenceChange(ViewOffsetKey.self) {
+                            if $0 <= -20.0 && !model.scrolledToTop {
+                                withAnimation {
+                                    model.scrolledToTop = true
+                                }
+                            } else if $0 > -20.0 && model.scrolledToTop {
+                                withAnimation {
+                                    model.scrolledToTop = false
+                                }
                             }
                         }
-                    }
+                }
+                content
             }
-            content
+            .introspect(.scrollView, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
+                $0.scrollerInsets.top = 50
+            }
+            .formStyle(.grouped)
+            .coordinateSpace(name: "scroll")
         }
-        .introspect(.scrollView, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
-            $0.scrollerInsets.top = 50
-        }
-        .formStyle(.grouped)
-        .coordinateSpace(name: "scroll")
         .safeAreaInset(edge: .top, spacing: -50) {
             EffectView(.menu)
                 .opacity(!model.scrolledToTop ? 1 : 0)

--- a/CodeEdit/Features/Settings/Views/View+HideSidebarToggle.swift
+++ b/CodeEdit/Features/Settings/Views/View+HideSidebarToggle.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftUIIntrospect
 
 extension View {
     func hideSidebarToggle() -> some View {
@@ -16,12 +17,11 @@ extension View {
 struct HideSidebarToggleViewModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .task {
-                let window = NSApp.windows.first { $0.identifier?.rawValue == SceneID.settings.rawValue }!
-                let sidebaritem = "com.apple.SwiftUI.navigationSplitView.toggleSidebar"
-                let index = window.toolbar?.items.firstIndex { $0.itemIdentifier.rawValue == sidebaritem }
-                if let index {
-                    window.toolbar?.removeItem(at: index)
+            .introspect(.window, on: .macOS(.v13, .v14, .v15)) { window in
+                if let toolbar = window.toolbar {
+                    let sidebarItem = "com.apple.SwiftUI.navigationSplitView.toggleSidebar"
+                    let sidebarToggle = toolbar.items.first(where: { $0.itemIdentifier.rawValue == sidebarItem })
+                    sidebarToggle?.view?.isHidden = true
                 }
             }
     }

--- a/CodeEdit/Features/Settings/Views/View+NavigationBarBackButtonVisible.swift
+++ b/CodeEdit/Features/Settings/Views/View+NavigationBarBackButtonVisible.swift
@@ -17,7 +17,6 @@ struct NavigationBarBackButtonVisible: ViewModifier {
         .toolbar {
             ToolbarItem(placement: .navigation) {
                 Button {
-                    print(self.presentationMode.wrappedValue)
                     self.presentationMode.wrappedValue.dismiss()
                 } label: {
                     Image(systemName: "chevron.left")
@@ -25,9 +24,12 @@ struct NavigationBarBackButtonVisible: ViewModifier {
                 }
             }
         }
-        .hideSidebarToggle()
+        .navigationBarBackButtonHidden()
         .onAppear {
             model.backButtonVisible = true
+        }
+        .onDisappear {
+            model.backButtonVisible = false
         }
     }
 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This pull request resolves several navigation related bugs within Settings. The most important being that it resolves getting suck within sub views. Additionally, I've improved how hiding the sidebar toggle works which is now consistently hidden regardless of macOS 13+. It now no longer makes unexpected returns or cameos.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #1923 

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] The issues this PR addresses are related to each other
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots

https://github.com/user-attachments/assets/f92bcc49-b397-4e33-85c5-06d0873e6b10

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->