### PR TITLE
fix(quickopen): prevent crash by providing UndoManagerRegistration

### DIFF
--- a/CodeEdit/Features/OpenQuickly/Views/OpenQuicklyPreviewView.swift
+++ b/CodeEdit/Features/OpenQuickly/Views/OpenQuicklyPreviewView.swift
@@ -15,6 +15,8 @@ struct OpenQuicklyPreviewView: View {
     @StateObject var editorInstance: EditorInstance
     @StateObject var document: CodeFileDocument
 
+    @StateObject var undoRegistration: UndoManagerRegistration = UndoManagerRegistration()
+
     init(item: CEWorkspaceFile) {
         self.item = item
         let doc = try? CodeFileDocument(
@@ -29,6 +31,7 @@ struct OpenQuicklyPreviewView: View {
     var body: some View {
         if let utType = document.utType, utType.conforms(to: .text) {
             CodeFileView(editorInstance: editorInstance, codeFile: document, isEditable: false)
+                .environmentObject(undoRegistration)
         } else {
             NonTextFileView(fileDocument: document)
         }


### PR DESCRIPTION
Fix crash in Open Quickly preview caused by missing UndoManagerRegistration.

Root cause: OpenQuicklyPreviewView renders CodeFileView in a separate view hierarchy without the environment object.
Fix: Provide UndoManagerRegistration for the preview (non-editable) path so CodeFileView resolves it.
Reproduce: Open Quickly (CMD+SHIFT+O) -> select a text file -> previously crashed.
Validation: No crash; normal editing unaffected.