### PR TITLE
Fix Split View Can't Collapse

### DIFF
--- a/CodeEdit/Features/SplitView/Views/SplitViewControllerView.swift
+++ b/CodeEdit/Features/SplitView/Views/SplitViewControllerView.swift
@@ -131,10 +131,6 @@ final class SplitViewController: NSSplitViewController {
         }
     }
 
-    override func splitView(_ splitView: NSSplitView, canCollapseSubview subview: NSView) -> Bool {
-        false
-    }
-
     override func splitView(_ splitView: NSSplitView, shouldHideDividerAt dividerIndex: Int) -> Bool {
         // For some reason, AppKit _really_ wants to hide dividers when there's only one item (and no dividers)
         // so we do this check for them.


### PR DESCRIPTION
### Description

Fixes an erroneous overridden method causing split views to not be collapsable.

### Related Issues

* closes #2070

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/12c3a5c2-bf70-4131-ad37-21adf5fa4e68

