### PR TITLE
Fix deterministic workspace indexing and search

### DIFF
--- a/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument+Find.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument+Find.swift
@@ -88,7 +88,7 @@ extension WorkspaceDocument.SearchState {
     ///
     /// - Parameter query: The search query to search for.
     func search(_ query: String) async {
-        clearResults()
+        await resetResults()
 
         await MainActor.run {
             self.searchQuery = query
@@ -104,44 +104,33 @@ extension WorkspaceDocument.SearchState {
         }
 
         let asyncController = SearchIndexer.AsyncManager(index: indexer)
-        let evaluateResultGroup = DispatchGroup()
-        let evaluateSearchQueue = DispatchQueue(label: "app.codeedit.CodeEdit.EvaluateSearch")
 
         let searchStream = await asyncController.search(query: searchQuery, 20)
         for try await result in searchStream {
-            for file in result.results {
-                let fileURL = file.url
-                let fileScore = file.score
-                let capturedRegexPattern = regexPattern
+            await withTaskGroup(of: SearchResultModel?.self) { group in
+                for file in result.results {
+                    let fileURL = file.url
+                    let fileScore = file.score
+                    let capturedRegexPattern = regexPattern
 
-                evaluateSearchQueue.async(group: evaluateResultGroup) {
-                    evaluateResultGroup.enter()
-                    Task { [weak self] in
-                        guard let self else {
-                            evaluateResultGroup.leave()
-                            return
-                        }
-
-                        let result = await self.evaluateSearchResult(
+                    group.addTask { [weak self] in
+                        await self?.evaluateSearchResult(
                             fileURL: fileURL,
                             fileScore: fileScore,
                             regexPattern: capturedRegexPattern
                         )
+                    }
+                }
 
-                        if let result = result {
-                            await self.appendNewResultsToTempResults(newResult: result)
-                        }
-                        evaluateResultGroup.leave()
+                for await evaluatedResult in group {
+                    if let evaluatedResult {
+                        await appendNewResultsToTempResults(newResult: evaluatedResult)
                     }
                 }
             }
         }
 
-        evaluateResultGroup.notify(queue: evaluateSearchQueue) {
-            Task { @MainActor [weak self] in
-                self?.setSearchResults()
-            }
-        }
+        await setSearchResults()
     }
 
     /// Appends a new search result to the temporary search results array on the main thread.
@@ -346,7 +335,13 @@ extension WorkspaceDocument.SearchState {
 
     /// Resets the search results along with counts for overall results and file-specific results.
     func clearResults() {
-        DispatchQueue.main.async {
+        Task {
+            await resetResults()
+        }
+    }
+
+    private func resetResults() async {
+        await MainActor.run {
             self.searchResult.removeAll()
             self.searchResultsCount = 0
             self.searchResultsFileCount = 0

--- a/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument+Index.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument+Index.swift
@@ -11,64 +11,120 @@ extension WorkspaceDocument.SearchState {
     /// Adds the contents of the current workspace URL to the search index.
     /// That means that the contents of the workspace will be indexed and searchable.
     func addProjectToIndex() {
+        startProjectIndexing()
+    }
+
+    /// Starts project indexing without blocking the caller.
+    func startProjectIndexing() {
         guard let indexer = indexer else { return }
         guard let url = workspace.fileURL else { return }
 
-        indexStatus = .indexing(progress: 0.0)
+        let previousTask = indexingTask
+        previousTask?.cancel()
+        indexingTask = Task { [weak self] in
+            await previousTask?.value
+            guard !Task.isCancelled else { return }
+
+            await self?.indexProject(indexer: indexer, url: url)
+        }
+    }
+
+    /// Indexes the project and returns after the index has been flushed.
+    func indexProject() async {
+        let previousTask = indexingTask
+        previousTask?.cancel()
+        await previousTask?.value
+        indexingTask = nil
+
+        guard let indexer = indexer else { return }
+        guard let url = workspace.fileURL else { return }
+
+        await indexProject(indexer: indexer, url: url)
+    }
+
+    private func indexProject(indexer: SearchIndexer, url: URL) async {
         let uuidString = UUID().uuidString
+        await publishIndexingStarted(id: uuidString)
+
+        let filePaths = getFileURLs(at: url)
+        let asyncController = SearchIndexer.AsyncManager(index: indexer)
+        var lastProgress: Double = 0
+
+        for await (file, index) in AsyncFileIterator(fileURLs: filePaths) {
+            guard !Task.isCancelled else {
+                await publishIndexingCancelled(id: uuidString)
+                return
+            }
+
+            _ = await asyncController.addText(files: [file], flushWhenComplete: false)
+            let progress = Double(index + 1) / Double(filePaths.count)
+
+            if progress - lastProgress > 0.005 || index == filePaths.count - 1 {
+                lastProgress = progress
+                await publishIndexingProgress(id: uuidString, progress: progress)
+            }
+        }
+
+        guard !Task.isCancelled else {
+            await publishIndexingCancelled(id: uuidString)
+            return
+        }
+
+        asyncController.index.flush()
+        await publishIndexingFinished(id: uuidString)
+    }
+
+    @MainActor
+    private func publishIndexingStarted(id: String) {
+        indexStatus = .indexing(progress: 0.0)
         let createInfo: [String: Any] = [
-            "id": uuidString,
+            "id": id,
             "action": "create",
             "title": "Indexing | Processing files",
             "message": "Creating an index to enable fast and accurate searches within your codebase.",
             "isLoading": true
         ]
         NotificationCenter.default.post(name: .taskNotification, object: nil, userInfo: createInfo)
+    }
 
-        Task.detached {
-            let filePaths = self.getFileURLs(at: url)
+    @MainActor
+    private func publishIndexingProgress(id: String, progress: Double) {
+        indexStatus = .indexing(progress: progress)
+        let updateInfo: [String: Any] = [
+            "id": id,
+            "action": "update",
+            "percentage": progress
+        ]
+        NotificationCenter.default.post(name: .taskNotification, object: nil, userInfo: updateInfo)
+    }
 
-            let asyncController = SearchIndexer.AsyncManager(index: indexer)
-            var lastProgress: Double = 0
+    @MainActor
+    private func publishIndexingFinished(id: String) {
+        indexStatus = .done
+        let updateInfo: [String: Any] = [
+            "id": id,
+            "action": "update",
+            "title": "Finished indexing",
+            "isLoading": false
+        ]
+        NotificationCenter.default.post(name: .taskNotification, object: nil, userInfo: updateInfo)
 
-            for await (file, index) in AsyncFileIterator(fileURLs: filePaths) {
-                _ = await asyncController.addText(files: [file], flushWhenComplete: false)
-                let progress = Double(index) / Double(filePaths.count)
+        let deleteInfo: [String: Any] = [
+            "id": id,
+            "action": "deleteWithDelay",
+            "delay": 4.0
+        ]
+        NotificationCenter.default.post(name: .taskNotification, object: nil, userInfo: deleteInfo)
+    }
 
-                // Send only if difference is > 0.5%, to keep updates from sending too frequently
-                if progress - lastProgress > 0.005 || index == filePaths.count - 1 {
-                    lastProgress = progress
-                    await MainActor.run {
-                        self.indexStatus = .indexing(progress: progress)
-                    }
-                    let updateInfo: [String: Any] = [
-                        "id": uuidString,
-                        "action": "update",
-                        "percentage": progress
-                    ]
-                    NotificationCenter.default.post(name: .taskNotification, object: nil, userInfo: updateInfo)
-                }
-            }
-            asyncController.index.flush()
-
-            await MainActor.run {
-                self.indexStatus = .done
-            }
-            let updateInfo: [String: Any] = [
-                "id": uuidString,
-                "action": "update",
-                "title": "Finished indexing",
-                "isLoading": false
-            ]
-            NotificationCenter.default.post(name: .taskNotification, object: nil, userInfo: updateInfo)
-
-            let deleteInfo = [
-                "id": uuidString,
-                "action": "deleteWithDelay",
-                "delay": 4.0
-            ]
-            NotificationCenter.default.post(name: .taskNotification, object: nil, userInfo: deleteInfo)
-        }
+    @MainActor
+    private func publishIndexingCancelled(id: String) {
+        indexStatus = .done
+        let deleteInfo: [String: Any] = [
+            "id": id,
+            "action": "delete"
+        ]
+        NotificationCenter.default.post(name: .taskNotification, object: nil, userInfo: deleteInfo)
     }
 
     /// Retrieves an array of file URLs within the specified directory URL.

--- a/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument+SearchState.swift
+++ b/CodeEdit/Features/Documents/WorkspaceDocument/WorkspaceDocument+SearchState.swift
@@ -38,6 +38,7 @@ extension WorkspaceDocument {
         @Published var shouldFocusSearchField: Bool = false
 
         unowned var workspace: WorkspaceDocument
+        var indexingTask: Task<Void, Never>?
         var tempSearchResults = [SearchResultModel]()
         var caseSensitive: Bool = false
         var indexer: SearchIndexer?
@@ -51,6 +52,10 @@ extension WorkspaceDocument {
             self.workspace = workspace
             self.indexer = SearchIndexer.Memory.create()
             addProjectToIndex()
+        }
+
+        deinit {
+            indexingTask?.cancel()
         }
 
         /// Represents the compare options to be used for find and replace.

--- a/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+FindAndReplaceTests.swift
+++ b/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+FindAndReplaceTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import CodeEdit
 
 @MainActor
-final class FindAndReplaceTests: XCTestCase { // swiftlint:disable:this type_body_length
+final class FindAndReplaceTests: XCTestCase {
     private var directory: URL!
     private var files: [CEWorkspaceFile] = []
     private var mockWorkspace: WorkspaceDocument!
@@ -64,20 +64,11 @@ final class FindAndReplaceTests: XCTestCase { // swiftlint:disable:this type_bod
         files[1].parent = folder1File
         files[2].parent = folder2File
 
-        mockWorkspace.searchState?.addProjectToIndex()
+        await mockWorkspace.searchState?.indexProject()
 
         // NOTE: This is a temporary solution. In the future, a file watcher should track file updates
         // and trigger an index update.
-        let startTime = Date()
-        let timeoutInSeconds = 2.0
-        while searchState.indexStatus != .done {
-            // Check every 0.1 seconds for index completion
-            try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
-            if Date().timeIntervalSince(startTime) > timeoutInSeconds {
-                XCTFail("TIMEOUT: Indexing took to long or did not complete.")
-                return
-            }
-        }
+        XCTAssertEqual(searchState.indexStatus, .done)
 
         // Retrieve indexed documents from the indexer
         guard let documentsInIndex = searchState.indexer?.documents() else {
@@ -99,15 +90,8 @@ final class FindAndReplaceTests: XCTestCase { // swiftlint:disable:this type_bod
         // IMPORTANT:
         // This is only a temporary solution, in the feature a file watcher would track the file update
         // and trigger a index update.
-        searchState.addProjectToIndex()
-        let startTime = Date()
-        while searchState.indexStatus != .done {
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            if Date().timeIntervalSince(startTime) > 2.0 {
-                XCTFail("TIMEOUT: Indexing took to long or did not complete.")
-                return
-            }
-        }
+        await searchState.indexProject()
+        XCTAssertEqual(searchState.indexStatus, .done)
     }
 
     func testFindAndReplace() async {

--- a/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+FindTests.swift
+++ b/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+FindTests.swift
@@ -60,20 +60,11 @@ final class FindTests: XCTestCase {
         files[1].parent = parent1
         files[2].parent = parent2
 
-        await mockWorkspace.searchState?.addProjectToIndex()
+        await mockWorkspace.searchState?.indexProject()
 
         // The following code also tests whether the workspace is indexed correctly
         // Wait until the index is up to date and flushed
-        let startTime = Date()
-        let timeoutInSeconds = 2.0
-        while searchState.indexStatus != .done {
-            // Check every 0.1 seconds for index completion
-            try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
-            if Date().timeIntervalSince(startTime) > timeoutInSeconds {
-                XCTFail("TIMEOUT: Indexing took to long or did not complete.")
-                return
-            }
-        }
+        XCTAssertEqual(searchState.indexStatus, .done)
 
         // Retrieve indexed documents from the indexer
         guard let documentsInIndex = searchState.indexer?.documents() else {

--- a/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+IndexTests.swift
+++ b/CodeEditTests/Features/Documents/WorkspaceDocument+SearchState+IndexTests.swift
@@ -63,20 +63,11 @@ final class WorkspaceDocumentIndexTests: XCTestCase {
         files[1].parent = folder1File
         files[2].parent = folder2File
 
-        await mockWorkspace.searchState?.addProjectToIndex()
+        await mockWorkspace.searchState?.indexProject()
 
         // The following code also tests whether the workspace is indexed correctly
         // Wait until the index is up to date and flushed
-        let startTime = Date()
-        let timeoutInSeconds = 2.0
-        while searchState.indexStatus != .done {
-            // Check every 0.1 seconds for index completion
-            try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
-            if Date().timeIntervalSince(startTime) > timeoutInSeconds {
-                XCTFail("TIMEOUT: Indexing took to long or did not complete.")
-                return
-            }
-        }
+        XCTAssertEqual(searchState.indexStatus, .done)
 
         // Retrieve indexed documents from the indexer
         guard let documentsInIndex = searchState.indexer?.documents() else {


### PR DESCRIPTION
### Description

This PR makes workspace search indexing and search result publication deterministic.

It keeps the existing `addProjectToIndex()` startup behavior as fire-and-forget, but moves the actual indexing work into an awaitable `indexProject()` path. That lets tests and explicit re-indexing callers wait until the index has been flushed instead of polling `indexStatus` with timing loops.

The patch also replaces the search path's `DispatchGroup` plus nested `Task` completion handling with structured concurrency. `search(_:)` now awaits result evaluation before publishing final search results, so callers do not observe stale or partially populated state.

This is intentionally narrower than #1993. It does not replace the task notification system or introduce the broader activity manager refactor. The goal is to land the lifecycle contract fix first so indexing/search behavior is stable before any notification or activity API cleanup continues.

Main changes:
- Add cancellable indexing task ownership to `WorkspaceDocument.SearchState`
- Keep `addProjectToIndex()` non-blocking for startup
- Add `indexProject() async` for deterministic indexing and tests
- Publish indexing progress from main-actor helpers
- Make `search(_:)` await result evaluation before `setSearchResults()`
- Remove timing-based polling from workspace search/index tests

### Related Issues

* Refs #1993

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Validation

Ran with XcodeBuildMCP on macOS using `-skipPackagePluginValidation`.

- Focused tests: `22/22` passed
  - `CodeEditTests/TaskNotificationHandlerTests`
  - `CodeEditTests/WorkspaceDocumentIndexTests`
  - `CodeEditTests/FindTests`
  - `CodeEditTests/FindAndReplaceTests`
- Full `CodeEditTests`: `140` passed, `0` failed, `2` skipped
- `git diff --check`: clean

Note: the test run still reports an existing trailing-whitespace warning in `CodeEdit/WorkspaceView.swift:90`, which is outside this diff.

### Screenshots

Not applicable. This PR changes workspace indexing/search lifecycle behavior and tests, not UI presentation.