### PR TITLE
Correctly Set Up EditorManager on New Workspaces

### DIFF
--- a/CodeEdit/Features/Editor/Models/EditorLayout/EditorLayout+StateRestoration.swift
+++ b/CodeEdit/Features/Editor/Models/EditorLayout/EditorLayout+StateRestoration.swift
@@ -13,6 +13,13 @@ extension EditorManager {
     /// Restores the tab manager from a captured state obtained using `saveRestorationState`
     /// - Parameter workspace: The workspace to retrieve state from.
     func restoreFromState(_ workspace: WorkspaceDocument) {
+        defer {
+            // No matter what, set the workspace on each editor. Even if we fail to read data.
+            flattenedEditors.forEach { editor in
+                editor.workspace = workspace
+            }
+        }
+
         do {
             guard let data = workspace.getFromWorkspaceState(.openTabs) as? Data else {
                 return

--- a/CodeEdit/Features/Editor/Views/EditorAreaView.swift
+++ b/CodeEdit/Features/Editor/Views/EditorAreaView.swift
@@ -77,7 +77,6 @@ struct EditorAreaView: View {
                             self.codeFile = { [weak latestValue] in latestValue }
                         }
                 }
-
             } else {
                 CEContentUnavailableView("No Editor")
                     .padding(.top, editorInsetAmount)

--- a/CodeEditUITests/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorFileManagementUITests.swift
+++ b/CodeEditUITests/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorFileManagementUITests.swift
@@ -57,6 +57,11 @@ final class ProjectNavigatorFileManagementUITests: XCTestCase {
             XCTFail("newFile.txt did not appear")
             return
         }
+
+        let newFileEditor = Query.Window.getFirstEditor(window)
+        XCTAssertTrue(newFileEditor.exists)
+        XCTAssertNotNil(newFileEditor.value as? String)
+
         guard Query.Navigator.getProjectNavigatorRow(
             fileTitle: "New Folder",
             navigator
@@ -95,6 +100,15 @@ final class ProjectNavigatorFileManagementUITests: XCTestCase {
 
             let newFileRow = selectedRows.firstMatch
             XCTAssertEqual(newFileRow.descendants(matching: .textField).firstMatch.value as? String, title)
+
+            let tabBar = Query.Window.getTabBar(window)
+            XCTAssertTrue(tabBar.exists)
+            let readmeTab = Query.TabBar.getTab(labeled: title, tabBar)
+            XCTAssertTrue(readmeTab.exists)
+
+            let newFileEditor = Query.Window.getFirstEditor(window)
+            XCTAssertTrue(newFileEditor.exists)
+            XCTAssertNotNil(newFileEditor.value as? String)
         }
     }
 }

--- a/CodeEditUITests/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorFileManagementUITests.swift
+++ b/CodeEditUITests/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorFileManagementUITests.swift
@@ -58,10 +58,6 @@ final class ProjectNavigatorFileManagementUITests: XCTestCase {
             return
         }
 
-        let newFileEditor = Query.Window.getFirstEditor(window)
-        XCTAssertTrue(newFileEditor.exists)
-        XCTAssertNotNil(newFileEditor.value as? String)
-
         guard Query.Navigator.getProjectNavigatorRow(
             fileTitle: "New Folder",
             navigator

--- a/CodeEditUITests/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorUITests.swift
+++ b/CodeEditUITests/Features/NavigatorArea/ProjectNavigator/ProjectNavigatorUITests.swift
@@ -35,6 +35,10 @@ final class ProjectNavigatorUITests: XCTestCase {
         let readmeTab = Query.TabBar.getTab(labeled: "README.md", tabBar)
         XCTAssertTrue(readmeTab.exists)
 
+        let readmeEditor = Query.Window.getFirstEditor(window)
+        XCTAssertTrue(readmeEditor.exists)
+        XCTAssertNotNil(readmeEditor.value as? String)
+
         let rowCount = navigator.descendants(matching: .outlineRow).count
 
         // Open a folder

--- a/CodeEditUITests/Query.swift
+++ b/CodeEditUITests/Query.swift
@@ -43,6 +43,12 @@ enum Query {
         static func getUtilityArea(_ window: XCUIElement) -> XCUIElement {
             return window.descendants(matching: .any).matching(identifier: "UtilityArea").element
         }
+
+        static func getFirstEditor(_ window: XCUIElement) -> XCUIElement {
+            return window.descendants(matching: .any)
+                .matching(NSPredicate(format: "label CONTAINS[c] 'Text Editor'"))
+                .firstMatch
+        }
     }
 
     enum Navigator {


### PR DESCRIPTION
### Description

Adjusts the setup of EditorManager to always assign the `workspace` property on all editors after restoring it. This creates duplicate work when we have editors that successfully restore from a saved state, but ensures we *always* set up the editor manager correctly even when an error is thrown or there is no restoration data.

Adjusted UI tests to catch this.

### Related Issues

* Issue on discord.

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A