### PR TITLE
Implement Invisible Characters Setting

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		6C0824A12C5C0C9700A0751E /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 6C0824A02C5C0C9700A0751E /* SwiftTerm */; };
 		6C147C4529A329350089B630 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 6C147C4429A329350089B630 /* OrderedCollections */; };
 		6C4E37FC2C73E00700AEE7B5 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 6C4E37FB2C73E00700AEE7B5 /* SwiftTerm */; };
+		6C50EF3B2DFC83E4007FE626 /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 6C50EF3A2DFC83E4007FE626 /* CodeEditSourceEditor */; };
 		6C66C31329D05CDC00DE9ED2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 6C66C31229D05CDC00DE9ED2 /* GRDB */; };
 		6C6BD6F429CD142C00235D17 /* CollectionConcurrencyKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6C6BD6F329CD142C00235D17 /* CollectionConcurrencyKit */; };
 		6C6BD6F829CD14D100235D17 /* CodeEditKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6C6BD6F729CD14D100235D17 /* CodeEditKit */; };
@@ -184,6 +185,7 @@
 				6C0824A12C5C0C9700A0751E /* SwiftTerm in Frameworks */,
 				6C81916B29B41DD300B75C92 /* DequeModule in Frameworks */,
 				6CB94D032CA1205100E8651C /* AsyncAlgorithms in Frameworks */,
+				6C50EF3B2DFC83E4007FE626 /* CodeEditSourceEditor in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -317,6 +319,7 @@
 				6CB94D022CA1205100E8651C /* AsyncAlgorithms */,
 				6CC00A8A2CBEF150004E8134 /* CodeEditSourceEditor */,
 				6C73A6D22D4F1E550012D95C /* CodeEditSourceEditor */,
+				6C50EF3A2DFC83E4007FE626 /* CodeEditSourceEditor */,
 			);
 			productName = CodeEdit;
 			productReference = B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */;
@@ -419,7 +422,7 @@
 				303E88462C276FD600EEA8D9 /* XCRemoteSwiftPackageReference "LanguageServerProtocol" */,
 				6C4E37FA2C73E00700AEE7B5 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
 				6CB94D012CA1205100E8651C /* XCRemoteSwiftPackageReference "swift-async-algorithms" */,
-				6CF368562DBBD274006A77FD /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */,
+				6C50EF392DFC83E4007FE626 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */,
 			);
 			preferredProjectObjectVersion = 55;
 			productRefGroup = B658FB2D27DA9E0F00EA4DBD /* Products */;
@@ -1616,6 +1619,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		6C50EF392DFC83E4007FE626 /* XCLocalSwiftPackageReference "../CodeEditSourceEditor" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../CodeEditSourceEditor;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		2816F592280CF50500DD548B /* XCRemoteSwiftPackageReference "CodeEditSymbols" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1745,14 +1755,6 @@
 				version = 1.0.1;
 			};
 		};
-		6CF368562DBBD274006A77FD /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor";
-			requirement = {
-				kind = exactVersion;
-				version = 0.13.2;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1799,6 +1801,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6C4E37FA2C73E00700AEE7B5 /* XCRemoteSwiftPackageReference "SwiftTerm" */;
 			productName = SwiftTerm;
+		};
+		6C50EF3A2DFC83E4007FE626 /* CodeEditSourceEditor */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CodeEditSourceEditor;
 		};
 		6C66C31229D05CDC00DE9ED2 /* GRDB */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ac57a6899925c3e4ac6d43aed791c845c6fc24a4441b6a10297a207d951b7836",
+  "originHash" : "454498edc6f3f47f3616318caf54005bbbfd026d4f4355edda503b072bfe9814",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -29,15 +29,6 @@
       }
     },
     {
-      "identity" : "codeeditsourceeditor",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
-      "state" : {
-        "revision" : "30eb8a8cf3b291c91da04cfbc6683bee643b86a6",
-        "version" : "0.13.2"
-      }
-    },
-    {
       "identity" : "codeeditsymbols",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditSymbols",
@@ -51,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "69282e2ea7ad8976b062b945d575da47b61ed208",
-        "version" : "0.11.1"
+        "revision" : "c045ffcf4d8b2904e7bd138cdeccda99cba3ab3c",
+        "version" : "0.11.2"
       }
     },
     {
@@ -222,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
       "state" : {
-        "revision" : "3780efccceaa87f17ec39638a9d263d0e742b71c",
-        "version" : "0.59.1"
+        "revision" : "3825ebf8d55bb877c91bc897e8e3d0c001f16fba",
+        "version" : "0.58.2"
       }
     },
     {
@@ -239,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/SwiftTreeSitter.git",
       "state" : {
-        "revision" : "36aa61d1b531f744f35229f010efba9c6d6cbbdd",
-        "version" : "0.9.0"
+        "revision" : "08ef81eb8620617b55b08868126707ad72bf754f",
+        "version" : "0.25.0"
       }
     },
     {
@@ -275,8 +266,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tree-sitter/tree-sitter",
       "state" : {
-        "revision" : "d97db6d63507eb62c536bcb2c4ac7d70c8ec665e",
-        "version" : "0.23.2"
+        "revision" : "bf655c0beaf4943573543fa77c58e8006ff34971",
+        "version" : "0.25.6"
       }
     }
   ],

