### PR TITLE
Fix Alignment In Git Clone Panel

### DIFF
--- a/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodeEdit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -294,8 +294,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/WelcomeWindow",
       "state" : {
-        "revision" : "5168cf1ce9579b35ad00706fafef441418d8011f",
-        "version" : "1.0.0"
+        "revision" : "cbd5c0d6f432449e2a8618e2b24e4691acbfcc98",
+        "version" : "1.1.0"
       }
     },
     {

--- a/CodeEdit/Features/SourceControl/Clone/GitCloneView.swift
+++ b/CodeEdit/Features/SourceControl/Clone/GitCloneView.swift
@@ -28,13 +28,12 @@ struct GitCloneView: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            HStack {
+            HStack(alignment: .top) {
                 Image(nsImage: NSApp.applicationIconImage)
                     .resizable()
                     .frame(width: 64, height: 64)
-                    .padding(.bottom, 50)
                 VStack(alignment: .leading) {
-                    Text("Clone a repository")
+                    Text("Clone a Repository")
                         .bold()
                         .padding(.bottom, 2)
                     Text("Enter a git repository URL:")
@@ -46,9 +45,9 @@ struct GitCloneView: View {
                     TextField("Git Repository URL", text: $viewModel.repoUrlStr)
                         .lineLimit(1)
                         .padding(.bottom, 15)
-                        .frame(width: 300)
 
                     HStack {
+                        Spacer()
                         Button("Cancel") {
                             dismiss()
                         }
@@ -58,11 +57,8 @@ struct GitCloneView: View {
                         .keyboardShortcut(.defaultAction)
                         .disabled(!viewModel.isValidUrl(url: viewModel.repoUrlStr))
                     }
-                    .offset(x: 185)
-                    .alignmentGuide(.leading) { context in
-                        context[.leading]
-                    }
                 }
+                .frame(width: 300)
             }
             .padding(.top, 20)
             .padding(.horizontal, 20)
@@ -71,28 +67,32 @@ struct GitCloneView: View {
                 viewModel.checkClipboard()
             }
             .sheet(isPresented: $viewModel.isCloning) {
-                NavigationStack {
-                    VStack {
-                        ProgressView(
-                            viewModel.cloningProgress.state.label,
-                            value: viewModel.cloningProgress.progress,
-                            total: 100
-                        )
-                    }
-                }
-                .toolbar {
-                    ToolbarItem {
-                        Button("Cancel Cloning") {
-                            viewModel.cloningTask?.cancel()
-                            viewModel.cloningTask = nil
-                            viewModel.isCloning = false
-                        }
-                    }
-                }
-                .padding()
-                .frame(width: 350)
+                cloningSheet
             }
         }
+    }
+
+    @ViewBuilder private var cloningSheet: some View {
+        NavigationStack {
+            VStack {
+                ProgressView(
+                    viewModel.cloningProgress.state.label,
+                    value: viewModel.cloningProgress.progress,
+                    total: 100
+                )
+            }
+        }
+        .toolbar {
+            ToolbarItem {
+                Button("Cancel Cloning") {
+                    viewModel.cloningTask?.cancel()
+                    viewModel.cloningTask = nil
+                    viewModel.isCloning = false
+                }
+            }
+        }
+        .padding()
+        .frame(width: 350)
     }
 
     func cloneRepository() {

--- a/CodeEdit/Features/SourceControl/Clone/ViewModels/GitCloneViewModel.swift
+++ b/CodeEdit/Features/SourceControl/Clone/ViewModels/GitCloneViewModel.swift
@@ -184,7 +184,7 @@ class GitCloneViewModel: ObservableObject {
         dialog.prompt = "Clone"
         dialog.nameFieldStringValue = saveName
         dialog.nameFieldLabel = "Clone as"
-        dialog.title = "Clone"
+        dialog.title = "Clone a Repository"
 
         guard dialog.runModal() == NSApplication.ModalResponse.OK,
               let result = dialog.url else {


### PR DESCRIPTION
### Description

Removes all hard-coded locations and widths in the git clone panel, swapping them out for correct SwiftUI layout.

This fixes an issue on macOS Tahoe but is not limited to Tahoe intentionally. This should not be hardcoded on any platform and does not change the layout of the panel on Sequoia or lower.

### Related Issues

* closes #2120  
* closes #2116 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="513" height="258" alt="Screenshot 2025-09-11 at 1 43 36 PM" src="https://github.com/user-attachments/assets/f36f379d-e020-40cf-93f2-2a4456f84a5c" />
