### PR TITLE
Update CESE (`0.14.0`), Add Gutter & Folding Settings

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -1784,7 +1784,7 @@
 			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor";
 			requirement = {
 				kind = exactVersion;
-				version = 0.13.2;
+				version = 0.14.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
       "state" : {
-        "revision" : "30eb8a8cf3b291c91da04cfbc6683bee643b86a6",
-        "version" : "0.13.2"
+        "revision" : "8a47aa4d3969a5e3bd372ce6c3d49ae3232883dd",
+        "version" : "0.14.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "69282e2ea7ad8976b062b945d575da47b61ed208",
-        "version" : "0.11.1"
+        "revision" : "d65c2a4b23a52f69d0b3a113124d7434c7af07fa",
+        "version" : "0.11.6"
       }
     },
     {

--- a/CodeEdit/Features/Editor/Views/CodeFileView.swift
+++ b/CodeEdit/Features/Editor/Views/CodeFileView.swift
@@ -16,8 +16,7 @@ import Combine
 struct CodeFileView: View {
     @ObservedObject private var codeFile: CodeFileDocument
 
-    /// The current cursor positions in the view
-    @State private var cursorPositions: [CursorPosition] = []
+    @State private var editorState: SourceEditorState
 
     @State private var treeSitterClient: TreeSitterClient = TreeSitterClient()
 
@@ -48,8 +47,12 @@ struct CodeFileView: View {
     var bracketEmphasis
     @AppSettings(\.textEditing.useSystemCursor)
     var useSystemCursor
+    @AppSettings(\.textEditing.showGutter)
+    var showGutter
     @AppSettings(\.textEditing.showMinimap)
     var showMinimap
+    @AppSettings(\.textEditing.showFoldingRibbon)
+    var showFoldingRibbon
     @AppSettings(\.textEditing.reformatAtColumn)
     var reformatAtColumn
     @AppSettings(\.textEditing.showReformattingGuide)
@@ -78,7 +81,9 @@ struct CodeFileView: View {
 
         if let openOptions = codeFile.openOptions {
             codeFile.openOptions = nil
-            self.cursorPositions = openOptions.cursorPositions
+            self.editorState = SourceEditorState(cursorPositions: openOptions.cursorPositions)
+        } else {
+            self.editorState = SourceEditorState()
         }
 
         updateHighlightProviders()
@@ -91,7 +96,7 @@ struct CodeFileView: View {
             }
             .store(in: &cancellables)
 
-        codeFile.undoManager = self.undoManager.manager
+        codeFile.undoManager = self.undoManager
     }
 
     private var currentTheme: Theme {
@@ -104,30 +109,44 @@ struct CodeFileView: View {
     private var edgeInsets
 
     var body: some View {
-        CodeEditSourceEditor(
+        SourceEditor(
             codeFile.content ?? NSTextStorage(),
             language: codeFile.getLanguage(),
-            theme: currentTheme.editor.editorTheme,
-            font: font,
-            tabWidth: codeFile.defaultTabWidth ?? defaultTabWidth,
-            indentOption: (codeFile.indentOption ?? indentOption).textViewOption(),
-            lineHeight: lineHeightMultiple,
-            wrapLines: codeFile.wrapLines ?? wrapLinesToEditorWidth,
-            editorOverscroll: overscroll.overscrollPercentage,
-            cursorPositions: $cursorPositions,
-            useThemeBackground: useThemeBackground,
+            configuration: SourceEditorConfiguration(
+                appearance: .init(
+                    theme: currentTheme.editor.editorTheme,
+                    useThemeBackground: useThemeBackground,
+                    font: font,
+                    lineHeightMultiple: lineHeightMultiple,
+                    letterSpacing: letterSpacing,
+                    wrapLines: wrapLinesToEditorWidth,
+                    useSystemCursor: useSystemCursor,
+                    tabWidth: defaultTabWidth,
+                    bracketPairEmphasis: getBracketPairEmphasis()
+                ),
+                behavior: .init(
+                    isEditable: isEditable,
+                    indentOption: indentOption.textViewOption(),
+                    reformatAtColumn: reformatAtColumn
+                ),
+                layout: .init(
+                    editorOverscroll: overscroll.overscrollPercentage,
+                    contentInsets: edgeInsets.nsEdgeInsets,
+                    additionalTextInsets: NSEdgeInsets(top: 2, left: 0, bottom: 0, right: 0)
+                ),
+                peripherals: .init(
+                    showGutter: showGutter,
+                    showMinimap: showMinimap,
+                    showReformattingGuide: showReformattingGuide,
+                    showFoldingRibbon: showFoldingRibbon,
+                    invisibleCharactersConfiguration: .empty,
+                    warningCharacters: []
+                )
+            ),
+            state: $editorState,
             highlightProviders: highlightProviders,
-            contentInsets: edgeInsets.nsEdgeInsets,
-            additionalTextInsets: NSEdgeInsets(top: 2, left: 0, bottom: 0, right: 0),
-            isEditable: isEditable,
-            letterSpacing: letterSpacing,
-            bracketPairEmphasis: getBracketPairEmphasis(),
-            useSystemCursor: useSystemCursor,
             undoManager: undoManager,
-            coordinators: textViewCoordinators,
-            showMinimap: showMinimap,
-            reformatAtColumn: reformatAtColumn,
-            showReformattingGuide: showReformattingGuide
+            coordinators: textViewCoordinators
         )
         .id(codeFile.fileURL)
         .background {

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/Models/TextEditingSettings.swift
@@ -28,6 +28,7 @@ extension SettingsData {
                 "Enable type-over completion",
                 "Bracket Pair Emphasis",
                 "Bracket Pair Highlight",
+                "Show Gutter",
                 "Show Minimap",
                 "Reformat at Column",
                 "Show Reformatting Guide",
@@ -73,8 +74,14 @@ extension SettingsData {
         /// Use the system cursor for the source editor.
         var useSystemCursor: Bool = true
 
+        /// Toggle the gutter in the editor.
+        var showGutter: Bool = true
+
         /// Toggle the minimap in the editor.
         var showMinimap: Bool = true
+
+        /// Toggle the code folding ribbon.
+        var showFoldingRibbon: Bool = true
 
         /// The column at which to reformat text
         var reformatAtColumn: Int = 80
@@ -130,7 +137,9 @@ extension SettingsData {
                 self.useSystemCursor = false
             }
 
+            self.showGutter = try container.decodeIfPresent(Bool.self, forKey: .showGutter) ?? true
             self.showMinimap = try container.decodeIfPresent(Bool.self, forKey: .showMinimap) ?? true
+            self.showFoldingRibbon = try container.decodeIfPresent(Bool.self, forKey: .showFoldingRibbon) ?? true
             self.reformatAtColumn = try container.decodeIfPresent(Int.self, forKey: .reformatAtColumn) ?? 80
             self.showReformattingGuide = try container.decodeIfPresent(
                 Bool.self,
@@ -171,12 +180,20 @@ extension SettingsData {
                 }
             )
 
-            mgr.addCommand(
-                name: "Toggle Minimap",
-                title: "Toggle Minimap",
-                id: "prefs.text_editing.toggle_minimap"
-            ) {
+            mgr.addCommand(name: "Toggle Minimap", title: "Toggle Minimap", id: "prefs.text_editing.toggle_minimap") {
                 Settings[\.textEditing].showMinimap.toggle()
+            }
+
+            mgr.addCommand(name: "Toggle Gutter", title: "Toggle Gutter", id: "prefs.text_editing.toggle_gutter") {
+                Settings[\.textEditing].showGutter.toggle()
+            }
+
+            mgr.addCommand(
+                name: "Toggle Folding Ribbon",
+                title: "Toggle Folding Ribbon",
+                id: "prefs.text_editing.toggle_folding_ribbon"
+            ) {
+                Settings[\.textEditing].showFoldingRibbon.toggle()
             }
         }
 

--- a/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
+++ b/CodeEdit/Features/Settings/Pages/TextEditingSettings/TextEditingSettingsView.swift
@@ -20,7 +20,11 @@ struct TextEditingSettingsView: View {
                 wrapLinesToEditorWidth
                 useSystemCursor
                 overscroll
+            }
+            Section {
+                showGutter
                 showMinimap
+                showFoldingRibbon
                 reformatSettings
             }
             Section {
@@ -202,13 +206,28 @@ private extension TextEditingSettingsView {
         }
     }
 
+    @ViewBuilder private var showGutter: some View {
+        Toggle("Show Gutter", isOn: $textEditing.showGutter)
+            .help("The gutter displays line numbers and code folding regions.")
+    }
+
     @ViewBuilder private var showMinimap: some View {
         Toggle("Show Minimap", isOn: $textEditing.showMinimap)
             // swiftlint:disable:next line_length
             .help("The minimap gives you a high-level summary of your source code, with controls to quickly navigate your document.")
     }
 
+    @ViewBuilder private var showFoldingRibbon: some View {
+        Toggle("Show Code Folding Ribbon", isOn: $textEditing.showFoldingRibbon)
+            .disabled(!textEditing.showGutter) // Disabled when the gutter is disabled
+            // swiftlint:disable:next line_length
+            .help("The code folding ribbon lets you fold regions of code. When the gutter is disabled, the folding ribbon is disabled.")
+    }
+
     @ViewBuilder private var reformatSettings: some View {
+        Toggle("Show Reformatting Guide", isOn: $textEditing.showReformattingGuide)
+            .help("Shows a vertical guide at the reformat column.")
+
         Stepper(
             "Reformat at Column",
             value: Binding<Double>(
@@ -219,9 +238,6 @@ private extension TextEditingSettingsView {
             step: 1,
             format: .number
         )
-        .help("The column at which text should be reformatted")
-
-        Toggle("Show Reformatting Guide", isOn: $textEditing.showReformattingGuide)
-            .help("Shows a vertical guide at the reformat column")
+        .help("The column at which text should be reformatted.")
     }
 }


### PR DESCRIPTION
### Description

Updates CodeEditSourceEditor to `0.14.0`, and subsequently CodeEditTextView to `0.11.6`. Adds two new settings: 
- Show Gutter - toggles the visibility of the entire gutter in the editor.
- Show Code Folding Ribbon - toggles the visibility of the folding ribbon.

### Related Issues

* should fix #2073 
* nearly closes #1020, that issue needs slightly more granularity in the setting to close.

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/8ebee47b-ad74-402b-b7c7-cdfc18bb4f6d
