### PR TITLE
Fix Autosave "changed by another application " Spam

### DIFF
--- a/CodeEdit/Features/Editor/Views/CodeFileView.swift
+++ b/CodeEdit/Features/Editor/Views/CodeFileView.swift
@@ -91,20 +91,6 @@ struct CodeFileView: View {
             }
             .store(in: &cancellables)
 
-        codeFile
-            .contentCoordinator
-            .textUpdatePublisher
-            .debounce(for: 1.0, scheduler: DispatchQueue.main)
-            .sink { _ in
-                // updateChangeCount is automatically managed by autosave(), so no manual call is necessary
-                codeFile.autosave(withImplicitCancellability: false) { error in
-                    if let error {
-                        CodeFileDocument.logger.error("Failed to autosave document, error: \(error)")
-                    }
-                }
-            }
-            .store(in: &cancellables)
-
         codeFile.undoManager = self.undoManager.manager
     }
 


### PR DESCRIPTION
### Description

Fixes an issue where a file save would not correctly update the `CodeFileDocument`'s metadata when saving. This caused scheduled autosave operations to fail with a false positive 'changed by another application' error.

To fix, I'm allowing `NSDocument` to handle the actual file system operation, rather than writing the data like we were before. I've kept the extra logic in the overridden `save` method to fix broken directories. There's no good reason to move the file saving operation out of `NSDocument`, since that subclass likely handles it better than we do with an atomic data write.

I've also moved autosave scheduling out of UI and into the document class.

### Related Issues

* closes #2033

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A