### PR TITLE
Jump Bar Overflow Accordion Effect 

### DIFF
--- a/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarComponent.swift
+++ b/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarComponent.swift
@@ -65,6 +65,11 @@ struct EditorJumpBarComponent: View {
 
             return button
         }
+        .frame(
+            maxWidth: isHovering || isLastItem ? nil : 20,
+            alignment: .leading
+        )
+        .clipped()
         .padding(.trailing, 11)
         .background {
             Color(nsColor: colorScheme == .dark ? .white : .black)

--- a/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarComponent.swift
+++ b/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarComponent.swift
@@ -75,7 +75,7 @@ struct EditorJumpBarComponent: View {
         .mask(
             LinearGradient(
                 gradient: Gradient(
-                    stops: truncatedCrumbWidth == nil ?
+                    stops: truncatedCrumbWidth == nil || isHovering ?
                     [
                         .init(color: .black, location: 0),
                         .init(color: .black, location: 1)

--- a/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarComponent.swift
+++ b/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarComponent.swift
@@ -72,6 +72,23 @@ struct EditorJumpBarComponent: View {
             maxWidth: isHovering || isLastItem ? nil : truncatedCrumbWidth,
             alignment: .leading
         )
+        .mask(
+            LinearGradient(
+                gradient: Gradient(
+                    stops: truncatedCrumbWidth == nil ?
+                    [
+                        .init(color: .black, location: 0),
+                        .init(color: .black, location: 1)
+                    ] : [
+                        .init(color: .black, location: 0),
+                        .init(color: .black, location: 0.8),
+                        .init(color: .clear, location: 1)
+                    ]
+                ),
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+        )
         .clipped()
         .padding(.trailing, 11)
         .background {

--- a/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarComponent.swift
+++ b/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarComponent.swift
@@ -88,7 +88,9 @@ struct EditorJumpBarComponent: View {
         }
         .padding(.vertical, 3)
         .onHover { hover in
-            isHovering = hover
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isHovering = hover
+            }
         }
         .onLongPressGesture(minimumDuration: 0) {
             button.performClick(nil)

--- a/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarComponent.swift
+++ b/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarComponent.swift
@@ -26,16 +26,19 @@ struct EditorJumpBarComponent: View {
     @State var selection: CEWorkspaceFile
     @State var isHovering: Bool = false
     @State var button = NSPopUpButton()
+    @Binding var truncatedCrumbWidth: CGFloat?
 
     init(
         fileItem: CEWorkspaceFile,
         tappedOpenFile: @escaping (CEWorkspaceFile) -> Void,
-        isLastItem: Bool
+        isLastItem: Bool,
+        isTruncated: Binding<CGFloat?>
     ) {
         self.fileItem = fileItem
         self._selection = .init(wrappedValue: fileItem)
         self.tappedOpenFile = tappedOpenFile
         self.isLastItem = isLastItem
+        self._truncatedCrumbWidth = isTruncated
     }
 
     var siblings: [CEWorkspaceFile] {
@@ -66,7 +69,7 @@ struct EditorJumpBarComponent: View {
             return button
         }
         .frame(
-            maxWidth: isHovering || isLastItem ? nil : 20,
+            maxWidth: isHovering || isLastItem ? nil : truncatedCrumbWidth,
             alignment: .leading
         )
         .clipped()

--- a/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarView.swift
+++ b/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarView.swift
@@ -28,7 +28,7 @@ struct EditorJumpBarView: View {
     @State private var textWidth: CGFloat = 0
     @State private var containerWidth: CGFloat = 0
     @State private var isTruncated: Bool = false
-    @State private var crumbWidth: CGFloat? = nil
+    @State private var crumbWidth: CGFloat?
 
     init(
         file: CEWorkspaceFile?,
@@ -78,6 +78,23 @@ struct EditorJumpBarView: View {
 
                     }
                 }
+                .mask(
+                    LinearGradient(
+                        gradient: Gradient(
+                            stops: crumbWidth != nil ?
+                            [
+                                .init(color: .black, location: 0),
+                                .init(color: .black, location: 0.8),
+                                .init(color: .clear, location: 1)
+                            ] : [
+                                .init(color: .black, location: 0),
+                                .init(color: .black, location: 1)
+                            ]
+                        ),
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
                 .background(
                     GeometryReader { proxy in
                         Color.clear

--- a/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarView.swift
+++ b/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarView.swift
@@ -67,6 +67,7 @@ struct EditorJumpBarView: View {
                                 ? isActiveEditor ? .primary : .secondary
                                 : Color(nsColor: .tertiaryLabelColor)
                             )
+                            .frame(maxHeight: .infinity)
                     } else {
                         ForEach(fileItems, id: \.self) { fileItem in
                             EditorJumpBarComponent(
@@ -146,7 +147,7 @@ struct EditorJumpBarView: View {
             crumbWidth = nil
         }
 
-        if betweenWidth > snapThreshold {
+        if betweenWidth > snapThreshold || crumbWidth == nil {
             firstCrumbWidth = nil
         } else {
             let otherCrumbs = CGFloat(max(fileItems.count - 1, 1))

--- a/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarView.swift
+++ b/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarView.swift
@@ -25,6 +25,11 @@ struct EditorJumpBarView: View {
 
     static let height = 28.0
 
+    @State private var textWidth: CGFloat = 0
+    @State private var containerWidth: CGFloat = 0
+    @State private var isTruncated: Bool = false
+    @State private var crumbWidth: CGFloat? = nil
+
     init(
         file: CEWorkspaceFile?,
         shouldShowTabBar: Bool,
@@ -50,24 +55,59 @@ struct EditorJumpBarView: View {
     }
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 0) {
-                if file == nil {
-                    Text("No Selection")
-                        .font(.system(size: 11, weight: .regular))
-                        .foregroundColor(
-                            activeState != .inactive
-                            ? isActiveEditor ? .primary : .secondary
-                            : Color(nsColor: .tertiaryLabelColor)
-                        )
-                } else {
-                    ForEach(fileItems, id: \.self) { fileItem in
-                        EditorJumpBarComponent(
-                            fileItem: fileItem,
-                            tappedOpenFile: tappedOpenFile,
-                            isLastItem: fileItems.last == fileItem
-                        )
+        GeometryReader { containerProxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 0) {
+                    if file == nil {
+                        Text("No Selection")
+                            .font(.system(size: 11, weight: .regular))
+                            .foregroundColor(
+                                activeState != .inactive
+                                ? isActiveEditor ? .primary : .secondary
+                                : Color(nsColor: .tertiaryLabelColor)
+                            )
+                    } else {
+                        ForEach(fileItems, id: \.self) { fileItem in
+                            EditorJumpBarComponent(
+                                fileItem: fileItem,
+                                tappedOpenFile: tappedOpenFile,
+                                isLastItem: fileItems.last == fileItem,
+                                isTruncated: $crumbWidth
+                            )
+                        }
+
                     }
+                }
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear
+                            .onAppear {
+                                if crumbWidth == nil {
+                                    textWidth = proxy.size.width
+                                }
+                            }
+                            .onChange(of: proxy.size.width) { newValue in
+                                if crumbWidth == nil {
+                                    textWidth = newValue
+                                }
+                            }
+                    }
+                )
+            }
+            .onAppear {
+                containerWidth = containerProxy.size.width
+            }
+            .onChange(of: containerProxy.size.width) { newValue in
+                containerWidth = newValue
+            }
+            .onChange(of: textWidth) { _ in
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    resize()
+                }
+            }
+            .onChange(of: containerWidth) { _ in
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    resize()
                 }
             }
         }
@@ -85,5 +125,23 @@ struct EditorJumpBarView: View {
         .frame(height: Self.height, alignment: .center)
         .opacity(activeState == .inactive ? 0.8 : 1.0)
         .grayscale(isActiveEditor ? 0.0 : 1.0)
+    }
+
+    private func resize() {
+        let minWidth: CGFloat = 20
+        let snapThreshold: CGFloat = 30
+        let maxWidth: CGFloat = textWidth / CGFloat(fileItems.count)
+        let exponent: CGFloat = 5.0
+
+        if textWidth >= containerWidth {
+            let scale = max(0, min(1, containerWidth / textWidth))
+            var width = floor((minWidth + (maxWidth - minWidth) * pow(scale, exponent)))
+            if width < snapThreshold {
+                width = minWidth
+            }
+            crumbWidth = width
+        } else {
+            crumbWidth = nil
+        }
     }
 }

--- a/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarView.swift
+++ b/CodeEdit/Features/Editor/JumpBar/Views/EditorJumpBarView.swift
@@ -79,23 +79,6 @@ struct EditorJumpBarView: View {
 
                     }
                 }
-                .mask(
-                    LinearGradient(
-                        gradient: Gradient(
-                            stops: crumbWidth != nil ?
-                            [
-                                .init(color: .black, location: 0),
-                                .init(color: .black, location: 0.8),
-                                .init(color: .clear, location: 1)
-                            ] : [
-                                .init(color: .black, location: 0),
-                                .init(color: .black, location: 1)
-                            ]
-                        ),
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    )
-                )
                 .background(
                     GeometryReader { proxy in
                         Color.clear


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

This PR introduces an initial implementation of an accordion-like effect for displaying file paths in the tab bar. The goal is to improve usability when file paths are too long to fit in the available space.

**Current (Draft) Behavior:**  
- The accordion effect is always shown, regardless of whether the file path is truncated.

**Expected Behavior:**  
- The accordion effect should only be triggered when a file path is truncated due to limited space in the scroll view.
- If the file path fits within the visible area, the full path should be shown without any animation or effect.

**Request for Feedback:**  
- I would appreciate guidance on the best way to detect when a file path is actually truncated, so the effect only triggers in those cases.
- Feedback on the user experience and any edge cases to consider is also welcome.

---

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* Related to #241

---

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

---

### Screenshots

https://github.com/user-attachments/assets/7ed81d9a-b4ea-4b4b-b97d-b68863e00e87


