### PR TITLE
Fix: Prevent git popup when Source Control is disabled (#2138)

### DIFF
--- a/CodeEdit/WorkspaceView.swift
+++ b/CodeEdit/WorkspaceView.swift
@@ -85,6 +85,9 @@ struct WorkspaceView: View {
                     // MARK: - Source Control
 
                     .task {
+                        // Only refresh git data if source control is enabled
+                        guard sourceControlIsEnabled else { return }
+                        
                         do {
                             try await sourceControlManager.refreshRemotes()
                             try await sourceControlManager.refreshStashEntries()
@@ -95,7 +98,7 @@ struct WorkspaceView: View {
                             )
                         }
                     }
-                    .onChange(of: sourceControlIsEnabled) { newValue in
+                    .onChange(of: sourceControlIsEnabled) { _, newValue in
                         if newValue {
                             Task {
                                 await sourceControlManager.refreshCurrentBranch()


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

Fixed issue where CodeEdit would show "The 'git' command requires the command line developer tools. Would you like to install the tools now?" popup on every app launch, even when Source Control was completely disabled in Settings.

### Description
- WorkspaceView.swift was unconditionally calling git operations (refreshRemotes and refreshStashEntries) on every workspace launch
- These git commands triggered macOS to show the Command Line Developer Tools installation popup if git wasn't installed
- The operations ran regardless of the sourceControlIsEnabled setting

Result:
- Users who disable Source Control no longer see the git tools popup
- Git operations still work normally when Source Control is enabled
- Popup behavior now respects user preferences as expected


### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #2138

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [X] The issues this PR addresses are related to each other
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
