### PR TITLE
Fix: Navigator Loses Editing, Drawer Not Draggable

### DIFF
--- a/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
+++ b/CodeEdit/Features/CEWorkspace/Models/CEWorkspaceFileManager+FileManagement.swift
@@ -251,11 +251,11 @@ extension CEWorkspaceFileManager {
     @discardableResult
     public func move(file: CEWorkspaceFile, to newLocation: URL) throws -> CEWorkspaceFile? {
         do {
-            guard fileManager.fileExists(atPath: file.url.path()) else {
+            guard fileManager.fileExists(atPath: file.url.path(percentEncoded: false)) else {
                 throw FileManagerError.originFileNotFound
             }
 
-            guard !fileManager.fileExists(atPath: newLocation.path) else {
+            guard !fileManager.fileExists(atPath: newLocation.path(percentEncoded: false)) else {
                 throw FileManagerError.destinationFileExists
             }
 
@@ -305,7 +305,9 @@ extension CEWorkspaceFileManager {
     ///   - newLocation: The location to copy to.
     public func copy(file: CEWorkspaceFile, to newLocation: URL) throws {
         do {
-            guard file.url != newLocation && !fileManager.fileExists(atPath: newLocation.absoluteString) else {
+            guard file.url != newLocation && !fileManager.fileExists(
+                atPath: newLocation.absoluteURL.path(percentEncoded: false)
+            ) else {
                 throw FileManagerError.originFileNotFound
             }
             try fileManager.copyItem(at: file.url, to: newLocation)

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorOutlineView.swift
@@ -85,8 +85,16 @@ struct ProjectNavigatorOutlineView: NSViewControllerRepresentable {
             guard let outlineView = controller?.outlineView else { return }
             let selectedRows = outlineView.selectedRowIndexes.compactMap({ outlineView.item(atRow: $0) })
 
-            for item in updatedItems {
-                outlineView.reloadItem(item, reloadChildren: true)
+            // If some text view inside the outline view is first responder right now, push the update off
+            // until editing is finished using the `shouldReloadAfterDoneEditing` flag.
+            if outlineView.window?.firstResponder !== outlineView
+                && outlineView.window?.firstResponder is NSTextView
+                && (outlineView.window?.firstResponder as? NSView)?.isDescendant(of: outlineView) == true {
+                controller?.shouldReloadAfterDoneEditing = true
+            } else {
+                for item in updatedItems {
+                    outlineView.reloadItem(item, reloadChildren: true)
+                }
             }
 
             // Restore selected items where the files still exist.

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorTableViewCell.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorTableViewCell.swift
@@ -10,6 +10,7 @@ import SwiftUI
 protocol OutlineTableViewCellDelegate: AnyObject {
     func moveFile(file: CEWorkspaceFile, to destination: URL)
     func copyFile(file: CEWorkspaceFile, to destination: URL)
+    func cellDidFinishEditing()
 }
 
 /// A `NSTableCellView` showing an ``icon`` and a ``label``
@@ -64,5 +65,6 @@ final class ProjectNavigatorTableViewCell: FileSystemTableViewCell {
         } else {
             textField?.stringValue = fileItem.labelFileName()
         }
+        delegate?.cellDidFinishEditing()
     }
 }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+OutlineTableViewCellDelegate.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController+OutlineTableViewCellDelegate.swift
@@ -39,4 +39,9 @@ extension ProjectNavigatorViewController: OutlineTableViewCellDelegate {
             alert.runModal()
         }
     }
+
+    func cellDidFinishEditing() {
+        guard shouldReloadAfterDoneEditing else { return }
+        outlineView.reloadData()
+    }
 }

--- a/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
+++ b/CodeEdit/Features/NavigatorArea/ProjectNavigator/OutlineView/ProjectNavigatorViewController.swift
@@ -64,6 +64,8 @@ final class ProjectNavigatorViewController: NSViewController {
     /// to open the file a second time.
     var shouldSendSelectionUpdate: Bool = true
 
+    var shouldReloadAfterDoneEditing: Bool = false
+
     var filterIsEmpty: Bool {
         workspace?.navigatorFilter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true
     }

--- a/CodeEdit/Features/SplitView/Views/SplitViewControllerView.swift
+++ b/CodeEdit/Features/SplitView/Views/SplitViewControllerView.swift
@@ -15,7 +15,7 @@ struct SplitViewControllerView: NSViewControllerRepresentable {
     @Binding var viewController: () -> SplitViewController?
 
     func makeNSViewController(context: Context) -> SplitViewController {
-        let controller = SplitViewController(axis: axis) { controller in
+        let controller = SplitViewController(axis: axis, parentView: self) { controller in
             updateItems(controller: controller)
         }
         return controller
@@ -64,10 +64,6 @@ struct SplitViewControllerView: NSViewControllerRepresentable {
             }
         }
     }
-
-    func makeCoordinator() -> SplitViewController {
-        SplitViewController(axis: axis, setUpItems: nil)
-    }
 }
 
 final class SplitViewController: NSSplitViewController {
@@ -108,8 +104,9 @@ final class SplitViewController: NSSplitViewController {
 
     var setUpItems: ((SplitViewController) -> Void)?
 
-    init(axis: Axis, setUpItems: ((SplitViewController) -> Void)?) {
+    init(axis: Axis, parentView: SplitViewControllerView?, setUpItems: ((SplitViewController) -> Void)?) {
         self.axis = axis
+        self.parentView = parentView
         self.setUpItems = setUpItems
         super.init(nibName: nil, bundle: nil)
     }


### PR DESCRIPTION
### Description

- Fixes an issue where the project navigator would receive a file system update while a file's name was being edited, then lose the focus.
  - Added a check to see if a child text field is in focus. If it is, delays the reload.
  - Added a flag that is checked after text fields are done editing. If it's on, reloads the project navigator.
  - This is particularly noticeable when a file is added, then needs to be edited. Like in #1995.
- Fixes an issue with moving files with spaces in their name.
- Fixes an issue introduced in #2055 that made the utility drawer not draggable.

### Related Issues

* #2055 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Example behavior, a file system update is scheduled, then a text field is focused. The project navigator correctly delays the outline view refresh until after the user is done editing.

https://github.com/user-attachments/assets/d6c091cb-349f-4815-b60e-d9bfd6717330

