### PR TITLE
Ensure LSPs Exit, Add Exit Activities

### DIFF
--- a/CodeEdit/Features/ActivityViewer/Notifications/TaskNotificationHandler.swift
+++ b/CodeEdit/Features/ActivityViewer/Notifications/TaskNotificationHandler.swift
@@ -170,7 +170,7 @@ final class TaskNotificationHandler: ObservableObject {
               let actionRaw = userInfo["action"] as? String,
               let action = Action(rawValue: actionRaw) else { return }
 
-        /// If a workspace is specified, don't do anything with this task.
+        // If a workspace is specified and doesn't match, don't do anything with this task.
         if let workspaceURL = userInfo["workspace"] as? URL, workspaceURL != self.workspaceURL {
             return
         }

--- a/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument.swift
@@ -161,6 +161,7 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
                 workspaceURL: url
             )
         }
+        self.taskNotificationHandler.workspaceURL = url
 
         editorManager?.restoreFromState(self)
         utilityAreaModel?.restoreFromState(self)

--- a/CodeEdit/Features/LSP/LanguageServer/DataChannel+localProcess.swift
+++ b/CodeEdit/Features/LSP/LanguageServer/DataChannel+localProcess.swift
@@ -1,0 +1,69 @@
+//
+//  DataChannel+localProcess.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 7/8/25.
+//
+
+import Foundation
+import LanguageServerProtocol
+import JSONRPC
+import ProcessEnv
+
+// This is almost exactly the same as the extension provided by `LanguageServerProtocol`, except it returns the
+// process ID as well as the channel, which we need.
+
+extension DataChannel {
+	@available(macOS 12.0, *)
+	public static func localProcessChannel(
+		parameters: Process.ExecutionParameters,
+		terminationHandler: @escaping @Sendable () -> Void
+    ) throws -> (pid: pid_t, channel: DataChannel) {
+		let process = Process()
+
+		let stdinPipe = Pipe()
+		let stdoutPipe = Pipe()
+		let stderrPipe = Pipe()
+
+		process.standardInput = stdinPipe
+		process.standardOutput = stdoutPipe
+		process.standardError = stderrPipe
+
+		process.parameters = parameters
+
+		let (stream, continuation) = DataSequence.makeStream()
+
+		process.terminationHandler = { _ in
+			continuation.finish()
+			terminationHandler()
+		}
+
+		Task {
+			let dataStream = stdoutPipe.fileHandleForReading.dataStream
+
+			for try await data in dataStream {
+				continuation.yield(data)
+			}
+
+			continuation.finish()
+		}
+
+		Task {
+			for try await line in stderrPipe.fileHandleForReading.bytes.lines {
+				print("stderr: ", line)
+			}
+		}
+
+		try process.run()
+
+		let handler: DataChannel.WriteHandler = {
+			// this is wacky, but we need the channel to hold a strong reference to the process
+			// to prevent it from being deallocated
+			_ = process
+
+			try stdinPipe.fileHandleForWriting.write(contentsOf: $0)
+		}
+
+        return (process.processIdentifier, DataChannel(writeHandler: handler, dataSequence: stream))
+	}
+}

--- a/CodeEdit/Utils/withTimeout.swift
+++ b/CodeEdit/Utils/withTimeout.swift
@@ -1,0 +1,46 @@
+//
+//  TimedOutError.swift
+//  CodeEdit
+//
+//  Created by Khan Winter on 7/8/25.
+//
+
+struct TimedOutError: Error, Equatable {}
+
+/// Execute an operation in the current task subject to a timeout.
+/// - Warning: This still requires cooperative task cancellation to work correctly. Ensure tasks opt
+///            into cooperative cancellation.
+/// - Parameters:
+///   - duration: The duration to wait until timing out. Uses a continuous clock.
+///   - operation: The async operation to perform.
+/// - Returns: Returns the result of `operation` if it completed in time.
+/// - Throws: Throws ``TimedOutError`` if the timeout expires before `operation` completes.
+///   If `operation` throws an error before the timeout expires, that error is propagated to the caller.
+public func withTimeout<R>(
+    duration: Duration,
+    onTimeout: @escaping @Sendable () async throws -> Void = { },
+    operation: @escaping @Sendable () async throws -> R
+) async throws -> R {
+    return try await withThrowingTaskGroup(of: R.self) { group in
+        let deadline: ContinuousClock.Instant = .now + duration
+
+        // Start actual work.
+        group.addTask {
+            return try await operation()
+        }
+        // Start timeout child task.
+        group.addTask {
+            if .now > deadline {
+                try await Task.sleep(until: deadline) // sleep until the deadline
+            }
+            try Task.checkCancellation()
+            // We’ve reached the timeout.
+            try await onTimeout()
+            throw TimedOutError()
+        }
+        // First finished child task wins, cancel the other task.
+        let result = try await group.next()!
+        group.cancelAll()
+        return result
+    }
+}


### PR DESCRIPTION
### Description

LSPs may refuse to exit (due to a bug or whatnot) but we need to ensure that CodeEdit can still close when quit. This adds both a timeout when language servers are stopped, and a method to send `SIGKILL` to language servers if necessary.

This can only cause a delay while quitting CodeEdit. To help with the UX here, I've added some activity notifications that tell the user why we're delaying quitting CodeEdit. Both task termination and language server stopping are displayed while CodeEdit attempts to quit.

#### Detailed Changes
- Added a helper to `DataChannel` from the language server package to obtain the process ID when starting a language server.
  - The `pid_t` of the process is stored on `LanguageServer` for future use.
- Updated `LSPService.stopServer` to not use a throwing task group. For some reason the task group refused to continue even if the language server did close correctly. A non-throwing task group works correctly.
- Added `LSPService.killAllServers` to send `SIGKILL` to all language servers if necessary.
- Updated `AppDelegate` to send activity notifications when delaying quitting the app.
- Updated `AppDelegate` to timeout language server stopping and kill them if necessary.
- Added a little helper to `TaskNotificationHandler` to help with sending tasks. Updated docs to match.
- Added a new parameter to `TaskNotificationHandler` to limit activities to a single workspace. If left out, does not limit the workspace.
  - Because of the new workspace parameter, I quickly limited tasks to only notify their workspaces.
  - I also added a second ID to `CEActiveTask` to differentiate between task runs (see screen recording).

### Related Issues

* related #1976

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Before change. Tasks show up in all workspaces, cancelled tasks remove new task activities.

https://github.com/user-attachments/assets/7a4f390d-5918-450c-afc7-ec164d7bb1e3

After the change. Active tasks have their own ID and cancelled tasks don't remove new task activities.

https://github.com/user-attachments/assets/5502f0b6-b34c-4c24-9ae4-f6eab3fc7100

