### PR TITLE
Prevent `Makefile` from being renamed to `Makefile.make` during save

### DIFF
--- a/CodeEdit/Features/Documents/CodeFileDocument/CodeFileDocument.swift
+++ b/CodeEdit/Features/Documents/CodeFileDocument/CodeFileDocument.swift
@@ -303,6 +303,16 @@ final class CodeFileDocument: NSDocument, ObservableObject {
         }
     }
 
+    override func fileNameExtension(
+        forType typeName: String,
+        saveOperation: NSDocument.SaveOperationType
+    ) -> String? {
+        guard let fileTypeName = Self.fileTypeExtension[typeName] else {
+            return super.fileNameExtension(forType: typeName, saveOperation: saveOperation)
+        }
+        return fileTypeName
+    }
+
     /// Determines the code language of the document.
     /// Use ``CodeFileDocument/language`` for the default value before using this. That property is used to override
     /// the file's language.
@@ -331,4 +341,11 @@ extension CodeFileDocument: LanguageServerDocument {
     var languageServerURI: String? {
         fileURL?.lspURI
     }
+}
+
+private extension CodeFileDocument {
+
+    static let fileTypeExtension: [String: String?] = [
+        "public.make-source": nil
+    ]
 }


### PR DESCRIPTION
### Description

Fixes an issue where saving a file like `Makefile` would sometimes append an unwanted `.make` extension, resulting in `Makefile.make`.

### Related Issues

* closes #2061

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code