### PR TITLE
Correctly Handle Language Server Timeout When Quitting

### DIFF
--- a/CodeEdit/AppDelegate.swift
+++ b/CodeEdit/AppDelegate.swift
@@ -270,8 +270,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
                 TaskNotificationHandler.postTask(action: .create, model: task)
             }
 
-            try await withTimeout(
-                duration: .seconds(5.0),
+            try? await withTimeout(
+                duration: .seconds(2.0),
                 onTimeout: {
                     // Stop-gap measure to ensure we don't hang on CMD-Q
                     await self.lspService.killAllServers()

--- a/CodeEdit/Features/LSP/LanguageServer/LanguageServer.swift
+++ b/CodeEdit/Features/LSP/LanguageServer/LanguageServer.swift
@@ -258,9 +258,7 @@ class LanguageServer<DocumentType: LanguageServerDocument> {
     /// Shuts down the language server and exits it.
     public func shutdown() async throws {
         self.logger.info("Shutting down language server")
-        try await withTimeout(duration: .seconds(1.0)) {
-            try await self.lspInstance.shutdownAndExit()
-        }
+        try await self.lspInstance.shutdownAndExit()
     }
 }
 


### PR DESCRIPTION
### Description

There has been work done to ensure CodeEdit cleans up language servers correctly on quit, this fixes a few final bugs with that system.

- Changes the `withTimeout` call's `try` to `try?` in the `AppDelegate` so a thrown timeout error still allows execution to continue.
- Removes an unnecessary `withTimeout` in the language server shutdown code.
- Ensures `withTimeout` always cancels all child tasks on either an error or a return value.

### Related Issues

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

