### PR TITLE
Show Language Server Menu, Adjust Warning, Add Info Button

### DIFF
--- a/CodeEdit/Features/Settings/Pages/Extensions/LanguageServersView.swift
+++ b/CodeEdit/Features/Settings/Pages/Extensions/LanguageServersView.swift
@@ -13,21 +13,10 @@ struct LanguageServersView: View {
     @State private var registryItems: [RegistryItem] = []
     @State private var isLoading = true
 
+    @State private var showingInfoPanel = false
+
     var body: some View {
         SettingsForm {
-            Section {
-                EmptyView()
-            } header: {
-                Label(
-                    "Warning: Language server installation is not complete. Use this at your own risk. It "
-                    + "**WILL** break.",
-                    systemImage: "exclamationmark.triangle.fill"
-                )
-                .padding()
-                .foregroundStyle(.black)
-                .background(RoundedRectangle(cornerRadius: 12).fill(.yellow))
-            }
-
             if isLoading {
                 HStack {
                     Spacer()
@@ -61,6 +50,11 @@ struct LanguageServersView: View {
                         )
                         .listRowInsets(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
                     }
+                } header: {
+                    Label(
+                        "Warning: Language server installation is experimental. Use at your own risk.",
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
                 }
             }
         }
@@ -82,6 +76,28 @@ struct LanguageServersView: View {
         } message: { details in
             Text(details.error)
         }
+        .toolbar {
+            Button {
+                showingInfoPanel.toggle()
+            } label: {
+                Image(systemName: "questionmark.circle")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .popover(isPresented: $showingInfoPanel, arrowEdge: .top) {
+                VStack(alignment: .leading) {
+                    HStack {
+                        Text("Language Server Installation").font(.title2)
+                        Spacer()
+                    }
+                    .frame(width: 300)
+                    Text(getInfoString())
+                        .lineLimit(nil)
+                        .frame(width: 300)
+                }
+                .padding()
+            }
+        }
     }
 
     private func loadRegistryItems() {
@@ -90,6 +106,23 @@ struct LanguageServersView: View {
         if !registryItems.isEmpty {
             isLoading = false
         }
+    }
+
+    private func getInfoString() -> AttributedString {
+        let string = "CodeEdit makes use of the Mason Registry for language server installation. To install a package, "
+        + "CodeEdit uses the package manager directed by the Mason Registry, and installs a copy of "
+        + "the language server in Application Support.\n\n"
+        + "Language server installation is still experimental, there may be bugs and expect this flow "
+        + "to change over time."
+
+        var attrString = AttributedString(string)
+
+        if let linkRange = attrString.range(of: "Mason Registry") {
+            attrString[linkRange].link = URL(string: "https://mason-registry.dev/")
+            attrString[linkRange].foregroundColor = NSColor.linkColor
+        }
+
+        return attrString
     }
 }
 

--- a/CodeEdit/Features/Settings/SettingsView.swift
+++ b/CodeEdit/Features/Settings/SettingsView.swift
@@ -141,7 +141,7 @@ struct SettingsView: View {
                 SettingsPageView(page, searchText: searchText)
             }
         } else if !page.isSetting {
-            if (page.name == .developer || page.name == .languageServers) && !showDeveloperSettings {
+            if page.name == .developer && !showDeveloperSettings {
                 EmptyView()
             } else {
                 SettingsPageView(page, searchText: searchText)


### PR DESCRIPTION
### Description

Adjusts the language server menu slightly to include a more reasonable danger warning and an info button. Since we're shipping this I'd like to have some kind of explainer for someone poking around.

### Related Issues

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="1798" height="1410" alt="Screenshot 2025-08-25 at 10 45 05 AM" src="https://github.com/user-attachments/assets/a6fa3eb8-7d25-4923-bfbb-284ee19f7a74" />
