### PR TITLE
Made Editor Separators Thicker

### DIFF
--- a/CodeEdit/Features/Editor/Views/EditorLayoutView.swift
+++ b/CodeEdit/Features/Editor/Views/EditorLayoutView.swift
@@ -48,7 +48,6 @@ struct EditorLayoutView: View {
 
     struct SubEditorLayoutView: View {
         @ObservedObject var data: SplitViewData
-
         @FocusState.Binding var focus: Editor?
 
         var body: some View {
@@ -58,8 +57,10 @@ struct EditorLayoutView: View {
             .edgesIgnoringSafeArea([.top, .bottom])
         }
 
-        var splitView: some View {
-            ForEach(Array(data.editorLayouts.enumerated()), id: \.offset) { index, item in
+        func stackContentsView(index: Int, item: EditorLayout) -> some View {
+            Group {
+                // Add a divider before the editor if it's not the first
+                if index != 0 { PanelDivider() }
                 EditorLayoutView(layout: item, focus: $focus)
                     .transformEnvironment(\.isAtEdge) { belowToolbar in
                         calcIsAtEdge(current: &belowToolbar, index: index)
@@ -67,6 +68,22 @@ struct EditorLayoutView: View {
                     .environment(\.splitEditor) { [weak data] edge, newEditor in
                         data?.split(edge, at: index, new: newEditor)
                     }
+                // Add a divider after the editor if it's not the last
+                if index != data.editorLayouts.count - 1 { PanelDivider() }
+            }
+        }
+
+        var splitView: some View {
+            ForEach(Array(data.editorLayouts.enumerated()), id: \.offset) { index, item in
+                if data.axis == .horizontal {
+                    HStack(spacing: 0) {
+                        stackContentsView(index: index, item: item)
+                    }
+                } else {
+                    VStack(spacing: 0) {
+                        stackContentsView(index: index, item: item)
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
### Description

Made editor separators thicker by conditionally adding separators to editors depending on its position in the split layout.

### Related Issues

* #2054

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/ab9defef-2f8e-45c8-bce2-c2e8bcb41b2b" />
