### PR TITLE
Adjust LSP Content Object Lifecycle

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -1783,7 +1783,7 @@
 			repositoryURL = "https://github.com/CodeEditApp/CodeEditSourceEditor";
 			requirement = {
 				kind = exactVersion;
-				version = 0.14.1;
+				version = 0.15.0;
 			};
 		};
 		6C85BB3E2C2105ED00EB5DEF /* XCRemoteSwiftPackageReference "CodeEditKit" */ = {

--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ed7a5ce46da2e530a4b8ff23058a67ef7423fa2378b9588d66359f210b6365cb",
+  "originHash" : "01191ca9685501db65981a6fd21ab2d11c32196633d4cb776b5bb25908ed212f",
   "pins" : [
     {
       "identity" : "aboutwindow",
@@ -40,10 +40,10 @@
     {
       "identity" : "codeeditsourceeditor",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor.git",
+      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
       "state" : {
-        "revision" : "afc57523b05c209496a221655c2171c0624b51d3",
-        "version" : "0.14.1"
+        "revision" : "c0d2c90aecca04ce2be2ff29c39a3add5951b539",
+        "version" : "0.15.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
       "state" : {
-        "revision" : "d65c2a4b23a52f69d0b3a113124d7434c7af07fa",
-        "version" : "0.11.6"
+        "revision" : "d7ac3f11f22ec2e820187acce8f3a3fb7aa8ddec",
+        "version" : "0.12.1"
       }
     },
     {
@@ -290,21 +290,21 @@
       }
     },
     {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation",
-      "state" : {
-        "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
-        "version" : "0.9.19"
-      }
-    },
-    {
       "identity" : "welcomewindow",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/WelcomeWindow",
       "state" : {
         "revision" : "5168cf1ce9579b35ad00706fafef441418d8011f",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation",
+      "state" : {
+        "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
+        "version" : "0.9.19"
       }
     }
   ],

--- a/CodeEdit/Features/Editor/Views/CodeFileView.swift
+++ b/CodeEdit/Features/Editor/Views/CodeFileView.swift
@@ -21,8 +21,7 @@ struct CodeFileView: View {
 
     /// Any coordinators passed to the view.
     private var textViewCoordinators: [TextViewCoordinator]
-
-    @State private var highlightProviders: [any HighlightProviding] = []
+    private var highlightProviders: [any HighlightProviding] = []
 
     @AppSettings(\.textEditing.defaultTabWidth)
     var defaultTabWidth
@@ -86,7 +85,7 @@ struct CodeFileView: View {
         self.textViewCoordinators = textViewCoordinators
             + [editorInstance.rangeTranslator]
             + [codeFile.contentCoordinator]
-            + [codeFile.languageServerObjects.textCoordinator].compactMap({ $0 })
+            + [codeFile.languageServerObjects.textCoordinator]
         self.isEditable = isEditable
 
         if let openOptions = codeFile.openOptions {
@@ -94,7 +93,7 @@ struct CodeFileView: View {
             editorInstance.cursorPositions = openOptions.cursorPositions
         }
 
-        updateHighlightProviders()
+        highlightProviders = [codeFile.languageServerObjects.highlightProvider] + [treeSitterClient]
 
         codeFile
             .contentCoordinator
@@ -186,10 +185,6 @@ struct CodeFileView: View {
         .onChange(of: settingsFont) { newFontSetting in
             font = newFontSetting.current
         }
-        .onReceive(codeFile.$languageServerObjects) { languageServerObjects in
-            // This will not be called in single-file views (for now) but is safe to listen to either way
-            updateHighlightProviders(lspHighlightProvider: languageServerObjects.highlightProvider)
-        }
     }
 
     /// Determines the style of bracket emphasis based on the `bracketEmphasis` setting and the current theme.
@@ -211,12 +206,6 @@ struct CodeFileView: View {
         case .underline:
             return .underline(color: color)
         }
-    }
-
-    /// Updates the highlight providers array.
-    /// - Parameter lspHighlightProvider: The language server provider, if available.
-    private func updateHighlightProviders(lspHighlightProvider: HighlightProviding? = nil) {
-        highlightProviders = [lspHighlightProvider].compactMap({ $0 }) + [treeSitterClient]
     }
 }
 

--- a/CodeEdit/Features/LSP/Features/DocumentSync/LSPContentCoordinator.swift
+++ b/CodeEdit/Features/LSP/Features/DocumentSync/LSPContentCoordinator.swift
@@ -47,7 +47,6 @@ class LSPContentCoordinator<DocumentType: LanguageServerDocument>: TextViewCoord
         documentURI = document.languageServerURI
     }
 
-
     func setUpUpdatesTask() {
         task?.cancel()
         // Create this stream here so it's always set up when the text view is set up, rather than only once on init.

--- a/CodeEdit/Features/LSP/Features/DocumentSync/LSPContentCoordinator.swift
+++ b/CodeEdit/Features/LSP/Features/DocumentSync/LSPContentCoordinator.swift
@@ -32,15 +32,21 @@ class LSPContentCoordinator<DocumentType: LanguageServerDocument>: TextViewCoord
     private var task: Task<Void, Never>?
 
     weak var languageServer: LanguageServer<DocumentType>?
-    var documentURI: String
+    var documentURI: String?
 
     /// Initializes a content coordinator, and begins an async stream of updates
-    init(documentURI: String, languageServer: LanguageServer<DocumentType>) {
+    init(documentURI: String? = nil, languageServer: LanguageServer<DocumentType>? = nil) {
         self.documentURI = documentURI
         self.languageServer = languageServer
 
         setUpUpdatesTask()
     }
+
+    func setUp(server: LanguageServer<DocumentType>, document: DocumentType) {
+        languageServer = server
+        documentURI = document.languageServerURI
+    }
+
 
     func setUpUpdatesTask() {
         task?.cancel()
@@ -76,7 +82,7 @@ class LSPContentCoordinator<DocumentType: LanguageServerDocument>: TextViewCoord
     }
 
     func textView(_ textView: TextView, didReplaceContentsIn range: NSRange, with string: String) {
-        guard let lspRange = editedRange else {
+        guard let lspRange = editedRange, let documentURI else {
             return
         }
         self.editedRange = nil

--- a/CodeEdit/Features/LSP/Features/SemanticTokens/SemanticTokenHighlightProvider.swift
+++ b/CodeEdit/Features/LSP/Features/SemanticTokens/SemanticTokenHighlightProvider.swift
@@ -34,7 +34,7 @@ final class SemanticTokenHighlightProvider<
 
     private var tokenMap: SemanticTokenMap?
     private var documentURI: String?
-    private weak var languageServer: LanguageServer<DocumentType>?
+    weak var languageServer: LanguageServer<DocumentType>?
     private weak var textView: TextView?
 
     private var lastEditCallback: EditCallback?

--- a/CodeEdit/Features/LSP/Features/SemanticTokens/SemanticTokenHighlightProvider.swift
+++ b/CodeEdit/Features/LSP/Features/SemanticTokens/SemanticTokenHighlightProvider.swift
@@ -32,8 +32,8 @@ final class SemanticTokenHighlightProvider<
     typealias EditCallback = @MainActor (Result<IndexSet, any Error>) -> Void
     typealias HighlightCallback = @MainActor (Result<[HighlightRange], any Error>) -> Void
 
-    private let tokenMap: SemanticTokenMap
-    private let documentURI: String
+    private var tokenMap: SemanticTokenMap?
+    private var documentURI: String?
     private weak var languageServer: LanguageServer<DocumentType>?
     private weak var textView: TextView?
 
@@ -45,11 +45,21 @@ final class SemanticTokenHighlightProvider<
         textView?.documentRange ?? .zero
     }
 
-    init(tokenMap: SemanticTokenMap, languageServer: LanguageServer<DocumentType>, documentURI: String) {
+    init(
+        tokenMap: SemanticTokenMap? = nil,
+        languageServer: LanguageServer<DocumentType>? = nil,
+        documentURI: String? = nil
+    ) {
         self.tokenMap = tokenMap
         self.languageServer = languageServer
         self.documentURI = documentURI
         self.storage = Storage()
+    }
+
+    func setUp(server: LanguageServer<DocumentType>, document: DocumentType) {
+        languageServer = server
+        documentURI = document.languageServerURI
+        tokenMap = server.highlightMap
     }
 
     // MARK: - Language Server Content Lifecycle
@@ -95,7 +105,8 @@ final class SemanticTokenHighlightProvider<
         textView: TextView,
         lastResultId: String
     ) async throws {
-        guard let response = try await languageServer.requestSemanticTokens(
+        guard let documentURI,
+              let response = try await languageServer.requestSemanticTokens(
             for: documentURI,
             previousResultId: lastResultId
         ) else {
@@ -112,7 +123,7 @@ final class SemanticTokenHighlightProvider<
     /// Requests and applies tokens for an entire document. This does not require a previous response id, and should be
     /// used in place of `requestDeltaTokens` when that's the case.
     private func requestTokens(languageServer: LanguageServer<DocumentType>, textView: TextView) async throws {
-        guard let response = try await languageServer.requestSemanticTokens(for: documentURI) else {
+        guard let documentURI, let response = try await languageServer.requestSemanticTokens(for: documentURI) else {
             return
         }
         await applyEntireResponse(response, callback: lastEditCallback)
@@ -159,7 +170,7 @@ final class SemanticTokenHighlightProvider<
             return
         }
 
-        guard let lspRange = textView.lspRangeFrom(nsRange: range) else {
+        guard let lspRange = textView.lspRangeFrom(nsRange: range), let tokenMap else {
             completion(.failure(HighlightError.lspRangeFailure))
             return
         }

--- a/CodeEdit/Features/LSP/LanguageServer/Capabilities/LanguageServer+DocumentSync.swift
+++ b/CodeEdit/Features/LSP/LanguageServer/Capabilities/LanguageServer+DocumentSync.swift
@@ -86,6 +86,7 @@ extension LanguageServer {
             switch resolveDocumentSyncKind() {
             case .full:
                 guard let content = await getIsolatedDocumentContent(document) else {
+                    logger.error("Failed to get isolated document content")
                     return
                 }
                 let changeEvent = TextDocumentContentChangeEvent(range: nil, rangeLength: nil, text: content.string)
@@ -107,7 +108,7 @@ extension LanguageServer {
 
             // Let the semantic token provider know about the update.
             // Note for future: If a related LSP object need notifying about document changes, do it here.
-            try await document.languageServerObjects.highlightProvider?.documentDidChange()
+            try await document.languageServerObjects.highlightProvider.documentDidChange()
         } catch {
             logger.warning("closeDocument: Error \(error)")
             throw error
@@ -128,10 +129,7 @@ extension LanguageServer {
 
     @MainActor
     private func updateIsolatedDocument(_ document: DocumentType) {
-        document.languageServerObjects = LanguageServerDocumentObjects(
-            textCoordinator: openFiles.contentCoordinator(for: document),
-            highlightProvider: openFiles.semanticHighlighter(for: document)
-        )
+        document.languageServerObjects.setUp(server: self, document: document)
     }
 
     @MainActor

--- a/CodeEdit/Features/LSP/LanguageServer/LanguageServer.swift
+++ b/CodeEdit/Features/LSP/LanguageServer/LanguageServer.swift
@@ -51,7 +51,8 @@ class LanguageServer<DocumentType: LanguageServerDocument> {
         lspInstance: InitializingServer,
         lspPid: pid_t,
         serverCapabilities: ServerCapabilities,
-        rootPath: URL
+        rootPath: URL,
+        logContainer: LanguageServerLogContainer
     ) {
         self.languageId = languageId
         self.binary = binary
@@ -60,7 +61,7 @@ class LanguageServer<DocumentType: LanguageServerDocument> {
         self.serverCapabilities = serverCapabilities
         self.rootPath = rootPath
         self.openFiles = LanguageServerFileMap()
-        self.logContainer = LanguageServerLogContainer(language: languageId)
+        self.logContainer = logContainer
         self.logger = Logger(
             subsystem: Bundle.main.bundleIdentifier ?? "",
             category: "LanguageServer.\(languageId.rawValue)"
@@ -89,9 +90,11 @@ class LanguageServer<DocumentType: LanguageServerDocument> {
             environment: binary.env
         )
 
+        let logContainer = LanguageServerLogContainer(language: languageId)
         let (connection, process) = try makeLocalServerConnection(
             languageId: languageId,
-            executionParams: executionParams
+            executionParams: executionParams,
+            logContainer: logContainer
         )
         let server = InitializingServer(
             server: connection,
@@ -105,7 +108,8 @@ class LanguageServer<DocumentType: LanguageServerDocument> {
             lspInstance: server,
             lspPid: process.processIdentifier,
             serverCapabilities: initializationResponse.capabilities,
-            rootPath: URL(filePath: workspacePath)
+            rootPath: URL(filePath: workspacePath),
+            logContainer: logContainer
         )
     }
 
@@ -118,13 +122,17 @@ class LanguageServer<DocumentType: LanguageServerDocument> {
     /// - Returns: A new connection to the language server.
     static func makeLocalServerConnection(
         languageId: LanguageIdentifier,
-        executionParams: Process.ExecutionParameters
+        executionParams: Process.ExecutionParameters,
+        logContainer: LanguageServerLogContainer
     ) throws -> (connection: JSONRPCServerConnection, process: Process) {
         do {
             let (channel, process) = try DataChannel.localProcessChannel(
                 parameters: executionParams,
-                terminationHandler: {
+                terminationHandler: { [weak logContainer] in
                     logger.debug("Terminated data channel for \(languageId.rawValue)")
+                    logContainer?.appendLog(
+                        LogMessageParams(type: .error, message: "Data Channel Terminated Unexpectedly")
+                    )
                 }
             )
             return (JSONRPCServerConnection(dataChannel: channel), process)

--- a/CodeEdit/Features/LSP/LanguageServer/LanguageServerFileMap.swift
+++ b/CodeEdit/Features/LSP/LanguageServer/LanguageServerFileMap.swift
@@ -16,8 +16,6 @@ class LanguageServerFileMap<DocumentType: LanguageServerDocument> {
     private struct DocumentObject {
         let uri: String
         var documentVersion: Int
-        var contentCoordinator: LSPContentCoordinator<DocumentType>
-        var semanticHighlighter: HighlightProviderType?
     }
 
     private var trackedDocuments: NSMapTable<NSString, DocumentType>
@@ -32,24 +30,7 @@ class LanguageServerFileMap<DocumentType: LanguageServerDocument> {
     func addDocument(_ document: DocumentType, for server: LanguageServer<DocumentType>) {
         guard let uri = document.languageServerURI else { return }
         trackedDocuments.setObject(document, forKey: uri as NSString)
-        var docData = DocumentObject(
-            uri: uri,
-            documentVersion: 0,
-            contentCoordinator: LSPContentCoordinator(
-                documentURI: uri,
-                languageServer: server
-            ),
-            semanticHighlighter: nil
-        )
-
-        if let tokenMap = server.highlightMap {
-            docData.semanticHighlighter = HighlightProviderType(
-                tokenMap: tokenMap,
-                languageServer: server,
-                documentURI: uri
-            )
-        }
-
+        let docData = DocumentObject(uri: uri, documentVersion: 0)
         trackedDocumentData[uri] = docData
     }
 
@@ -86,23 +67,5 @@ class LanguageServerFileMap<DocumentType: LanguageServerDocument> {
 
     func documentVersion(for uri: DocumentUri) -> Int? {
         return trackedDocumentData[uri]?.documentVersion
-    }
-
-    // MARK: - Content Coordinator
-
-    func contentCoordinator(for document: DocumentType) -> LSPContentCoordinator<DocumentType>? {
-        guard let uri = document.languageServerURI else { return nil }
-        return contentCoordinator(for: uri)
-    }
-
-    func contentCoordinator(for uri: DocumentUri) -> LSPContentCoordinator<DocumentType>? {
-        trackedDocumentData[uri]?.contentCoordinator
-    }
-
-    // MARK: - Semantic Highlighter
-
-    func semanticHighlighter(for document: DocumentType) -> HighlightProviderType? {
-        guard let uri = document.languageServerURI else { return nil }
-        return trackedDocumentData[uri]?.semanticHighlighter
     }
 }

--- a/CodeEdit/Features/LSP/LanguageServerDocument.swift
+++ b/CodeEdit/Features/LSP/LanguageServerDocument.swift
@@ -10,8 +10,15 @@ import CodeEditLanguages
 
 /// A set of properties a language server sets when a document is registered.
 struct LanguageServerDocumentObjects<DocumentType: LanguageServerDocument> {
-    var textCoordinator: LSPContentCoordinator<DocumentType>?
-    var highlightProvider: SemanticTokenHighlightProvider<SemanticTokenStorage, DocumentType>?
+    var textCoordinator: LSPContentCoordinator<DocumentType> = LSPContentCoordinator()
+    // swiftlint:disable:next line_length
+    var highlightProvider: SemanticTokenHighlightProvider<SemanticTokenStorage, DocumentType> = SemanticTokenHighlightProvider()
+
+    @MainActor
+    func setUp(server: LanguageServer<DocumentType>, document: DocumentType) {
+        textCoordinator.setUp(server: server, document: document)
+        highlightProvider.setUp(server: server, document: document)
+    }
 }
 
 /// A protocol that allows a language server to register objects on a text document.

--- a/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorPositionLabel.swift
+++ b/CodeEdit/Features/StatusBar/Views/StatusBarItems/StatusBarCursorPositionLabel.swift
@@ -115,7 +115,7 @@ struct StatusBarCursorPositionLabel: View {
             }
 
             // When there's a single cursor, display the line and column.
-            return "Line: \(cursorPositions[0].line)  Col: \(cursorPositions[0].column)"
+            return "Line: \(cursorPositions[0].start.line)  Col: \(cursorPositions[0].start.column)"
         }
     }
 }

--- a/CodeEditTests/Features/LSP/LanguageServer+CodeFileDocument.swift
+++ b/CodeEditTests/Features/LSP/LanguageServer+CodeFileDocument.swift
@@ -71,7 +71,8 @@ final class LanguageServerCodeFileDocumentTests: XCTestCase {
             ),
             lspPid: -1,
             serverCapabilities: capabilities,
-            rootPath: tempTestDir
+            rootPath: tempTestDir,
+            logContainer: LanguageServerLogContainer(language: .swift)
         )
         _ = try await server.lspInstance.initializeIfNeeded()
         return (connection: bufferingConnection, server: server)
@@ -231,13 +232,13 @@ final class LanguageServerCodeFileDocumentTests: XCTestCase {
             let (connection, server) = try await makeTestServer()
             // Create a CodeFileDocument to test with, attach it to the workspace and file
             let codeFile = try await openCodeFile(for: server, connection: connection, file: file, syncOption: option)
-            XCTAssertNotNil(server.openFiles.contentCoordinator(for: codeFile))
-            server.openFiles.contentCoordinator(for: codeFile)?.setUpUpdatesTask()
+            XCTAssertNotNil(codeFile.languageServerObjects.textCoordinator.languageServer)
+            codeFile.languageServerObjects.textCoordinator.setUpUpdatesTask()
             codeFile.content?.replaceString(in: .zero, with: #"func testFunction() -> String { "Hello " }"#)
 
             let textView = TextView(string: "")
             textView.setTextStorage(codeFile.content!)
-            textView.delegate = server.openFiles.contentCoordinator(for: codeFile)
+            textView.delegate = codeFile.languageServerObjects.textCoordinator
 
             textView.replaceCharacters(in: NSRange(location: 39, length: 0), with: "Worlld")
             textView.replaceCharacters(in: NSRange(location: 39, length: 6), with: "")
@@ -289,13 +290,13 @@ final class LanguageServerCodeFileDocumentTests: XCTestCase {
             let (connection, server) = try await makeTestServer()
             let codeFile = try await openCodeFile(for: server, connection: connection, file: file, syncOption: option)
 
-            XCTAssertNotNil(server.openFiles.contentCoordinator(for: codeFile))
-            server.openFiles.contentCoordinator(for: codeFile)?.setUpUpdatesTask()
+            XCTAssertNotNil(codeFile.languageServerObjects.textCoordinator.languageServer)
+            codeFile.languageServerObjects.textCoordinator.setUpUpdatesTask()
             codeFile.content?.replaceString(in: .zero, with: #"func testFunction() -> String { "Hello " }"#)
 
             let textView = TextView(string: "")
             textView.setTextStorage(codeFile.content!)
-            textView.delegate = server.openFiles.contentCoordinator(for: codeFile)
+            textView.delegate =  codeFile.languageServerObjects.textCoordinator
             textView.replaceCharacters(in: NSRange(location: 39, length: 0), with: "Worlld")
             textView.replaceCharacters(in: NSRange(location: 39, length: 6), with: "")
             textView.replaceCharacters(in: NSRange(location: 39, length: 0), with: "World")

--- a/CodeEditTests/Features/LSP/LanguageServer+DocumentObjects.swift
+++ b/CodeEditTests/Features/LSP/LanguageServer+DocumentObjects.swift
@@ -51,7 +51,8 @@ final class LanguageServerDocumentObjectsTests: XCTestCase {
             ),
             lspPid: -1,
             serverCapabilities: capabilities,
-            rootPath: URL(fileURLWithPath: "")
+            rootPath: URL(fileURLWithPath: ""),
+            logContainer: LanguageServerLogContainer(language: .swift)
         )
         _ = try await server.lspInstance.initializeIfNeeded()
         document = MockDocumentType()
@@ -75,7 +76,7 @@ final class LanguageServerDocumentObjectsTests: XCTestCase {
         XCTAssertNotNil(server.openFiles.document(for: languageServerURI))
 
         try await server.closeDocument(languageServerURI)
-        XCTAssertNil(document.languageServerObjects.highlightProvider)
-        XCTAssertNil(document.languageServerObjects.textCoordinator)
+        XCTAssertNil(document.languageServerObjects.highlightProvider.languageServer)
+        XCTAssertNil(document.languageServerObjects.textCoordinator.languageServer)
     }
 }


### PR DESCRIPTION
### Description

Adjusts how LSP content objects are created and updated. CESE works best when coordinators and highlighters are static for the lifetime of the editor. This adjusts both the content coordinator and semantic highlighter objects to have optional document URIs and server references. That makes it so these objects will be passed into the editor immediately, and will just ignore requests or notifications until the language server tells the object about itself.

The change fixes a bug where an editor opened that triggers a language server startup would not have a working semantic highlighter or update its contents with the server when the document was updated. This fixes that race condition.

This also makes a small change to language server initialization, this creates the log container before the server and injects it  into the data channel so if the channel terminates the log container can receive a message.

### Related Issues

* N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A