### PR TITLE
Restore Icon Composer product icons

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 /* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		816BB1303036109C008206B6 /* ProductIcons */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ProductIcons; sourceTree = "<group>"; };
 		B624520B2D78A3CC009A86D1 /* CodeEdit */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (B62454482D78A3CC009A86D1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, B62454492D78A3CC009A86D1 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = CodeEdit; sourceTree = "<group>"; };
 		B624544F2D78A3D3009A86D1 /* Configs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Configs; sourceTree = "<group>"; };
 		B62454602D78A3D4009A86D1 /* CodeEditUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = CodeEditUITests; sourceTree = "<group>"; };
@@ -239,6 +240,7 @@
 		B658FB2327DA9E0F00EA4DBD = {
 			isa = PBXGroup;
 			children = (
+				816BB1303036109C008206B6 /* ProductIcons */,
 				B624520B2D78A3CC009A86D1 /* CodeEdit */,
 				B62454A32D78A3D4009A86D1 /* CodeEditTests */,
 				B62454602D78A3D4009A86D1 /* CodeEditUITests */,
@@ -308,6 +310,7 @@
 				2BE487F328245162003F3F64 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
+				816BB1303036109C008206B6 /* ProductIcons */,
 				B624520B2D78A3CC009A86D1 /* CodeEdit */,
 			);
 			name = CodeEdit;

--- a/Configs/Alpha.xcconfig
+++ b/Configs/Alpha.xcconfig
@@ -8,6 +8,6 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-CE_APPICON_NAME = AppIconAlpha
+CE_APPICON_NAME = CodeEditAlphaIcon
 CE_VERSION_POSTFIX = -alpha
 CE_COPYRIGHT = Copyright © 2022-2025 CodeEdit

--- a/Configs/Beta.xcconfig
+++ b/Configs/Beta.xcconfig
@@ -8,6 +8,6 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-CE_APPICON_NAME = AppIconBeta
+CE_APPICON_NAME = CodeEditBetaIcon
 CE_VERSION_POSTFIX = -beta
 CE_COPYRIGHT = Copyright © 2022-2025 CodeEdit

--- a/Configs/Debug.xcconfig
+++ b/Configs/Debug.xcconfig
@@ -8,6 +8,6 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-CE_APPICON_NAME = AppIconDev
+CE_APPICON_NAME = CodeEditDevIcon
 CE_VERSION_POSTFIX = -dev
 CE_COPYRIGHT = Copyright © 2022-2025 CodeEdit

--- a/Configs/Pre.xcconfig
+++ b/Configs/Pre.xcconfig
@@ -8,6 +8,6 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-CE_APPICON_NAME = AppIconPre
+CE_APPICON_NAME = CodeEditPreIcon
 CE_VERSION_POSTFIX = -pre
 CE_COPYRIGHT = Copyright © 2022-2025 CodeEdit

--- a/Configs/Release.xcconfig
+++ b/Configs/Release.xcconfig
@@ -8,6 +8,6 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-CE_APPICON_NAME = AppIcon
+CE_APPICON_NAME = CodeEditIcon
 // CE_VERSION_POSTFIX = // this is a placeholder since we don't want a postfix in final release
 CE_COPYRIGHT = Copyright © 2022-2025 CodeEdit


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Restores the Icon Composer product icons that are present in the repository but missing from the Xcode project.

This adds the existing `ProductIcons` folder to the CodeEdit target and updates the app icon configuration names to reference the corresponding `.icon` files.

Verified that the Debug and Beta configurations build and run with their expected app icons.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #2190

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<img width="852" height="600" alt="Screenshot 2026-08-20 at 12 57 21 am" src="https://github.com/user-attachments/assets/b51fa283-afd7-415f-a70a-c580b3fa22f1" />

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
