### PR TITLE
Fix Language Servers settings page UI and search

### DIFF
--- a/CodeEdit/Features/Settings/Pages/Extensions/LanguageServerRowView.swift
+++ b/CodeEdit/Features/Settings/Pages/Extensions/LanguageServerRowView.swift
@@ -27,8 +27,6 @@ struct LanguageServerRowView: View, Equatable {
     @State private var removalError: Error?
     @State private var showingRemovalError = false
 
-    @State private var showMore: Bool = false
-
     @EnvironmentObject var registryManager: RegistryManager
 
     init(
@@ -46,49 +44,10 @@ struct LanguageServerRowView: View, Equatable {
             Label {
                 VStack(alignment: .leading) {
                     Text(package.sanitizedName)
-
-                    ZStack(alignment: .leadingLastTextBaseline) {
-                        VStack(alignment: .leading) {
-                            Text(package.sanitizedDescription)
-                                .font(.footnote)
-                                .foregroundColor(.secondary)
-                                .lineLimit(showMore ? nil : 1)
-                                .truncationMode(.tail)
-                            if showMore {
-                                Button(package.homepagePretty) {
-                                    guard let url = package.homepageURL else { return }
-                                    NSWorkspace.shared.open(url)
-                                }
-                                .buttonStyle(.plain)
-                                .foregroundColor(Color(NSColor.linkColor))
-                                .font(.footnote)
-                                .cursor(.pointingHand)
-                                if let installerName = package.installMethod?.packageManagerType?.rawValue {
-                                    Text("Install using \(installerName)")
-                                        .font(.footnote)
-                                        .foregroundColor(.secondary)
-                                }
-                            }
-                        }
-                        if isHovering {
-                            HStack {
-                                Spacer()
-                                Button {
-                                    showMore.toggle()
-                                } label: {
-                                    Text(showMore ? "Show Less" : "Show More")
-                                        .font(.footnote)
-                                }
-                                .buttonStyle(.plain)
-                                .background(
-                                    Rectangle()
-                                        .inset(by: -2)
-                                        .fill(.clear)
-                                        .background(Color(NSColor.windowBackgroundColor))
-                                )
-                            }
-                        }
-                    }
+                    Text(package.sanitizedDescription)
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
                 }
             } icon: {
                 letterIcon()

--- a/CodeEdit/Features/Settings/Pages/Extensions/LanguageServersView.swift
+++ b/CodeEdit/Features/Settings/Pages/Extensions/LanguageServersView.swift
@@ -10,51 +10,72 @@ import SwiftUI
 /// Displays a searchable list of packages from the ``RegistryManager``.
 struct LanguageServersView: View {
     @StateObject var registryManager: RegistryManager = .shared
-    @StateObject private var searchModel = FuzzySearchUIModel<RegistryItem>()
     @State private var searchText: String = ""
+    @State private var filteredItems: [RegistryItem]?
     @State private var selectedInstall: PackageManagerInstallOperation?
 
-    @State private var showingInfoPanel = false
-
     var body: some View {
-        Group {
+        VStack {
             SettingsForm {
-                if registryManager.isDownloadingRegistry {
-                    HStack {
-                        Spacer()
-                        ProgressView()
-                            .controlSize(.small)
-                        Spacer()
-                    }
+                Section {
+                    SearchField("Search", text: $searchText)
                 }
 
                 Section {
-                    List(searchModel.items ?? registryManager.registryItems, id: \.name) { item in
-                        LanguageServerRowView(
-                            package: item,
-                            onCancel: {
-                                registryManager.cancelInstallation()
-                            },
-                            onInstall: { [item] in
-                                do {
-                                    selectedInstall = try registryManager.installOperation(package: item)
-                                } catch {
-                                    // Display the error
-                                    NSAlert(error: error).runModal()
-                                }
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.footnote)
+                            .foregroundColor(.yellow)
+                        Text("Warning: Language server installation is experimental. Use at your own risk.")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                    if registryManager.isDownloadingRegistry {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                                .controlSize(.small)
+                            Spacer()
+                        }
+                    } else {
+                        LazyVStack(spacing: 0) {
+                            ForEach(
+                                filteredItems ?? registryManager.registryItems,
+                                id: \.name
+                            ) { item in
+                                Divider().padding(.horizontal, 10)
+                                LanguageServerRowView(
+                                    package: item,
+                                    onCancel: {
+                                        registryManager.cancelInstallation()
+                                    },
+                                    onInstall: { [item] in
+                                        do {
+                                            selectedInstall = try registryManager.installOperation(
+                                                package: item
+                                            )
+                                        } catch {
+                                            NSAlert(error: error).runModal()
+                                        }
+                                    }
+                                )
+                                .padding(10)
                             }
-                        )
-                        .listRowInsets(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
+                        }
+                        .padding(-10)
                     }
-                    .searchable(text: $searchText)
-                    .onChange(of: searchText) { _, newValue in
-                        searchModel.searchTextUpdated(searchText: newValue, allItems: registryManager.registryItems)
+                }
+            }
+            .onChange(of: searchText) { _, newValue in
+                if newValue.isEmpty {
+                    filteredItems = nil
+                } else {
+                    let query = newValue.lowercased()
+                    filteredItems = registryManager.registryItems.filter { item in
+                        item.sanitizedName.lowercased().split(separator: " ").contains {
+                            $0.hasPrefix(query)
+                        }
                     }
-                } header: {
-                    Label(
-                        "Warning: Language server installation is experimental. Use at your own risk.",
-                        systemImage: "exclamationmark.triangle.fill"
-                    )
                 }
             }
             .sheet(item: $selectedInstall) { operation in
@@ -62,22 +83,5 @@ struct LanguageServersView: View {
             }
         }
         .environmentObject(registryManager)
-    }
-
-    private func getInfoString() -> AttributedString {
-        let string = "CodeEdit makes use of the Mason Registry for language server installation. To install a package, "
-        + "CodeEdit uses the package manager directed by the Mason Registry, and installs a copy of "
-        + "the language server in Application Support.\n\n"
-        + "Language server installation is still experimental, there may be bugs and expect this flow "
-        + "to change over time."
-
-        var attrString = AttributedString(string)
-
-        if let linkRange = attrString.range(of: "Mason Registry") {
-            attrString[linkRange].link = URL(string: "https://mason-registry.dev/")
-            attrString[linkRange].foregroundColor = NSColor.linkColor
-        }
-
-        return attrString
     }
 }


### PR DESCRIPTION
### Description

fixes several ui/ux issues on the language servers settings page:

- **row view**: replaced the broken `ZStack` overlay ("Show More" button with background rectangle hack that caused text collision) with a clean `VStack` layout showing a single-line description
- **page layout**: replaced `.searchable()` toolbar search with `SearchField` in its own `Section`, matching the pattern used by other settings pages (e.g. themes). replaced `List` with `LazyVStack` for scroll performance with hundreds of registry items
- **search**: replaced fuzzy search with word-prefix matching. fuzzy search returned irrelevant results (e.g. "ad" matched "Gradle" because it found a→d scattered in the string). word-prefix only matches items where a word in the display name starts with the query
- **warning banner**: styled inline with a small yellow triangle icon and secondary text, matching apple system settings pattern. previously was a section header with inconsistent spacing
- **cleanup**: removed unused `getInfoString()` and `showingInfoPanel`

### Related Issues

* closes #2157

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Before

<img width="731" height="469" alt="image" src="https://github.com/user-attachments/assets/7d9aa0c8-4977-42ef-967e-a163ab53d8ee" />

<img width="742" height="497" alt="image" src="https://github.com/user-attachments/assets/850fb5de-2508-4037-b55f-c8a6f4807822" />


After

https://github.com/user-attachments/assets/95c444c3-0975-4b6a-ba12-cb9890bde7b4