--- a/CodeEdit/Features/Editor/Views/CodeFileView.swift
+++ b/CodeEdit/Features/Editor/Views/CodeFileView.swift
@@ -54,6 +54,8 @@ struct CodeFileView: View {
     var reformatAtColumn
     @AppSettings(\.textEditing.showReformattingGuide)
     var showReformattingGuide
+    @AppSettings(\.textEditing.invisibleCharacters)
+    var invisibleCharactersConfig
 
     @Environment(\.colorScheme)
     private var colorScheme
@@ -141,7 +143,13 @@ struct CodeFileView: View {
             coordinators: textViewCoordinators,
             showMinimap: showMinimap,
             reformatAtColumn: reformatAtColumn,
-            showReformattingGuide: showReformattingGuide
+            showReformattingGuide: showReformattingGuide,
+            invisibleCharactersConfig: .init(
+                showSpaces: invisibleCharactersConfig.showSpaces,
+                showTabs: invisibleCharactersConfig.showTabs,
+                showLineEndings: invisibleCharactersConfig.showLineEndings,
+                warningCharacters: Set(invisibleCharactersConfig.warningCharacters.keys)
+            )
         )
         .id(codeFile.fileURL)
         .background {

--- a/CodeEdit/Features/Settings/Pages/DeveloperSettings/DeveloperSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/DeveloperSettings/DeveloperSettingsView.swift
@@ -34,7 +34,10 @@ struct DeveloperSettingsView: View {
                     Text(
                         "Specify the absolute path to your LSP binary and its associated language."
                     )
+                } actionBarTrailing: {
+                    EmptyView()
                 }
+                .frame(minHeight: 96)
             } header: {
                 Text("LSP Binaries")
                 Text("Specify the language and the absolute path to the language server binary.")

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/InvisiblesSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/InvisiblesSettingsView.swift
@@ -1,0 +1,60 @@
+//
+//  InvisiblesSettingsView.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 6/13/25.
+//
+
+import SwiftUI
+
+struct InvisiblesSettingsView: View {
+    @AppSettings(\.textEditing)
+    var textEditing
+
+    @Environment(\.dismiss)
+    private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                Form {
+                    Section {
+                        Toggle(isOn: $textEditing.invisibleCharacters.showSpaces) {
+                            Text("Show Spaces")
+                        }
+                        Toggle(isOn: $textEditing.invisibleCharacters.showTabs) {
+                            Text("Show Tabs")
+                        }
+                        Toggle(isOn: $textEditing.invisibleCharacters.showLineEndings) {
+                            Text("Show Line Endings")
+                        }
+                    }
+                    Section {
+                        InvisibleCharacterWarningList(items: $textEditing.invisibleCharacters.warningCharacters)
+                    } header: {
+                        Text("Warning Characters")
+                        Text(
+                            "CodeEdit can help identify invisible or ambiguous characters, such as zero-width spaces," +
+                            " directional quotes, and more. These will appear with a red block highlighting them." +
+                            "You can disable characters or add more here."
+                        )
+                    }
+                }
+                .formStyle(.grouped)
+                Divider()
+                HStack {
+                    Spacer()
+                    Button {
+                        dismiss()
+                    } label: {
+                        Text("Done")
+                            .frame(minWidth: 56)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+            }
+            .navigationTitle("Invisible Characters")
+        }
+    }
+}

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
@@ -31,6 +31,8 @@ extension SettingsData {
                 "Show Minimap",
                 "Reformat at Column",
                 "Show Reformatting Guide",
+                "Invisibles",
+                "Show whitespace",
             ]
             if #available(macOS 14.0, *) {
                 keys.append("System Cursor")
@@ -81,6 +83,8 @@ extension SettingsData {
 
         /// Show the reformatting guide in the editor
         var showReformattingGuide: Bool = false
+
+        var invisibleCharacters: InvisibleCharactersConfig = .default
 
         /// Default initializer
         init() {
@@ -136,6 +140,10 @@ extension SettingsData {
                 Bool.self,
                 forKey: .showReformattingGuide
             ) ?? false
+            self.invisibleCharacters = try container.decodeIfPresent(
+                InvisibleCharactersConfig.self,
+                forKey: .invisibleCharacters
+            ) ?? .default
 
             self.populateCommands()
         }
@@ -221,6 +229,39 @@ extension SettingsData {
                 case .large: return 0.75
                 }
             }
+        }
+
+        struct InvisibleCharactersConfig: Equatable, Hashable, Codable {
+            static var `default`: InvisibleCharactersConfig = {
+                InvisibleCharactersConfig(
+                    showSpaces: false,
+                    showTabs: false,
+                    showLineEndings: false,
+                    warningCharacters: [
+                        0x0003: "End of text",
+
+                        0x00A0: "Non-breaking space",
+                        0x202F: "Narrow non-breaking space",
+                        0x200B: "Zero-width space",
+                        0x200C: "Zero-width non-joiner",
+                        0x2029: "Paragraph separator",
+
+                        0x2013: "Em-dash",
+                        0x00AD: "Soft hyphen",
+
+                        0x2018: "Left single quote",
+                        0x2019: "Right single quote",
+                        0x201C: "Left double quote",
+                        0x201D: "Right double quote",
+                    ]
+                )
+            }()
+
+            var showSpaces: Bool
+            var showTabs: Bool
+            var showLineEndings: Bool
+            // Map of unicode character codes to a note about them
+            var warningCharacters: [UInt16: String]
         }
     }
 

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -12,6 +12,8 @@ struct TextEditingSettingsView: View {
     @AppSettings(\.textEditing)
     var textEditing
 
+    @State private var isShowingInvisibleCharacterSettings = false
+
     var body: some View {
         SettingsForm {
             Section {
@@ -36,6 +38,20 @@ struct TextEditingSettingsView: View {
             }
             Section {
                 bracketPairHighlight
+            }
+            Section {
+                HStack {
+                    Text("Invisible Characters")
+                    Spacer()
+                    _DisclosureIndicator()
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    isShowingInvisibleCharacterSettings = true
+                }
+                .sheet(isPresented: $isShowingInvisibleCharacterSettings) {
+                    InvisiblesSettingsView()
+                }
             }
         }
     }

--- a/CodeEdit/Features/Settings/Views/InvisibleCharacterWarningList.swift
+++ b/CodeEdit/Features/Settings/Views/InvisibleCharacterWarningList.swift
@@ -1,0 +1,66 @@
+//
+//  InvisibleCharacterWarningList.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 6/13/25.
+//
+
+import SwiftUI
+
+struct InvisibleCharacterWarningList: View {
+    @Binding var items: [UInt16: String]
+
+    @State private var selection: String?
+
+    var body: some View {
+        KeyValueTable(
+            items: Binding(
+                get: {
+                    items.reduce(into: [String: String]()) { dict, keyVal in
+                        let hex = String(keyVal.key, radix: 16).uppercased()
+                        let padding = String(repeating: "0", count: 4 - hex.count)
+                        dict["U+" + padding + hex] = keyVal.value
+                    }
+                },
+                set: { dict in
+                    items = dict.reduce(into: [UInt16: String]()) { dict, keyVal in
+                        guard let intFromHex = UInt(hexString: String(keyVal.key.trimmingPrefix("U+"))),
+                              intFromHex < UInt16.max else {
+                            return
+                        }
+                        let charCode = UInt16(intFromHex)
+                        dict[charCode] = keyVal.value
+                    }
+                }
+            ),
+            keyColumnName: "Unicode Character Code",
+            valueColumnName: "Notes",
+            newItemInstruction: "Add A Character As A Hexidecimal Unicode Value",
+            actionBarTrailing: {
+                Button {
+                    // Add defaults without removing user's data. We do still override notes here.
+                    items = items.merging(
+                        SettingsData.TextEditingSettings.InvisibleCharactersConfig.default.warningCharacters,
+                        uniquingKeysWith: { _, defaults in
+                            defaults
+                        }
+                    )
+                } label: {
+                    Text("Restore Defaults")
+                }
+                .buttonStyle(PlainButtonStyle())
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: true, vertical: false)
+                .padding(.trailing, 4)
+            }
+        )
+        .frame(minHeight: 96, maxHeight: .infinity)
+        .overlay {
+            if items.isEmpty {
+                Text("No warning characters")
+                    .foregroundStyle(Color(.secondaryLabelColor))
+            }
+        }
+    }
+}

--- a/CodeEdit/Utils/Extensions/Int/Int+HexString.swift
+++ b/CodeEdit/Utils/Extensions/Int/Int+HexString.swift
@@ -1,0 +1,28 @@
+//
+//  Int+HexString.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 6/13/25.
+//
+
+extension UInt {
+    init?(hexString: String) {
+        // Trim 0x if it's there
+        let string = String(hexString.trimmingPrefix("0x"))
+        guard let value = UInt(string, radix: 16) else {
+            return nil
+        }
+        self = value
+    }
+}
+
+extension Int {
+    init?(hexString: String) {
+        // Trim 0x if it's there
+        let string = String(hexString.trimmingPrefix("0x"))
+        guard let value = Int(string, radix: 16) else {
+            return nil
+        }
+        self = value
+    }
+}


### PR DESCRIPTION
### Description

Implements invisible character drawing in CodeEdit, including warning characters for ambiguous or invisible characters.

This is stored in a new submenu in the Text Editing settings page. I decided a pane like this was the best option, as a table cannot grow to fit it's contents or scroll when it's placed in some Forms (like our settings pages for some reason). The table also takes up a lot of space, so I felt it was a good use of a sheet.

### Related Issues

* closes https://github.com/CodeEditApp/CodeEditTextView/issues/22

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/5287c52b-4581-4296-8426-e6fb58beee3b
