### PR TITLE
Fixed History Inspector popover UI bug

### DIFF
--- a/CodeEdit/Features/InspectorArea/HistoryInspector/HistoryPopoverView.swift
+++ b/CodeEdit/Features/InspectorArea/HistoryInspector/HistoryPopoverView.swift
@@ -18,10 +18,8 @@ struct HistoryPopoverView: View {
     var body: some View {
         VStack {
             CommitDetailsHeaderView(commit: commit)
-                .padding(.horizontal)
 
             Divider()
-                .padding(.horizontal)
 
             VStack(alignment: .leading, spacing: 0) {
                 // TODO: Implementation Needed
@@ -71,6 +69,8 @@ struct HistoryPopoverView: View {
                 }, icon: {
                     Image(systemName: image)
                         .frame(width: 16, alignment: .center)
+                        .padding(.leading, -2.5)
+                        .padding(.trailing, 2.5)
                 })
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .foregroundColor(isHovering && isEnabled ? .white : .primary)


### PR DESCRIPTION
### Description

This PR fixes some UI spacing issues found in the History Inspector popover.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Before
<img width="649" alt="Screenshot 2025-05-08 at 12 24 21 AM" src="https://github.com/user-attachments/assets/80c6a118-4ad2-4f5e-bc64-14ff721bfc3d" />

After
<img width="649" alt="Screenshot 2025-05-08 at 12 24 48 AM" src="https://github.com/user-attachments/assets/b9ea3c63-d13d-4884-bcc1-c662f522e003" />
