### PR TITLE
Update SettingsView for macOS 26 Tahoe

### DIFF
--- a/CodeEdit/Features/Settings/SettingsView.swift
+++ b/CodeEdit/Features/Settings/SettingsView.swift
@@ -144,18 +144,32 @@ struct SettingsView: View {
 
     var body: some View {
         NavigationSplitView {
-            List { }
-                .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
-                .scrollDisabled(true)
-                .frame(height: 30)
-            List(selection: $selectedPage) {
-                Section {
-                    ForEach(Self.pages) { pageAndSettings in
-                        results(pageAndSettings.page, pageAndSettings.settings)
+            /// Remove the extra List workaround; macOS 26's sidebar .searchable now matches System Settings
+            if #unavailable(macOS 26.0) {
+                List { }
+                    .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
+                    .scrollDisabled(true)
+                    .frame(height: 30)
+                List(selection: $selectedPage) {
+                    Section {
+                        ForEach(Self.pages) { pageAndSettings in
+                            results(pageAndSettings.page, pageAndSettings.settings)
+                        }
                     }
                 }
+                .navigationSplitViewColumnWidth(215)
+            } else {
+                List(selection: $selectedPage) {
+                    Section {
+                        ForEach(Self.pages) { pageAndSettings in
+                            results(pageAndSettings.page, pageAndSettings.settings)
+                        }
+                    }
+                }
+                .toolbar(removing: .sidebarToggle)
+                .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
+                .navigationSplitViewColumnWidth(215)
             }
-            .navigationSplitViewColumnWidth(215)
         } detail: {
             Group {
                 switch selectedPage.name {
@@ -191,13 +205,16 @@ struct SettingsView: View {
         .hideSidebarToggle()
         .navigationTitle(selectedPage.name.rawValue)
         .toolbar {
-            ToolbarItem(placement: .navigation) {
-                if !model.backButtonVisible {
-                    Rectangle()
-                        .frame(width: 10)
-                        .opacity(0)
-                } else {
-                    EmptyView()
+            /// macOS 26 automatically adjusts the leading padding for navigationTitle
+            if #unavailable(macOS 26.0) {
+                ToolbarItem(placement: .navigation) {
+                    if !model.backButtonVisible {
+                        Rectangle()
+                            .frame(width: 10)
+                            .opacity(0)
+                    } else {
+                        EmptyView()
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description

This PR makes early adjustments for CodeEdit Settings with macOS 26 Tahoe due to its new design. Due to several changes in UI frameworks, workarounds that are currently used in macOS 15 or earlier have new incorrect behavior. Issues include:

- Sidebar toggle being shown again
- Top of the sidebar list having tall blank space
- Blank unusable button being shown next to the navigation title

For the toolbar, we no longer need an empty space to properly align the toolbar's navigationTitle. For the sidebar, we no longer have to rely on the stacked List workaround to fix the search bar to the top of the list. SwiftUI's updated searchable modifier has been updated to match the one in System Settings.

This beta is brand new, I will be keeping track of this to make sure it does not cause issues in future beta builds.

### Checklist
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

**Before, macOS 26**
<img width="827" alt="Screenshot of CodeEdit Settings, General pane, in macOS 26" src="https://github.com/user-attachments/assets/21cf3888-4814-4ac9-9305-6452b3034415" />

**After, macOS 26**
<img width="827" alt="Screenshot of CodeEdit Settings, General pane, in macOS 26" src="https://github.com/user-attachments/assets/df8c7770-658f-45d0-8acc-72b73633c447" />
<img width="827" alt="Screenshot of CodeEdit Settings, GitHub pane, in macOS 26" src="https://github.com/user-attachments/assets/6ff89af0-0b8c-4da8-b9d3-c9862a96a6e2" />

**After, macOS 15**
<img width="827" alt="Screenshot of CodeEdit Settings, General pane, in macOS 15" src="https://github.com/user-attachments/assets/8546cfd1-6a61-46bd-bb17-ad04a75acaa3" />
<img width="827" alt="Screenshot of CodeEdit Settings, GitHub pane, in macOS 15" src="https://github.com/user-attachments/assets/a8ff655c-9e31-43e6-a7fa-d58e3b449266" />
