### PR TITLE
Added check for git installation presence

### DIFF
--- a/CodeEdit/Features/SourceControl/Clone/ViewModels/GitCloneViewModel.swift
+++ b/CodeEdit/Features/SourceControl/Clone/ViewModels/GitCloneViewModel.swift
@@ -61,8 +61,8 @@ class GitCloneViewModel: ObservableObject {
     func cloneRepository(completionHandler: @escaping (URL) -> Void) {
         if !isGitInstalled() {
             showAlert(
-                alertMsg: "Git installation not found",
-                infoText: "Ensure Git is installed on your system and try again"
+                alertMsg: "Git installation not found.",
+                infoText: "Ensure Git is installed on your system and try again."
             )
             return
         }

--- a/CodeEdit/Features/SourceControl/Clone/ViewModels/GitCloneViewModel.swift
+++ b/CodeEdit/Features/SourceControl/Clone/ViewModels/GitCloneViewModel.swift
@@ -31,6 +31,22 @@ class GitCloneViewModel: ObservableObject {
         }
         return false
     }
+    /// Check if Git is installed
+    /// - Returns: True if Git is found by running "which git" command
+    func isGitInstalled() -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        process.arguments = ["git"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
 
     /// Check if clipboard contains git url
     func checkClipboard() {
@@ -43,6 +59,13 @@ class GitCloneViewModel: ObservableObject {
 
     /// Clone repository
     func cloneRepository(completionHandler: @escaping (URL) -> Void) {
+        if !isGitInstalled() {
+            showAlert(
+                alertMsg: "Git installation not found",
+                infoText: "Ensure Git is installed on your system and try again"
+            )
+            return
+        }
         if repoUrlStr == "" {
             showAlert(
                 alertMsg: "Url cannot be empty",


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description
Added Git installation checking before attempting to clone a repository. Instead of silently opening an empty workspace when Git is not available, users now receive an alert message informing them that Git is required. 

The implementation adds:
1. A new isGitInstalled() method that validates Git installation by running the "which git" command and checking its exit status
2. A validation check at the beginning of the cloneRepository() method that displays a user-friendly error when Git is not detected

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues
<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #2031 

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] The issues this PR addresses are related to each other
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots
<img width="1728" alt="Снимок экрана 2025-05-17 в 11 17 21" src="https://github.com/user-attachments/assets/ed858edf-0470-4fd6-b0eb-baef1add78db" />


<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
