### PR TITLE
Add `⌘R` and `⌘.` to Start and Stop Tasks, Add Tasks Menu

### DIFF
--- a/CodeEdit/Features/Tasks/TaskManager.swift
+++ b/CodeEdit/Features/Tasks/TaskManager.swift
@@ -93,7 +93,7 @@ class TaskManager: ObservableObject {
         }
     }
 
-    func terminateSelectedTask() {
+    func terminateActiveTask() {
         guard let taskID = selectedTaskID else {
             return
         }

--- a/CodeEdit/Features/Tasks/Views/StopTaskToolbarButton.swift
+++ b/CodeEdit/Features/Tasks/Views/StopTaskToolbarButton.swift
@@ -24,7 +24,7 @@ struct StopTaskToolbarButton: View {
         HStack {
             if let currentSelectedStatus, currentSelectedStatus == .running {
                     Button {
-                        taskManager.terminateSelectedTask()
+                        taskManager.terminateActiveTask()
                     } label: {
                         Label("Stop", systemImage: "stop.fill")
                             .labelStyle(.iconOnly)

--- a/CodeEditTests/Features/Tasks/TaskManagerTests.swift
+++ b/CodeEditTests/Features/Tasks/TaskManagerTests.swift
@@ -59,7 +59,7 @@ final class TaskManagerTests: XCTestCase {
         let testExpectation1 = XCTestExpectation()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             XCTAssertEqual(self.taskManager.taskStatus(taskID: task.id), .running)
-            self.taskManager.terminateSelectedTask()
+            self.taskManager.terminateActiveTask()
             testExpectation1.fulfill()
         }
 


### PR DESCRIPTION
### Description

- Adds two key commands - Command R and Command . to start and stop tasks.
- Adds a new Tasks menu item. Subitems:
  - Run {Selected Task}
    - Runs the selected task, disabled when no selected task.
  - Stop {Selected Task}
    - Stops the selected task, disabled when no task is running.
  - Show {Selected Task} Output
    - Navigates to the selected task output - this could maybe? be in the Navigate menu. *Looking for feedback here.*
  - Chose Task...
    - Submenu is a list of the user's tasks. Selects a task. If the user has no tasks, has a single "Create Task" item.
  - Manage Tasks
    - Opens the workspace's task settings.

### Related Issues

* Thought there was an open issue but there isn't, whoops.

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Demo with running a task, stopping it, navigating to it's output.

> Note that there's a few bugs in this demo that are fixed by #2080. Such as overlapping task status and task activities appearing in all workspaces.

https://github.com/user-attachments/assets/602dedf2-3626-4ea1-a04b-9d7a9945a458
