### PR TITLE
Copy Version Information On Click

### DIFF
--- a/CodeEdit/Features/About/Views/AboutDefaultView.swift
+++ b/CodeEdit/Features/About/Views/AboutDefaultView.swift
@@ -27,6 +27,9 @@ struct AboutDefaultView: View {
     @Environment(\.colorScheme)
     var colorScheme
 
+    @State private var didCopyVersion = false
+    @State private var isHoveringVersion = false
+
     private static var licenseURL = URL(string: "https://github.com/CodeEditApp/CodeEdit/blob/main/LICENSE.md")!
 
     let smallTitlebarHeight: CGFloat = 28
@@ -52,9 +55,39 @@ struct AboutDefaultView: View {
                         weight: .bold
                     ))
                 Text("Version \(appVersion)\(appVersionPostfix) (\(appBuild))")
-                    .textSelection(.enabled)
-                    .foregroundColor(Color(.tertiaryLabelColor))
+                    .textSelection(.disabled)
                     .font(.body)
+                    .onTapGesture {
+                        // Create a string suitable for pasting into a bug report
+                        let macOSVersion = ProcessInfo.processInfo.operatingSystemVersion.semverString
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(
+                            "CodeEdit: \(appVersion) (\(appBuild))\nmacOS: \(macOSVersion)",
+                            forType: .string
+                        )
+                        didCopyVersion.toggle()
+                    }
+                    .background(alignment: .leading) {
+                        if isHoveringVersion {
+                            if #available(macOS 14.0, *) {
+                                Image(systemName: "document.on.document.fill")
+                                    .font(.caption)
+                                    .offset(x: -16, y: 0)
+                                    .transition(.opacity)
+                                    .symbolEffect(
+                                        .bounce.down.wholeSymbol,
+                                        options: .nonRepeating.speed(1.8),
+                                        value: didCopyVersion
+                                    )
+                            } else {
+                                Image(systemName: "document.on.document.fill")
+                                    .font(.caption)
+                                    .offset(x: -16, y: 0)
+                                    .transition(.opacity)
+                            }
+                        }
+                    }
+                    .foregroundColor(Color(.tertiaryLabelColor))
                     .blendMode(colorScheme == .dark ? .plusLighter : .plusDarker)
                     .padding(.top, 4)
                     .matchedGeometryEffect(
@@ -65,14 +98,10 @@ struct AboutDefaultView: View {
                     )
                     .blur(radius: aboutMode == .about ? 0 : 10)
                     .opacity(aboutMode == .about ? 1 : 0)
-                    .onTapGesture {
-                        // Create a string suitable for pasting into a bug report
-                        let macOSVersion = ProcessInfo.processInfo.operatingSystemVersion.semverString
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(
-                            "CodeEdit: \(appVersion) (\(appBuild))\nmacOS: \(macOSVersion)",
-                            forType: .string
-                        )
+                    .onHover { hovering in
+                        withAnimation(.easeInOut(duration: 0.1)) {
+                            isHoveringVersion = hovering
+                        }
                     }
             }
             .padding(.horizontal)

--- a/CodeEdit/Features/About/Views/AboutDefaultView.swift
+++ b/CodeEdit/Features/About/Views/AboutDefaultView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Foundation
 
 struct AboutDefaultView: View {
     private var appVersion: String {
@@ -64,6 +65,15 @@ struct AboutDefaultView: View {
                     )
                     .blur(radius: aboutMode == .about ? 0 : 10)
                     .opacity(aboutMode == .about ? 1 : 0)
+                    .onTapGesture {
+                        // Create a string suitable for pasting into a bug report
+                        let macOSVersion = ProcessInfo.processInfo.operatingSystemVersion.semverString
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(
+                            "CodeEdit: \(appVersion) (\(appBuild))\nmacOS: \(macOSVersion)",
+                            forType: .string
+                        )
+                    }
             }
             .padding(.horizontal)
         }
@@ -96,7 +106,6 @@ struct AboutDefaultView: View {
                     Link(destination: Self.licenseURL) {
                         Text("MIT License")
                             .underline()
-
                     }
                     Text(Bundle.copyrightString ?? "")
                 }

--- a/CodeEdit/Utils/Extensions/OperatingSystemVersion/OperatingSystemVersion+String.swift
+++ b/CodeEdit/Utils/Extensions/OperatingSystemVersion/OperatingSystemVersion+String.swift
@@ -1,0 +1,14 @@
+//
+//  OperatingSystemVersion+String.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 5/27/25.
+//
+
+import Foundation
+
+extension OperatingSystemVersion {
+    var semverString: String {
+        "\(majorVersion).\(minorVersion).\(patchVersion)"
+    }
+}


### PR DESCRIPTION
### Description

Adds a quick interaction to copy version information (CodeEdit & macOS) for bug reports in the about window.

### Related Issues

N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/user-attachments/assets/be25d31d-8611-4abc-9497-30ca052ec82f

