### PR TITLE
Open New Files in Workspace

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager.swift
@@ -103,12 +103,12 @@ final class CEWorkspaceFileManager {
                 return nil
             }
 
-            // Drill down towards the file, indexing any directories needed. 
-            // If file is not in the `workspaceSettingsFolderURL` or subdirectories, exit.
-            guard url.absoluteString.starts(with: folderUrl.absoluteString),
-                  url.pathComponents.count > folderUrl.pathComponents.count else {
+            // If file is not in the `folderUrl` or subdirectories, exit.
+            guard folderUrl.containsSubPath(url) else {
                 return nil
             }
+
+            // Drill down towards the file, indexing any directories needed.
             let pathComponents = url.pathComponents.dropFirst(folderUrl.pathComponents.count)
             var currentURL = folderUrl
 

--- a/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditDocumentController.swift
@@ -75,7 +75,7 @@ final class CodeEditDocumentController: NSDocumentController {
             completionHandler(document, documentWasAlreadyOpen, error)
         }
     }
-    
+
     /// Attempt to open the file URL in an open workspace, finding the nearest workspace to open it in if possible.
     /// - Parameter url: The file URL to open.
     /// - Returns: True, if the document was opened in a workspace.

--- a/CodeEdit/Utils/Extensions/URL/URL+componentCompare.swift
+++ b/CodeEdit/Utils/Extensions/URL/URL+componentCompare.swift
@@ -15,4 +15,39 @@ extension URL {
     func componentCompare(_ other: URL) -> Bool {
         return self.pathComponents == other.pathComponents
     }
+
+    /// Determines if another URL is lower in the file system than this URL.
+    ///
+    /// Examples:
+    /// ```
+    /// URL(filePath: "/Users/Bob/Desktop").containsSubPath(URL(filePath: "/Users/Bob/Desktop/file.txt")) // true
+    /// URL(filePath: "/Users/Bob/Desktop").containsSubPath(URL(filePath: "/Users/Bob/Desktop/")) // false
+    /// URL(filePath: "/Users/Bob/Desktop").containsSubPath(URL(filePath: "/Users/Bob/")) // false
+    /// URL(filePath: "/Users/Bob/Desktop").containsSubPath(URL(filePath: "/Users/Bob/Desktop/Folder")) // true
+    /// ```
+    ///
+    /// - Parameter other: The URL to compare.
+    /// - Returns: True, if the other URL is lower in the file system.
+    func containsSubPath(_ other: URL) -> Bool {
+        other.absoluteString.starts(with: absoluteString)
+        && other.pathComponents.count > pathComponents.count
+    }
+
+    /// Compares this url with another, counting the number of shared path components. Stops counting once a
+    /// different component is found.
+    ///
+    /// - Note: URL treats a leading `/` as a component, so `/Users` and `/` will return `1`.
+    /// - Parameter other: The URL to compare against.
+    /// - Returns: The number of shared components.
+    func sharedComponents(_ other: URL) -> Int {
+        var count = 0
+        for (component, otherComponent) in zip(pathComponents, other.pathComponents) {
+            if component == otherComponent {
+                count += 1
+            } else {
+                return count
+            }
+        }
+        return count
+    }
 }

--- a/CodeEditTests/Utils/UnitTests_Extensions.swift
+++ b/CodeEditTests/Utils/UnitTests_Extensions.swift
@@ -196,4 +196,38 @@ final class CodeEditUtilsExtensionsUnitTests: XCTestCase {
         let path = #"/Hello World/ With Spaces/ And " Characters "#
         XCTAssertEqual(path.escapedDirectory(), #""/Hello World/ With Spaces/ And \" Characters ""#)
     }
+
+    // MARK: - URL + Contains
+
+    func testURLContainsSubPath() {
+        XCTAssertTrue(URL(filePath: "/Users/Bob/Desktop").containsSubPath(URL(filePath: "/Users/Bob/Desktop/file.txt")))
+        XCTAssertFalse(URL(filePath: "/Users/Bob/Desktop").containsSubPath(URL(filePath: "/Users/Bob/Desktop/")))
+        XCTAssertFalse(URL(filePath: "/Users/Bob/Desktop").containsSubPath(URL(filePath: "/Users/Bob/")))
+        XCTAssertTrue(URL(filePath: "/Users/Bob/Desktop").containsSubPath(URL(filePath: "/Users/Bob/Desktop/Folder")))
+    }
+
+    func testURLSharedComponentsCount() {
+        // URL Treats the leading `/` as a component, so these all appear to have + 1 but are correct.
+        XCTAssertEqual(
+            URL(filePath: "/Users/Bob/Desktop").sharedComponents(URL(filePath: "/Users/Bob/Desktop/file.txt")),
+            4
+        )
+        XCTAssertEqual(
+            URL(filePath: "/Users/Bob/Desktop").sharedComponents(URL(filePath: "/Users/Bob/Desktop/")),
+            4
+        )
+        XCTAssertEqual(
+            URL(filePath: "/Users/Bob/Desktop").sharedComponents(URL(filePath: "/Users/Bob/")),
+            3
+        )
+        XCTAssertEqual(
+            URL(filePath: "/Users/Bob/Desktop").sharedComponents(URL(filePath: "/Users/Bob/Desktop/Folder")),
+            4
+        )
+
+        XCTAssertEqual(
+            URL(filePath: "/Users/Bob/Desktop").sharedComponents(URL(filePath: "/Some Other/ Path ")),
+            1
+        )
+    }
 }


### PR DESCRIPTION
### Description

When a new file is opened, tries to open it in a nearby workspace. Right now new files are opened in their own window no matter what (eg using `⌘N` or a file URL).

The workspace is chosen by proximity, so if a user has `/User/Desktop` and `/User/Desktop/Project` open. Opening the file `/User/Desktop/Project/MAKEFILE` will open it in the `Project` workspace.

### Related Issues

* Reported by @ BSM on Discord

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

(please ignore the messed up gutter, it's been fixed in CESE but not cut in a release)

https://github.com/user-attachments/assets/8d341dee-d043-4b0a-8fd3-f544bf952abb

Files open to the nearest folder, and bring the window to front.

https://github.com/user-attachments/assets/96ec98a5-20ec-4d53-a996-446d9264e7c4

