### PR TITLE
Utility area animation disabled with hide interface

### DIFF
--- a/CodeEdit/Features/Documents/Controllers/CodeEditWindowController+Panels.swift
+++ b/CodeEdit/Features/Documents/Controllers/CodeEditWindowController+Panels.swift
@@ -82,7 +82,7 @@ extension CodeEditWindowController {
                 isCollapsed: { self.workspace?.utilityAreaModel?.isCollapsed ?? true },
                 getPrevCollapsed: { self.prevUtilityAreaCollapsed },
                 setPrevCollapsed: { self.prevUtilityAreaCollapsed = $0 },
-                toggle: { CommandManager.shared.executeCommand("open.drawer") }
+                toggle: { self.workspace?.utilityAreaModel?.togglePanel(animation: false) }
             ),
             PanelDescriptor(
                 isCollapsed: { self.toolbarCollapsed },

--- a/CodeEdit/Features/WindowCommands/ViewCommands.swift
+++ b/CodeEdit/Features/WindowCommands/ViewCommands.swift
@@ -149,7 +149,7 @@ extension ViewCommands {
                 windowController?.toggleInterface(shouldHide: !isInterfaceHidden)
             }
             .disabled(windowController == nil)
-            .keyboardShortcut(".", modifiers: .command)
+            .keyboardShortcut("H", modifiers: [.shift, .command])
         }
     }
 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This PR contains 2 single-line changes, doing the following:
- Disabled the utility area toggle animation when using hide interface, using the disable animation functionality implemented in PR #2044
- Changed the shortcut for hide interface from "⌘ ." to "⌘ ⇧ H"

With this change, the issue should be able to be closed.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #1632 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots
<img width="248" height="130" alt="Skærmbillede 2025-08-20 kl  21 56 51" src="https://github.com/user-attachments/assets/aa50d075-f2f6-43cc-945f-38291689faf3" />

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
